### PR TITLE
Aggregate EIA data to BA before hourly shaping

### DIFF
--- a/src/data_pipeline.py
+++ b/src/data_pipeline.py
@@ -283,9 +283,12 @@ def main():
     del residual_profiles
     hourly_profiles = impute_hourly_profiles.convert_profile_to_percent(hourly_profiles)
 
-    # TODO: shaped_eia_data is HUGE, consider moving to dask.dataframe
+    # Aggregate EIA data to BA/fuel/month, then assign hourly profile per BA/fuel
+    monthly_eia_data_to_shape = impute_hourly_profiles.monthly_eia_data_to_ba(
+        monthly_eia_data_to_shape, plant_attributes
+    )
     shaped_eia_data = impute_hourly_profiles.shape_monthly_eia_data_as_hourly(
-        monthly_eia_data_to_shape, hourly_profiles, plant_attributes
+        monthly_eia_data_to_shape, hourly_profiles
     )
     # Export data
     output_data.output_intermediate_data(


### PR DESCRIPTION
Because all plants within a BA and fuel get the same hourly profile, scaled for monthly production, we can aggregate EIA data to BA/fuel/month and get the same result with less data.

* Each BA/fuel is assigned a new plant id according to `impute_hourly_profiles.get_artificial_plant`
* In data pipeline, call `impute_hourly_profiles.monthly_eia_data_to_ba` (new function) to aggregate EIA data to BA/fuel before calling `impute_hourly_profiles.shape_monthly_eia_data_as_hourly`

Should address #86 by decreasing the size of the largest hourly dataframe, which was previously the shaped EIA data (because 90% of plants are EIA-reporting, non-CEMS)