### PR TITLE
fix profile imputation

### DIFF
--- a/data/manual/ba_reference.csv
+++ b/data/manual/ba_reference.csv
@@ -8,208 +8,210 @@ AEP,AEP Service Corp. -- Transmission System,,,,Yes,1/1/2004,7/1/2006,,,,FERC,6
 AESO,Alberta Electric System Operator,rto,Canada/Mountain,Canada/Mountain,No,1/1/2004,,,,,EIA & FERC,7
 AEWC,"AESC, LLC - Wheatland CIN",,,,Yes,1/1/2004,4/1/2015,,,,FERC,8
 AEWI,"AESC, LLC - Wheatland IPL",,,,Yes,1/1/2004,7/1/2006,,,,FERC,9
-AKMS,No Balancing Authority - Alaska,miscellaneous,US/Alaska,US/Alaska,Yes,,,,,,EPA,10
-ALEX,"Alliant Energy Corporate Services, LLC",,,,Yes,1/1/2004,7/1/2006,,,,FERC,11
-ALTE,"Alliant Energy Corporate Services, LLC - East",,,,Yes,1/1/2004,,,,,FERC,12
-ALTW,"Alliant Energy Corporate Services, LLC- West",,,,Yes,1/1/2004,,,,,FERC,13
-ALWX,"Alliant Energy Corporate Services, LLC",,,,Yes,1/1/2004,7/1/2006,,,,FERC,14
-AMIL,Ameren Transmission-Illinois,,,,Yes,1/1/2007,,,,,FERC,15
-AMMO,Ameren Transmission-Missouri,,,,Yes,1/1/2007,,,,,FERC,16
-AMPL,Anchorage Municipal Light and Power,,US/Alaska,US/Alaska,Yes,,,,,,EIA,17
-AMRN,Ameren Transmission,,,,Yes,1/1/2004,,,,,FERC,18
-AVA,Avista Corporation,,US/Pacific,US/Pacific,Yes,1/1/2004,,,,,EIA & FERC,19
-AVRN,"Avangrid Renewables, LLC",generation_only,US/Pacific,US/Pacific,Yes,7/31/2018,,,7/1/2017,,EIA & FERC,20
-AZPS,Arizona Public Service Company,,US/Arizona,US/Arizona,Yes,1/1/2004,,,,,EIA & FERC,21
-BANC,Balancing Authority of Northern California,,US/Pacific,US/Pacific,Yes,7/1/2013,,,,,EIA & FERC,22
-BBA,Batesville Balancing Authority,,,,Yes,7/1/2006,4/1/2015,,,,FERC,23
-BCA,Batesville Control Area,,,,Yes,1/1/2004,9/30/2006,,,,FERC,24
-BCHA,British Columbia Hydro and Power Authority,,Canada/Pacific,Canada/Pacific,No,1/1/2004,,,,,EIA & FERC,25
-BCTC,British Columbia Transmission Corporation,,,,No,10/1/2008,4/1/2015,,,,FERC,26
-BERC,"DECA, LLC",,,,Yes,1/1/2004,7/1/2006,,,,FERC,27
-BPAT,Bonneville Power Administration,power_marketing_administration,US/Pacific,US/Pacific,Yes,1/1/2004,,,,,EIA & FERC,28
-BRAZ,"CECD, LLC",,,,Yes,7/1/2013,4/1/2015,,,,FERC,29
-BREC,Big Rivers Electric Corp.,,,,Yes,1/1/2004,,,,,FERC,30
-BUBA,"Constellation Energy Control and Dispatch - City of Benton, Arkansas",,,,Yes,1/1/2007,4/1/2015,,,,FERC,31
-CE,Commonwealth Edison,,,,Yes,1/1/2004,7/1/2006,,,,FERC,32
-CEA,Chugash Electric Association,,US/Alaska,US/Alaska,Yes,,,,,,EIA,33
-CEN,Centro Nacional de Control de Energia,,America/Mexico_City,America/Mexico_City,No,10/31/2017,,,1/1/2016,,EIA & FERC,34
-CFE,Comision Federal de Electricidad,,America/Mexico_City,America/Mexico_City,No,,,,,,EIA & FERC,35
-CFEN,Comision Federal de Electricidad,,,,No,,4/1/2015,,,,FERC,36
-CHPD,Public Utility District No. 1 of Chelan County,,US/Pacific,US/Pacific,Yes,1/1/2004,,,,,EIA & FERC,37
-CILC,Central Illinois Light Co,,,,Yes,1/1/2004,10/1/2007,,,,FERC,38
-CIN,Cinergy Corporation,,,,Yes,1/1/2004,,,,,FERC,39
-CISO,California Independent System Operator,rto,US/Pacific,US/Pacific,Yes,1/1/2004,,,,,EIA & FERC,40
-CLEC,Cleco Power LLC,,,,Yes,1/1/2004,,,,,FERC,41
-CNWY,"Constellation Energy Control and Dispatch - Conway, Arkansas",,,,Yes,1/1/2005,4/1/2015,,,,FERC,42
-CONS,Michigan Electric Coordinated System- CONS,,,,Yes,1/1/2004,,,,,FERC,43
-CPLE,Duke Energy Progress East,,US/Eastern,US/Eastern,Yes,1/1/2004,,Carolina Power and Light Company - East,,,EIA & FERC,44
-CPLW,Duke Energy Progress West,limited_generation,US/Eastern,US/Eastern,Yes,1/1/2004,,Carolina Power & Light Company - CPLW,,,EIA & FERC,45
-CSTO,"Constellation Energy Control and Dispatch, LLC",,US/Eastern,US/Eastern,Yes,7/1/2013,4/1/2015,"CECD, LLC",,,EIA & FERC,46
-CSWS,Central and Southwest,,,,Yes,1/1/2004,4/1/2015,,,,FERC,47
-CWAY,"Louisiana Generating, LLC - City of Conway",,,,Yes,4/1/2010,7/1/2016,,,,FERC,48
-CWLD,Columbia Water & Light,,,,Yes,1/1/2004,,,,,FERC,49
-CWLP,City Water Light & Power,,,,Yes,1/1/2004,,,,,FERC,50
-DEAA,"Arlington Valley, LLC",generation_only,US/Arizona,US/Arizona,Yes,1/1/2004,,"DECA, LLC - Arlington Valley",,,EIA & FERC,51
-DECO,Michigan Electric Coordinated System- DECO,,,,Yes,1/1/2004,,,,,FERC,52
-DEEM,"DECA, LLC - Enterprise",,,,Yes,1/1/2004,7/1/2006,,,,FERC,53
-DEHA,"DECA, LLC",,,,Yes,1/1/2004,7/1/2006,,,,FERC,54
-DELI,"DECA, LLC - Lee",,,,Yes,1/1/2004,7/1/2006,,,,FERC,55
-DELO,"DECA, LLC",,,,Yes,1/1/2004,7/1/2006,,,,FERC,56
-DEMG,"DECA, LLC",,,,Yes,1/1/2004,7/1/2006,,,,FERC,57
-DEMT,"DECA, LLC - Murray",,,,Yes,1/1/2004,7/1/2006,,,,FERC,58
-DENL,"Constellation Energy Control and Dispatch - North Little Rock, AK",,,,Yes,1/1/2004,4/1/2015,,,,FERC,59
-DERS,"Constellation Energy Control and Dispatch - City of Ruston, LA",,,,Yes,1/1/2004,4/1/2015,,,,FERC,60
-DESG,"DECA, LLC - Sandersville",,,,Yes,1/1/2004,7/1/2006,,,,FERC,61
-DESM,"DECA, LLC",,,,Yes,1/1/2004,7/1/2006,,,,FERC,62
-DEVI,Constellation Energy Control and Dispatch - Vermillion,,,,Yes,1/1/2004,7/1/2006,,,,FERC,63
-DEWO,"DECA, LLC - Washington",,,,Yes,1/1/2004,7/1/2006,,,,FERC,64
-DLCO,Duquesne Light,,,,Yes,1/1/2004,7/1/2006,,,,FERC,65
-DOPD,PUD No. 1 of Douglas County,,US/Pacific,US/Pacific,Yes,1/1/2004,,,,,EIA & FERC,66
-DPC,Dairyland Power Cooperative,,,,Yes,1/1/2004,,,,,FERC,67
-DPL,Dayton Power & Light,,,,Yes,1/1/2004,7/1/2006,,,,FERC,68
-DSK1,BridgeCo,,,,Yes,1/1/2004,7/1/2006,,,,FERC,69
-DUK,Duke Energy Carolinas,,US/Eastern,US/Eastern,Yes,1/1/2004,,Duke Energy Corporation,,,EIA & FERC,70
-EAI,"Entergy Arkansas, Inc.",,,,Yes,7/1/2013,,,,,FERC,71
-EDE,"Empire District Electric Co., The",,,,Yes,1/1/2004,4/1/2015,,,,FERC,72
-EEI,"Electric Energy, Inc.",,US/Central,US/Central,Yes,1/1/2004,2/29/2020,,,,EIA & FERC,73
-EES,Entergy,,,,Yes,1/1/2004,,,,,FERC,74
-EKPC,"East Kentucky Power Cooperative, Inc.",,,,Yes,1/1/2004,4/1/2015,,,,FERC,75
-EMBA,"Entergy Mississippi, Inc.",,,,Yes,4/1/2015,,,,,FERC,76
-EPE,El Paso Electric Company,,US/Arizona,US/Mountain,Yes,1/1/2004,,El Paso Electric,,,EIA & FERC,77
-ERCO,"Electric Reliability Council of Texas, Inc.",rto,US/Central,US/Central,Yes,1/1/2004,,ERCOT ISO,,,EIA & FERC,78
-FE,"American Transmission Systems, Inc.",,,,Yes,1/1/2004,4/1/2015,,,,FERC,79
-FMPP,Florida Municipal Power Pool,,US/Eastern,US/Eastern,Yes,1/1/2004,,,,,EIA & FERC,80
-FPC,"Duke Energy Florida, Inc.",,US/Eastern,US/Eastern,Yes,1/1/2004,,Florida Power Corporation,,,EIA & FERC,81
-FPL,Florida Power & Light Co.,,US/Eastern,US/Eastern,Yes,1/1/2004,,,,,EIA & FERC,82
-GA,GridAmerica,,,,Yes,1/1/2004,4/1/2015,,,,FERC,83
-GCPD,"Public Utility District No. 2 of Grant County, Washington",,US/Pacific,US/Pacific,Yes,1/1/2004,,,,,EIA & FERC,84
-GLHB,GridLiance,generation_only,US/Central,US/Central,Yes,2/29/2020,,GridLiance Heartland (BA),1/1/2020,,EIA & FERC,85
-GLHL,GridLiance Heartland,,,,Yes,1/1/2020,,,,,FERC,86
-GRDA,Grand River Dam Authority,,,,Yes,1/1/2004,4/1/2015,,,,FERC,87
-GRE,Great River Energy,,,,Yes,1/1/2004,,,,,FERC,88
-GREC,Great River Energy,,,,Yes,1/1/2004,,,,,FERC,89
-GREN,Great River Energy,,,,Yes,1/1/2004,,,,,FERC,90
-GRES,Great River Energy,,,,Yes,1/1/2004,,,,,FERC,91
-GRID,"Gridforce Energy Management, LLC",generation_only,US/Pacific,US/Pacific,Yes,4/1/2014,,Constellation Energy Control and Dispatch,,,EIA & FERC,92
-GRIF,"Griffith Energy, LLC",generation_only,US/Arizona,US/Arizona,Yes,10/1/2008,,Constellation Energy Control and Dispatch,,,EIA & FERC,93
-GRIS,Gridforce South,,US/Central,US/Central,Yes,,,,,,EIA,94
-GRMA,"Gila River Power, LLC",generation_only,US/Arizona,US/Arizona,Yes,1/1/2004,5/3/2018,Constellation Energy Control and Dispatch - Gila River,,,EIA & FERC,95
-GSOC,Georgia System Operations Corporation,,,,Yes,1/1/2004,12/31/2009,,,,FERC,96
-GTC,Georgia Transmission Corporation,,,,Yes,1/1/2005,12/31/2009,,,,FERC,97
-GVL,Gainesville Regional Utilities,,US/Eastern,US/Eastern,Yes,1/1/2004,,,,,EIA & FERC,98
-GWA,"NaturEner Power Watch, LLC",generation_only,US/Mountain,US/Mountain,Yes,7/1/2008,,Constellation Energy Control and Dispatch - Glacier Wind Energy,,,EIA & FERC,99
-HE,Hoosier Energy,,,,Yes,1/1/2004,,,,,FERC,100
-HECO,Hawaiian Electric Company,,US/Hawaii,US/Hawaii,Yes,,,,,,EIA,101
-HGMA,"New Harquahala Generating Company, LLC",generation_only,US/Arizona,US/Arizona,Yes,1/1/2004,,Constellation Energy Control and Dispatch - Harquehala,,,EIA & FERC,102
-HIMS,No Balancing Authority - Hawaii,miscellaneous,US/Hawaii,US/Hawaii,Yes,,,,,,EPA,103
-HMPL,"City of Henderson, KY, Utility Commission, DBA Henderson Municip",,,,Yes,1/1/2019,,,,,FERC,104
-HQT,Hydro-Quebec TransEnergie,,Canada/Eastern,Canada/Eastern,No,1/1/2004,,,,,EIA & FERC,105
-HST,City of Homestead,limited_generation,US/Eastern,US/Eastern,Yes,1/1/2004,,,,,EIA & FERC,106
-IESO,Ontario IESO,rto,Canada/Eastern,Canada/Eastern,No,,,,,,EIA,107
-IID,Imperial Irrigation District,,US/Pacific,US/Pacific,Yes,1/1/2004,,,,,EIA & FERC,108
-IMO,Ontario - Independent Electricity Market Operator,,,,No,1/1/2004,12/31/2008,,,,FERC,109
-INDN,City of Independence P&L Dept.,,,,Yes,1/1/2004,10/1/2015,,,,FERC,110
-IP,Illinois Power Co.,,,,Yes,1/1/2004,10/1/2007,,,,FERC,111
-IPCO,Idaho Power Company,,US/Pacific,US/Mountain,Yes,1/1/2004,,,,,EIA & FERC,112
-IPL,Indianapolis Power & Light Company,,,,Yes,1/1/2004,,,,,FERC,113
-IPRV,Illinois Power Co.,,,,Yes,1/1/2004,4/1/2015,,,,FERC,114
-ISNE,ISO New England,rto,US/Eastern,US/Eastern,Yes,1/1/2004,,,,,EIA & FERC,115
-JEA,JEA,,US/Eastern,US/Eastern,Yes,1/1/2004,,,,,EIA & FERC,116
-KACY,Board of Public Utilities,,,,Yes,1/1/2004,,,,,FERC,117
-KCPL,"Kansas City Power & Light, Co",,,,Yes,1/1/2004,10/1/2015,,,,FERC,118
-LAFA,Lafayette Utilities System,,,,Yes,1/1/2004,10/1/2015,,,,FERC,119
-LAGN,"Louisiana Generating, LLC",,,,Yes,1/1/2004,,,,,FERC,120
-LDWP,Los Angeles Department of Water and Power,,US/Pacific,US/Pacific,Yes,1/1/2004,,,,,EIA & FERC,121
-LEPA,Louisiana Energy & Power Authority,,,,Yes,1/1/2004,10/1/2015,,,,FERC,122
-LES,Lincoln Electric System,,,,Yes,1/1/2004,4/1/2015,,,,FERC,123
-LGEE,Louisville Gas and Electric Company and Kentucky Utilities Company,,ETC/GMT+6,US/Eastern,Yes,1/1/2004,,LG&E Energy Transmission Services,,,EIA & FERC,124
-MCLN,NRG South Central Generating LLC,,,,Yes,1/1/2004,7/1/2006,,,,FERC,125
-MDU,Montana-Dakota Utilities Co.,,,,Yes,1/1/2004,,,,,FERC,126
-MEC,MidAmerican Energy Company,,,,Yes,1/1/2004,,,,,FERC,127
-MECS,Michigan Electric Coordinated System,,,,Yes,1/1/2004,,,,,FERC,128
-MGE,Madison Gas and Electric Company,,,,Yes,1/1/2004,,,,,FERC,129
-MHEB,Manitoba Hydro,,Canada/Central,Canada/Central,No,1/1/2004,,,,,EIA & FERC,130
-MISO,"Midcontinent Independent System Operator, Inc.",rto,ETC/GMT+5,US/Central,Yes,1/1/2004,,,,,EIA & FERC,131
-MIUP,Wisconsin Energy Corporation,,,,Yes,4/1/2014,,,,,FERC,132
-MOWR,Westar Energy - MoPEP Cities,,,,Yes,1/1/2004,4/1/2015,,,,FERC,133
-MP,"Minnesota Power, Inc.",,,,Yes,1/1/2004,,,,,FERC,134
-MPS,Aquila Networks - Missouri Public Service,,,,Yes,1/1/2004,10/1/2015,,,,FERC,135
-MPW,Muscatine Power and Water,,,,Yes,1/1/2004,,,,,FERC,136
-NBPC,New Brunswick Power Corporation,,,,No,1/1/2004,12/31/2008,,,,FERC,137
-NBSO,New Brunswick System Operator,,Canada/Atlantic,Canada/Atlantic,No,7/1/2008,,,,,EIA & FERC,138
-NEVP,Nevada Power Company,,US/Pacific,US/Pacific,Yes,1/1/2004,,,,,EIA & FERC,139
-NHC1,New Horizons Electric Cooperative,,,,Yes,1/1/2004,,,,,FERC,140
-NIPS,Northern Indiana Public Service Company,,,,Yes,1/1/2004,,,,,FERC,141
-NLR,"Louisiana Generating, LLC - North Little Rock",,,,Yes,1/1/2010,,,,,FERC,142
-NLSO,Newfoundland and Labrador Hydro,,,,No,7/1/2017,,,,,FERC,143
-NPPD,Nebraska Public Power District,,,,Yes,1/1/2004,4/1/2015,,,,FERC,144
-NSB,Utilities Commission of New Smyrna Beach,limited_generation,US/Eastern,US/Eastern,Yes,1/1/2004,1/8/2020,,,,EIA & FERC,145
-NSP,Northern States Power Company,,,,Yes,1/1/2004,,,,,FERC,146
-NSSO,Nova Scotia Power System Operator,,,,No,7/1/2013,,,,,FERC,147
-NWMT,NorthWestern Corporation,,US/Mountain,US/Mountain,Yes,1/1/2004,,NorthWestern Energy,,,EIA & FERC,148
-NYIS,New York Independent System Operator,rto,US/Eastern,US/Eastern,Yes,1/1/2004,,,,,EIA & FERC,149
-OKGE,Oklahoma Gas and Electric,,,,Yes,1/1/2004,4/1/2015,,,,FERC,150
-OMLP,Constellation Energy Control and Dispatch - Osceola Municipal Light an,,,,Yes,10/1/2009,4/1/2015,,,,FERC,151
-ONT,Ontario - Independent Electricity System Operator,,,,No,3/2/2006,,,,,FERC,152
-OPPD,OPPD CA/TP,,,,Yes,1/1/2004,7/1/2016,,,,FERC,153
-OTP,Otter Tail Power Company,,,,Yes,1/1/2004,,,,,FERC,154
-OVEC,Ohio Valley Electric Corporation,,US/Eastern,US/Eastern,Yes,1/1/2004,12/1/2018,,,,EIA & FERC,155
-PACE,PacifiCorp East,,US/Mountain,US/Mountain,Yes,1/1/2004,,,,,EIA & FERC,156
-PACW,PacifiCorp West,,US/Pacific,US/Pacific,Yes,1/1/2004,,,,,EIA & FERC,157
-PGE,Portland General Electric Company,,US/Pacific,US/Pacific,Yes,1/1/2004,,,,,EIA & FERC,158
-PJM,"PJM Interconnection, LLC",rto,US/Eastern,US/Eastern,Yes,1/1/2004,,,,,EIA & FERC,159
-PLUM,Constellation Energy Control and Dispatch - Plum Point,,,,Yes,4/1/2009,4/1/2015,,,,FERC,160
-PNM,Public Service Company of New Mexico,,US/Arizona,US/Mountain,Yes,1/1/2004,,,,,EIA & FERC,161
-PRMS,No Balancing Authority - Puerto Rico,miscellaneous,America/Puerto_Rico,America/Puerto_Rico,Yes,,,,,,EPA,162
-PSCO,Public Service Company of Colorado,,US/Mountain,US/Mountain,Yes,1/1/2004,,,,,EIA & FERC,163
-PSEI,"Puget Sound Energy, Inc.",,US/Pacific,US/Pacific,Yes,1/1/2004,,,,,EIA & FERC,164
-PUPP,Constellation Energy Control and Dispatch - Arkansas,,,,Yes,1/1/2004,4/1/2015,,,,FERC,165
-RC,Reedy Creek Improvement District,,,,Yes,1/1/2004,4/1/2015,,,,FERC,166
-SC,South Carolina Public Service Authority,,US/Eastern,US/Eastern,Yes,1/1/2004,,Santee Cooper,,,EIA & FERC,167
-SCEG,South Carolina Electric & Gas Company,,US/Eastern,US/Eastern,Yes,1/1/2004,,,,,EIA & FERC,168
-SCL,Seattle City Light,,US/Pacific,US/Pacific,Yes,1/1/2004,,,,,EIA & FERC,169
-SEC,Seminole Electric Cooperative,,US/Eastern,US/Eastern,Yes,1/1/2004,,,,,EIA & FERC,170
-SECI,Sunflower Electric Power Corporation,,,,Yes,1/1/2004,,,,,FERC,171
-SEHA,Southeastern Power Administration - Hartwell,,,,Yes,1/1/2004,,,,,FERC,172
-SEPA,Southeastern Power Administration,generation_only,US/Central,US/Eastern,Yes,,,,,,EIA,173
-SERU,Southeastern Power Administration - Russell,,,,Yes,1/1/2004,,,,,FERC,174
-SETH,Southeastern Power Administration - Thurmond,,,,Yes,1/1/2004,,,,,FERC,175
-SIGE,Southern Indiana Gas & Electric Co.,,,,Yes,1/1/2004,,,,,FERC,176
-SIPC,Southern Illinois Power Cooperative,,,,Yes,1/1/2004,,,,,FERC,177
-SME,South Mississippi Electric Power Association,,,,Yes,1/1/2004,,,,,FERC,178
-SMEE,South Mississippi Electric Power Association,,,,Yes,1/1/2004,,,,,FERC,179
-SMP,Southern Minnesota Municipal Power Agency,,,,Yes,1/1/2004,,,,,FERC,180
-SMUD,Sacramento Municipal Utility District,,,,Yes,1/1/2004,4/1/2015,,,,FERC,181
-SOCO,"Southern Company Services, Inc. - Trans",,US/Central,US/Central,Yes,1/1/2004,,,,,EIA & FERC,182
-SPA,Southwestern Power Administration,power_marketing_administration,US/Central,US/Central,Yes,1/1/2004,,,,,EIA & FERC,183
-SPC,Saskatchewan Power Corporation,,Canada/Central,Canada/Central,No,1/1/2004,,,,,EIA & FERC,184
-SPPC,Sierra Pacific Power Co. - Transmission,,,,Yes,1/1/2004,4/1/2015,,,,FERC,185
-SPRM,City Utilities of Springfield,,,,Yes,7/1/2013,10/1/2015,,,,FERC,186
-SPS,Southwestern Public Service Company,,,,Yes,1/1/2004,4/1/2015,,,,FERC,187
-SRP,Salt River Project Agricultural Improvement and Power District,,US/Arizona,US/Arizona,Yes,1/1/2004,,,,,EIA & FERC,188
-SWPP,Southwest Power Pool,rto,US/Central,US/Central,Yes,1/1/2004,,,,,EIA & FERC,189
-TAL,City of Tallahassee,,US/Eastern,US/Eastern,Yes,1/1/2004,,,,,EIA & FERC,190
-TEC,Tampa Electric Company,,US/Eastern,US/Eastern,Yes,1/1/2004,,,,,EIA & FERC,191
-TEPC,Tucson Electric Power,,US/Arizona,US/Arizona,Yes,1/1/2004,,,,,EIA & FERC,192
-TEST,North American Electric Reliability Council,,,,Yes,1/1/2004,12/31/2007,,,,FERC,193
-TIDC,Turlock Irrigation District,,US/Pacific,US/Pacific,Yes,1/1/2004,,,,,EIA & FERC,194
-TLKN,TRANSLink Management Company,,,,Yes,1/1/2004,4/1/2015,,,,FERC,195
-TPWR,"City of Tacoma, Department of Public Utilities, Light Division",,US/Pacific,US/Pacific,Yes,1/1/2004,,Tacoma Power,,,EIA & FERC,196
-TVA,Tennessee Valley Authority,,US/Central,US/Central,Yes,1/1/2004,,,,,EIA & FERC,197
-UPPC,Upper Peninsula Power Co.,,,,Yes,1/1/2004,,,,,FERC,198
-VAP,Dominion Virginia Power,,,,Yes,1/1/2004,7/1/2006,,,,FERC,199
-WACM,Western Area Power Administration - Rocky Mountain Region,power_marketing_administration,US/Arizona,US/Mountain,Yes,1/1/2004,,Western Area Power Administration - Colorado-Missouri,,,EIA & FERC,200
-WALC,Western Area Power Administration - Desert Southwest Region,power_marketing_administration,US/Arizona,US/Arizona,Yes,1/1/2004,,Western Area Power Administration - Lower Colorado,,,EIA & FERC,201
-WAUE,Western Area Power Administration - Upper Great Plains East,power_marketing_administration,US/Mountain,US/Mountain,Yes,1/1/2004,10/1/2015,,,7/1/2016,EIA & FERC,202
-WAUW,Western Area Power Administration - Upper Great Plains West,power_marketing_administration,US/Mountain,US/Mountain,Yes,1/1/2004,,,,,EIA & FERC,203
-WEC,Wisconsin Energy Corporation,,,,Yes,1/1/2004,,,,,FERC,204
-WFEC,Western Farmers Electric Cooperative,,,,Yes,1/1/2004,,,,,FERC,205
-WMU,"Louisiana Generating, LLC - City of West Memphis",,,,Yes,4/1/2010,,,,,FERC,206
-WMUC,"Constellation Energy Control and Dispatch - West Memphis, Arkansas",,,,Yes,1/1/2005,4/1/2015,,,,FERC,207
-WPEC,Aquila Networks - West Plains Dispatch,,,,Yes,1/1/2004,4/1/2015,,,,FERC,208
-WPEK,Aquila Networks - Kansas,,,,Yes,1/1/2004,4/1/2015,,,,FERC,209
-WPS,Wisconsin Public Service Corporation,,,,Yes,1/1/2004,,,,,FERC,210
-WR,Western Resources dba Westar Energy,,,,Yes,1/1/2004,4/1/2015,,,,FERC,211
-WWA,"NaturEner Wind Watch, LLC",generation_only,US/Mountain,US/Mountain,Yes,7/1/2013,,"CECD, LLC",,,EIA & FERC,212
-YAD,"Alcoa Power Generating, Inc. - Yadkin Division",generation_only,US/Eastern,US/Eastern,Yes,1/1/2004,,"Yadkin, Inc.",,,EIA & FERC,213
-None,No Balancing Authority,,,,,,,,,,,999
+ALEX,"Alliant Energy Corporate Services, LLC",,,,Yes,1/1/2004,7/1/2006,,,,FERC,10
+ALTE,"Alliant Energy Corporate Services, LLC - East",,,,Yes,1/1/2004,,,,,FERC,11
+ALTW,"Alliant Energy Corporate Services, LLC- West",,,,Yes,1/1/2004,,,,,FERC,12
+ALWX,"Alliant Energy Corporate Services, LLC",,,,Yes,1/1/2004,7/1/2006,,,,FERC,13
+AMIL,Ameren Transmission-Illinois,,,,Yes,1/1/2007,,,,,FERC,14
+AMMO,Ameren Transmission-Missouri,,,,Yes,1/1/2007,,,,,FERC,15
+AMPL,Anchorage Municipal Light and Power,,US/Alaska,US/Alaska,Yes,,,,,,EIA,16
+AMRN,Ameren Transmission,,,,Yes,1/1/2004,,,,,FERC,17
+AVA,Avista Corporation,,US/Pacific,US/Pacific,Yes,1/1/2004,,,,,EIA & FERC,18
+AVRN,"Avangrid Renewables, LLC",generation_only,US/Pacific,US/Pacific,Yes,7/31/2018,,,7/1/2017,,EIA & FERC,19
+AZPS,Arizona Public Service Company,,US/Arizona,US/Arizona,Yes,1/1/2004,,,,,EIA & FERC,20
+BANC,Balancing Authority of Northern California,,US/Pacific,US/Pacific,Yes,7/1/2013,,,,,EIA & FERC,21
+BBA,Batesville Balancing Authority,,,,Yes,7/1/2006,4/1/2015,,,,FERC,22
+BCA,Batesville Control Area,,,,Yes,1/1/2004,9/30/2006,,,,FERC,23
+BCHA,British Columbia Hydro and Power Authority,,Canada/Pacific,Canada/Pacific,No,1/1/2004,,,,,EIA & FERC,24
+BCTC,British Columbia Transmission Corporation,,,,No,10/1/2008,4/1/2015,,,,FERC,25
+BERC,"DECA, LLC",,,,Yes,1/1/2004,7/1/2006,,,,FERC,26
+BPAT,Bonneville Power Administration,power_marketing_administration,US/Pacific,US/Pacific,Yes,1/1/2004,,,,,EIA & FERC,27
+BRAZ,"CECD, LLC",,,,Yes,7/1/2013,4/1/2015,,,,FERC,28
+BREC,Big Rivers Electric Corp.,,,,Yes,1/1/2004,,,,,FERC,29
+BUBA,"Constellation Energy Control and Dispatch - City of Benton, Arkansas",,,,Yes,1/1/2007,4/1/2015,,,,FERC,30
+CE,Commonwealth Edison,,,,Yes,1/1/2004,7/1/2006,,,,FERC,31
+CEA,Chugash Electric Association,,US/Alaska,US/Alaska,Yes,,,,,,EIA,32
+CEN,Centro Nacional de Control de Energia,,America/Mexico_City,America/Mexico_City,No,10/31/2017,,,1/1/2016,,EIA & FERC,33
+CFE,Comision Federal de Electricidad,,America/Mexico_City,America/Mexico_City,No,,,,,,EIA & FERC,34
+CFEN,Comision Federal de Electricidad,,,,No,,4/1/2015,,,,FERC,35
+CHPD,Public Utility District No. 1 of Chelan County,,US/Pacific,US/Pacific,Yes,1/1/2004,,,,,EIA & FERC,36
+CILC,Central Illinois Light Co,,,,Yes,1/1/2004,10/1/2007,,,,FERC,37
+CIN,Cinergy Corporation,,,,Yes,1/1/2004,,,,,FERC,38
+CISO,California Independent System Operator,rto,US/Pacific,US/Pacific,Yes,1/1/2004,,,,,EIA & FERC,39
+CLEC,Cleco Power LLC,,,,Yes,1/1/2004,,,,,FERC,40
+CNWY,"Constellation Energy Control and Dispatch - Conway, Arkansas",,,,Yes,1/1/2005,4/1/2015,,,,FERC,41
+CONS,Michigan Electric Coordinated System- CONS,,,,Yes,1/1/2004,,,,,FERC,42
+CPLE,Duke Energy Progress East,,US/Eastern,US/Eastern,Yes,1/1/2004,,Carolina Power and Light Company - East,,,EIA & FERC,43
+CPLW,Duke Energy Progress West,limited_generation,US/Eastern,US/Eastern,Yes,1/1/2004,,Carolina Power & Light Company - CPLW,,,EIA & FERC,44
+CSTO,"Constellation Energy Control and Dispatch, LLC",,US/Eastern,US/Eastern,Yes,7/1/2013,4/1/2015,"CECD, LLC",,,EIA & FERC,45
+CSWS,Central and Southwest,,,,Yes,1/1/2004,4/1/2015,,,,FERC,46
+CWAY,"Louisiana Generating, LLC - City of Conway",,,,Yes,4/1/2010,7/1/2016,,,,FERC,47
+CWLD,Columbia Water & Light,,,,Yes,1/1/2004,,,,,FERC,48
+CWLP,City Water Light & Power,,,,Yes,1/1/2004,,,,,FERC,49
+DEAA,"Arlington Valley, LLC",generation_only,US/Arizona,US/Arizona,Yes,1/1/2004,,"DECA, LLC - Arlington Valley",,,EIA & FERC,50
+DECO,Michigan Electric Coordinated System- DECO,,,,Yes,1/1/2004,,,,,FERC,51
+DEEM,"DECA, LLC - Enterprise",,,,Yes,1/1/2004,7/1/2006,,,,FERC,52
+DEHA,"DECA, LLC",,,,Yes,1/1/2004,7/1/2006,,,,FERC,53
+DELI,"DECA, LLC - Lee",,,,Yes,1/1/2004,7/1/2006,,,,FERC,54
+DELO,"DECA, LLC",,,,Yes,1/1/2004,7/1/2006,,,,FERC,55
+DEMG,"DECA, LLC",,,,Yes,1/1/2004,7/1/2006,,,,FERC,56
+DEMT,"DECA, LLC - Murray",,,,Yes,1/1/2004,7/1/2006,,,,FERC,57
+DENL,"Constellation Energy Control and Dispatch - North Little Rock, AK",,,,Yes,1/1/2004,4/1/2015,,,,FERC,58
+DERS,"Constellation Energy Control and Dispatch - City of Ruston, LA",,,,Yes,1/1/2004,4/1/2015,,,,FERC,59
+DESG,"DECA, LLC - Sandersville",,,,Yes,1/1/2004,7/1/2006,,,,FERC,60
+DESM,"DECA, LLC",,,,Yes,1/1/2004,7/1/2006,,,,FERC,61
+DEVI,Constellation Energy Control and Dispatch - Vermillion,,,,Yes,1/1/2004,7/1/2006,,,,FERC,62
+DEWO,"DECA, LLC - Washington",,,,Yes,1/1/2004,7/1/2006,,,,FERC,63
+DLCO,Duquesne Light,,,,Yes,1/1/2004,7/1/2006,,,,FERC,64
+DOPD,PUD No. 1 of Douglas County,,US/Pacific,US/Pacific,Yes,1/1/2004,,,,,EIA & FERC,65
+DPC,Dairyland Power Cooperative,,,,Yes,1/1/2004,,,,,FERC,66
+DPL,Dayton Power & Light,,,,Yes,1/1/2004,7/1/2006,,,,FERC,67
+DSK1,BridgeCo,,,,Yes,1/1/2004,7/1/2006,,,,FERC,68
+DUK,Duke Energy Carolinas,,US/Eastern,US/Eastern,Yes,1/1/2004,,Duke Energy Corporation,,,EIA & FERC,69
+EAI,"Entergy Arkansas, Inc.",,,,Yes,7/1/2013,,,,,FERC,70
+EDE,"Empire District Electric Co., The",,,,Yes,1/1/2004,4/1/2015,,,,FERC,71
+EEI,"Electric Energy, Inc.",,US/Central,US/Central,Yes,1/1/2004,2/29/2020,,,,EIA & FERC,72
+EES,Entergy,,,,Yes,1/1/2004,,,,,FERC,73
+EKPC,"East Kentucky Power Cooperative, Inc.",,,,Yes,1/1/2004,4/1/2015,,,,FERC,74
+EMBA,"Entergy Mississippi, Inc.",,,,Yes,4/1/2015,,,,,FERC,75
+EPE,El Paso Electric Company,,US/Arizona,US/Mountain,Yes,1/1/2004,,El Paso Electric,,,EIA & FERC,76
+ERCO,"Electric Reliability Council of Texas, Inc.",rto,US/Central,US/Central,Yes,1/1/2004,,ERCOT ISO,,,EIA & FERC,77
+FE,"American Transmission Systems, Inc.",,,,Yes,1/1/2004,4/1/2015,,,,FERC,78
+FMPP,Florida Municipal Power Pool,,US/Eastern,US/Eastern,Yes,1/1/2004,,,,,EIA & FERC,79
+FPC,"Duke Energy Florida, Inc.",,US/Eastern,US/Eastern,Yes,1/1/2004,,Florida Power Corporation,,,EIA & FERC,80
+FPL,Florida Power & Light Co.,,US/Eastern,US/Eastern,Yes,1/1/2004,,,,,EIA & FERC,81
+GA,GridAmerica,,,,Yes,1/1/2004,4/1/2015,,,,FERC,82
+GCPD,"Public Utility District No. 2 of Grant County, Washington",,US/Pacific,US/Pacific,Yes,1/1/2004,,,,,EIA & FERC,83
+GLHB,GridLiance,generation_only,US/Central,US/Central,Yes,2/29/2020,,GridLiance Heartland (BA),1/1/2020,,EIA & FERC,84
+GLHL,GridLiance Heartland,,,,Yes,1/1/2020,,,,,FERC,85
+GRDA,Grand River Dam Authority,,,,Yes,1/1/2004,4/1/2015,,,,FERC,86
+GRE,Great River Energy,,,,Yes,1/1/2004,,,,,FERC,87
+GREC,Great River Energy,,,,Yes,1/1/2004,,,,,FERC,88
+GREN,Great River Energy,,,,Yes,1/1/2004,,,,,FERC,89
+GRES,Great River Energy,,,,Yes,1/1/2004,,,,,FERC,90
+GRID,"Gridforce Energy Management, LLC",generation_only,US/Pacific,US/Pacific,Yes,4/1/2014,,Constellation Energy Control and Dispatch,,,EIA & FERC,91
+GRIF,"Griffith Energy, LLC",generation_only,US/Arizona,US/Arizona,Yes,10/1/2008,,Constellation Energy Control and Dispatch,,,EIA & FERC,92
+GRIS,Gridforce South,,US/Central,US/Central,Yes,,,,,,EIA,93
+GRMA,"Gila River Power, LLC",generation_only,US/Arizona,US/Arizona,Yes,1/1/2004,5/3/2018,Constellation Energy Control and Dispatch - Gila River,,,EIA & FERC,94
+GSOC,Georgia System Operations Corporation,,,,Yes,1/1/2004,12/31/2009,,,,FERC,95
+GTC,Georgia Transmission Corporation,,,,Yes,1/1/2005,12/31/2009,,,,FERC,96
+GVL,Gainesville Regional Utilities,,US/Eastern,US/Eastern,Yes,1/1/2004,,,,,EIA & FERC,97
+GWA,"NaturEner Power Watch, LLC",generation_only,US/Mountain,US/Mountain,Yes,7/1/2008,,Constellation Energy Control and Dispatch - Glacier Wind Energy,,,EIA & FERC,98
+HE,Hoosier Energy,,,,Yes,1/1/2004,,,,,FERC,99
+HECO,Hawaiian Electric Company,,US/Hawaii,US/Hawaii,Yes,,,,,,EIA,100
+HGMA,"New Harquahala Generating Company, LLC",generation_only,US/Arizona,US/Arizona,Yes,1/1/2004,,Constellation Energy Control and Dispatch - Harquehala,,,EIA & FERC,101
+HMPL,"City of Henderson, KY, Utility Commission, DBA Henderson Municip",,,,Yes,1/1/2019,,,,,FERC,102
+HQT,Hydro-Quebec TransEnergie,,Canada/Eastern,Canada/Eastern,No,1/1/2004,,,,,EIA & FERC,103
+HST,City of Homestead,limited_generation,US/Eastern,US/Eastern,Yes,1/1/2004,,,,,EIA & FERC,104
+IESO,Ontario IESO,rto,Canada/Eastern,Canada/Eastern,No,,,,,,EIA,105
+IID,Imperial Irrigation District,,US/Pacific,US/Pacific,Yes,1/1/2004,,,,,EIA & FERC,106
+IMO,Ontario - Independent Electricity Market Operator,,,,No,1/1/2004,12/31/2008,,,,FERC,107
+INDN,City of Independence P&L Dept.,,,,Yes,1/1/2004,10/1/2015,,,,FERC,108
+IP,Illinois Power Co.,,,,Yes,1/1/2004,10/1/2007,,,,FERC,109
+IPCO,Idaho Power Company,,US/Pacific,US/Mountain,Yes,1/1/2004,,,,,EIA & FERC,110
+IPL,Indianapolis Power & Light Company,,,,Yes,1/1/2004,,,,,FERC,111
+IPRV,Illinois Power Co.,,,,Yes,1/1/2004,4/1/2015,,,,FERC,112
+ISNE,ISO New England,rto,US/Eastern,US/Eastern,Yes,1/1/2004,,,,,EIA & FERC,113
+JEA,JEA,,US/Eastern,US/Eastern,Yes,1/1/2004,,,,,EIA & FERC,114
+KACY,Board of Public Utilities,,,,Yes,1/1/2004,,,,,FERC,115
+KCPL,"Kansas City Power & Light, Co",,,,Yes,1/1/2004,10/1/2015,,,,FERC,116
+LAFA,Lafayette Utilities System,,,,Yes,1/1/2004,10/1/2015,,,,FERC,117
+LAGN,"Louisiana Generating, LLC",,,,Yes,1/1/2004,,,,,FERC,118
+LDWP,Los Angeles Department of Water and Power,,US/Pacific,US/Pacific,Yes,1/1/2004,,,,,EIA & FERC,119
+LEPA,Louisiana Energy & Power Authority,,,,Yes,1/1/2004,10/1/2015,,,,FERC,120
+LES,Lincoln Electric System,,,,Yes,1/1/2004,4/1/2015,,,,FERC,121
+LGEE,Louisville Gas and Electric Company and Kentucky Utilities Company,,ETC/GMT+6,US/Eastern,Yes,1/1/2004,,LG&E Energy Transmission Services,,,EIA & FERC,122
+MCLN,NRG South Central Generating LLC,,,,Yes,1/1/2004,7/1/2006,,,,FERC,123
+MDU,Montana-Dakota Utilities Co.,,,,Yes,1/1/2004,,,,,FERC,124
+MEC,MidAmerican Energy Company,,,,Yes,1/1/2004,,,,,FERC,125
+MECS,Michigan Electric Coordinated System,,,,Yes,1/1/2004,,,,,FERC,126
+MGE,Madison Gas and Electric Company,,,,Yes,1/1/2004,,,,,FERC,127
+MHEB,Manitoba Hydro,,Canada/Central,Canada/Central,No,1/1/2004,,,,,EIA & FERC,128
+MISO,"Midcontinent Independent System Operator, Inc.",rto,ETC/GMT+5,US/Central,Yes,1/1/2004,,,,,EIA & FERC,129
+MIUP,Wisconsin Energy Corporation,,,,Yes,4/1/2014,,,,,FERC,130
+MOWR,Westar Energy - MoPEP Cities,,,,Yes,1/1/2004,4/1/2015,,,,FERC,131
+MP,"Minnesota Power, Inc.",,,,Yes,1/1/2004,,,,,FERC,132
+MPS,Aquila Networks - Missouri Public Service,,,,Yes,1/1/2004,10/1/2015,,,,FERC,133
+MPW,Muscatine Power and Water,,,,Yes,1/1/2004,,,,,FERC,134
+NBPC,New Brunswick Power Corporation,,,,No,1/1/2004,12/31/2008,,,,FERC,135
+NBSO,New Brunswick System Operator,,Canada/Atlantic,Canada/Atlantic,No,7/1/2008,,,,,EIA & FERC,136
+NEVP,Nevada Power Company,,US/Pacific,US/Pacific,Yes,1/1/2004,,,,,EIA & FERC,137
+NHC1,New Horizons Electric Cooperative,,,,Yes,1/1/2004,,,,,FERC,138
+NIPS,Northern Indiana Public Service Company,,,,Yes,1/1/2004,,,,,FERC,139
+NLR,"Louisiana Generating, LLC - North Little Rock",,,,Yes,1/1/2010,,,,,FERC,140
+NLSO,Newfoundland and Labrador Hydro,,,,No,7/1/2017,,,,,FERC,141
+NPPD,Nebraska Public Power District,,,,Yes,1/1/2004,4/1/2015,,,,FERC,142
+NSB,Utilities Commission of New Smyrna Beach,limited_generation,US/Eastern,US/Eastern,Yes,1/1/2004,1/8/2020,,,,EIA & FERC,143
+NSP,Northern States Power Company,,,,Yes,1/1/2004,,,,,FERC,144
+NSSO,Nova Scotia Power System Operator,,,,No,7/1/2013,,,,,FERC,145
+NWMT,NorthWestern Corporation,,US/Mountain,US/Mountain,Yes,1/1/2004,,NorthWestern Energy,,,EIA & FERC,146
+NYIS,New York Independent System Operator,rto,US/Eastern,US/Eastern,Yes,1/1/2004,,,,,EIA & FERC,147
+OKGE,Oklahoma Gas and Electric,,,,Yes,1/1/2004,4/1/2015,,,,FERC,148
+OMLP,Constellation Energy Control and Dispatch - Osceola Municipal Light an,,,,Yes,10/1/2009,4/1/2015,,,,FERC,149
+ONT,Ontario - Independent Electricity System Operator,,,,No,3/2/2006,,,,,FERC,150
+OPPD,OPPD CA/TP,,,,Yes,1/1/2004,7/1/2016,,,,FERC,151
+OTP,Otter Tail Power Company,,,,Yes,1/1/2004,,,,,FERC,152
+OVEC,Ohio Valley Electric Corporation,,US/Eastern,US/Eastern,Yes,1/1/2004,12/1/2018,,,,EIA & FERC,153
+PACE,PacifiCorp East,,US/Mountain,US/Mountain,Yes,1/1/2004,,,,,EIA & FERC,154
+PACW,PacifiCorp West,,US/Pacific,US/Pacific,Yes,1/1/2004,,,,,EIA & FERC,155
+PGE,Portland General Electric Company,,US/Pacific,US/Pacific,Yes,1/1/2004,,,,,EIA & FERC,156
+PJM,"PJM Interconnection, LLC",rto,US/Eastern,US/Eastern,Yes,1/1/2004,,,,,EIA & FERC,157
+PLUM,Constellation Energy Control and Dispatch - Plum Point,,,,Yes,4/1/2009,4/1/2015,,,,FERC,158
+PNM,Public Service Company of New Mexico,,US/Arizona,US/Mountain,Yes,1/1/2004,,,,,EIA & FERC,159
+PSCO,Public Service Company of Colorado,,US/Mountain,US/Mountain,Yes,1/1/2004,,,,,EIA & FERC,160
+PSEI,"Puget Sound Energy, Inc.",,US/Pacific,US/Pacific,Yes,1/1/2004,,,,,EIA & FERC,161
+PUPP,Constellation Energy Control and Dispatch - Arkansas,,,,Yes,1/1/2004,4/1/2015,,,,FERC,162
+RC,Reedy Creek Improvement District,,,,Yes,1/1/2004,4/1/2015,,,,FERC,163
+SC,South Carolina Public Service Authority,,US/Eastern,US/Eastern,Yes,1/1/2004,,Santee Cooper,,,EIA & FERC,164
+SCEG,South Carolina Electric & Gas Company,,US/Eastern,US/Eastern,Yes,1/1/2004,,,,,EIA & FERC,165
+SCL,Seattle City Light,,US/Pacific,US/Pacific,Yes,1/1/2004,,,,,EIA & FERC,166
+SEC,Seminole Electric Cooperative,,US/Eastern,US/Eastern,Yes,1/1/2004,,,,,EIA & FERC,167
+SECI,Sunflower Electric Power Corporation,,,,Yes,1/1/2004,,,,,FERC,168
+SEHA,Southeastern Power Administration - Hartwell,,,,Yes,1/1/2004,,,,,FERC,169
+SEPA,Southeastern Power Administration,generation_only,US/Central,US/Eastern,Yes,,,,,,EIA,170
+SERU,Southeastern Power Administration - Russell,,,,Yes,1/1/2004,,,,,FERC,171
+SETH,Southeastern Power Administration - Thurmond,,,,Yes,1/1/2004,,,,,FERC,172
+SIGE,Southern Indiana Gas & Electric Co.,,,,Yes,1/1/2004,,,,,FERC,173
+SIPC,Southern Illinois Power Cooperative,,,,Yes,1/1/2004,,,,,FERC,174
+SME,South Mississippi Electric Power Association,,,,Yes,1/1/2004,,,,,FERC,175
+SMEE,South Mississippi Electric Power Association,,,,Yes,1/1/2004,,,,,FERC,176
+SMP,Southern Minnesota Municipal Power Agency,,,,Yes,1/1/2004,,,,,FERC,177
+SMUD,Sacramento Municipal Utility District,,,,Yes,1/1/2004,4/1/2015,,,,FERC,178
+SOCO,"Southern Company Services, Inc. - Trans",,US/Central,US/Central,Yes,1/1/2004,,,,,EIA & FERC,179
+SPA,Southwestern Power Administration,power_marketing_administration,US/Central,US/Central,Yes,1/1/2004,,,,,EIA & FERC,180
+SPC,Saskatchewan Power Corporation,,Canada/Central,Canada/Central,No,1/1/2004,,,,,EIA & FERC,181
+SPPC,Sierra Pacific Power Co. - Transmission,,,,Yes,1/1/2004,4/1/2015,,,,FERC,182
+SPRM,City Utilities of Springfield,,,,Yes,7/1/2013,10/1/2015,,,,FERC,183
+SPS,Southwestern Public Service Company,,,,Yes,1/1/2004,4/1/2015,,,,FERC,184
+SRP,Salt River Project Agricultural Improvement and Power District,,US/Arizona,US/Arizona,Yes,1/1/2004,,,,,EIA & FERC,185
+SWPP,Southwest Power Pool,rto,US/Central,US/Central,Yes,1/1/2004,,,,,EIA & FERC,186
+TAL,City of Tallahassee,,US/Eastern,US/Eastern,Yes,1/1/2004,,,,,EIA & FERC,187
+TEC,Tampa Electric Company,,US/Eastern,US/Eastern,Yes,1/1/2004,,,,,EIA & FERC,188
+TEPC,Tucson Electric Power,,US/Arizona,US/Arizona,Yes,1/1/2004,,,,,EIA & FERC,189
+TEST,North American Electric Reliability Council,,,,Yes,1/1/2004,12/31/2007,,,,FERC,190
+TIDC,Turlock Irrigation District,,US/Pacific,US/Pacific,Yes,1/1/2004,,,,,EIA & FERC,191
+TLKN,TRANSLink Management Company,,,,Yes,1/1/2004,4/1/2015,,,,FERC,192
+TPWR,"City of Tacoma, Department of Public Utilities, Light Division",,US/Pacific,US/Pacific,Yes,1/1/2004,,Tacoma Power,,,EIA & FERC,193
+TVA,Tennessee Valley Authority,,US/Central,US/Central,Yes,1/1/2004,,,,,EIA & FERC,194
+UPPC,Upper Peninsula Power Co.,,,,Yes,1/1/2004,,,,,FERC,195
+VAP,Dominion Virginia Power,,,,Yes,1/1/2004,7/1/2006,,,,FERC,196
+WACM,Western Area Power Administration - Rocky Mountain Region,power_marketing_administration,US/Arizona,US/Mountain,Yes,1/1/2004,,Western Area Power Administration - Colorado-Missouri,,,EIA & FERC,197
+WALC,Western Area Power Administration - Desert Southwest Region,power_marketing_administration,US/Arizona,US/Arizona,Yes,1/1/2004,,Western Area Power Administration - Lower Colorado,,,EIA & FERC,198
+WAUE,Western Area Power Administration - Upper Great Plains East,power_marketing_administration,US/Mountain,US/Mountain,Yes,1/1/2004,10/1/2015,,,7/1/2016,EIA & FERC,199
+WAUW,Western Area Power Administration - Upper Great Plains West,power_marketing_administration,US/Mountain,US/Mountain,Yes,1/1/2004,,,,,EIA & FERC,200
+WEC,Wisconsin Energy Corporation,,,,Yes,1/1/2004,,,,,FERC,201
+WFEC,Western Farmers Electric Cooperative,,,,Yes,1/1/2004,,,,,FERC,202
+WMU,"Louisiana Generating, LLC - City of West Memphis",,,,Yes,4/1/2010,,,,,FERC,203
+WMUC,"Constellation Energy Control and Dispatch - West Memphis, Arkansas",,,,Yes,1/1/2005,4/1/2015,,,,FERC,204
+WPEC,Aquila Networks - West Plains Dispatch,,,,Yes,1/1/2004,4/1/2015,,,,FERC,205
+WPEK,Aquila Networks - Kansas,,,,Yes,1/1/2004,4/1/2015,,,,FERC,206
+WPS,Wisconsin Public Service Corporation,,,,Yes,1/1/2004,,,,,FERC,207
+WR,Western Resources dba Westar Energy,,,,Yes,1/1/2004,4/1/2015,,,,FERC,208
+WWA,"NaturEner Wind Watch, LLC",generation_only,US/Mountain,US/Mountain,Yes,7/1/2013,,"CECD, LLC",,,EIA & FERC,209
+YAD,"Alcoa Power Generating, Inc. - Yadkin Division",generation_only,US/Eastern,US/Eastern,Yes,1/1/2004,,"Yadkin, Inc.",,,EIA & FERC,210
+AKMS,No Balancing Authority - Alaska,miscellaneous,US/Alaska,US/Alaska,Yes,,,,,,,902
+HIMS,No Balancing Authority - Hawaii,miscellaneous,US/Hawaii,US/Hawaii,Yes,,,,,,,915
+PAMS,No Balancing Authority - Pennsylvania,miscellaneous,US/Eastern,US/Eastern,Yes,,,,,,,942
+PRMS,No Balancing Authority - Puerto Rico,miscellaneous,America/Puerto_Rico,America/Puerto_Rico,Yes,,,,,,,972
+RIMS,No Balancing Authority - Rhode Island,miscellaneous,US/Eastern,US/Eastern,Yes,,,,,,,944
+NA,No Balancing Authority,miscellaneous,,,Yes,,,,,,,999

--- a/notebooks/test_data_pipeline.ipynb
+++ b/notebooks/test_data_pipeline.ipynb
@@ -96,10 +96,317 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "combined_plant_data = pd.read_csv(f\"../data/results/{path_prefix}plant_data/hourly_plant_data.csv\", )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plant_attributes = pd.read_csv(f\"../data/outputs/{path_prefix}plant_static_attributes_{year}.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "combined_plant_data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Aggregating to BA-fuel\")\n",
+    "# 12. Aggregate CEMS data to BA-fuel and write power sector results\n",
+    "ba_fuel_data = data_cleaning.aggregate_plant_data_to_ba_fuel(\n",
+    "    combined_plant_data, plant_attributes\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_columns = [\n",
+    "    \"net_generation_mwh\",\n",
+    "    \"fuel_consumed_mmbtu\",\n",
+    "    \"fuel_consumed_for_electricity_mmbtu\",\n",
+    "    \"co2_mass_lb\",\n",
+    "    \"ch4_mass_lb\",\n",
+    "    \"n2o_mass_lb\",\n",
+    "    \"nox_mass_lb\",\n",
+    "    \"so2_mass_lb\",\n",
+    "    \"co2_mass_lb_for_electricity\",\n",
+    "    \"ch4_mass_lb_for_electricity\",\n",
+    "    \"n2o_mass_lb_for_electricity\",\n",
+    "    \"nox_mass_lb_for_electricity\",\n",
+    "    \"so2_mass_lb_for_electricity\",\n",
+    "    \"co2_mass_lb_adjusted\",\n",
+    "    \"ch4_mass_lb_adjusted\",\n",
+    "    \"n2o_mass_lb_adjusted\",\n",
+    "    \"nox_mass_lb_adjusted\",\n",
+    "    \"so2_mass_lb_adjusted\",\n",
+    "]\n",
+    "\n",
+    "ba_fuel_data = combined_plant_data.merge(\n",
+    "    plant_attributes, how=\"left\", on=[\"plant_id_eia\"]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ba_fuel_data"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Test"
+    "# Check Negative scaled residuals"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load data from csv\n",
+    "year = 2020\n",
+    "path_prefix = ''\n",
+    "cems = pd.read_csv(f'../data/outputs/{path_prefix}cems_{year}.csv', dtype=get_dtypes(), parse_dates=['datetime_utc', 'report_date'])\n",
+    "\n",
+    "\n",
+    "partial_cems_scaled = pd.read_csv(f'../data/outputs/{path_prefix}partial_cems_scaled_{year}.csv', dtype=get_dtypes(), parse_dates=['datetime_utc', 'report_date'])\n",
+    "cems = data_cleaning.filter_unique_cems_data(cems, partial_cems_scaled)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eia930_data = eia930.load_chalendar_for_pipeline(\n",
+    "        \"../data/downloads/eia930/chalendar/EBA_adjusted_elec.csv\", year=year\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plant_attributes = pd.read_csv(f\"../data/outputs/{path_prefix}plant_static_attributes_{year}.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plant_attributes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems = cems.drop(columns=[\"distribution_flag_x\",\"fuel_category_x\",\"fuel_category_eia930_x\",\"timezone_x\",\"plant_primary_fuel\",\"source\",\"ba_code\",\"ba_code_physical\",\"state\",\"distribution_flag_y\",\"fuel_category_y\",\"fuel_category_eia930_y\",\"timezone_y\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Options for how to group. Could make command line arguments if needed.\n",
+    "# transmission = True and physical BA code is based on EIA-930 instructions\n",
+    "TRANSMISSION = False  # use only transmission-level connections?\n",
+    "BA_CODE = \"ba_code\"  # ba_code or ba_code_physical?\n",
+    "\n",
+    "# Name column same as 930, hourly_profiles.\n",
+    "cems = cems.merge(plant_attributes, how=\"left\", on=\"plant_id_eia\")\n",
+    "\n",
+    "cems = impute_hourly_profiles.aggregate_for_residual(\n",
+    "    cems, \"datetime_utc\", BA_CODE, transmission=TRANSMISSION\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "combined_data = eia930_data.merge(\n",
+    "    cems, how=\"left\", on=[\"ba_code\", \"fuel_category_eia930\", \"datetime_utc\"]\n",
+    ")\n",
+    "# only keep rows where local datetime is in the current year\n",
+    "combined_data = combined_data[\n",
+    "    combined_data[\"datetime_local\"].apply(lambda x: x.year) == year\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "combined_data[\"net_generation_mwh\"] = combined_data[\"net_generation_mwh\"].fillna(0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "combined_data[(combined_data['net_generation_mwh_930'] < 1) & (combined_data['net_generation_mwh'] > 1)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "px.line(combined_data[(combined_data['ba_code'] == 'AECI') & (combined_data['fuel_category_eia930'] == 'natural_gas')], x='datetime_local', y=['net_generation_mwh_930','net_generation_mwh',\"cems_scaled\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "combined_data[(combined_data['ba_code'] == 'AECI') & (combined_data['fuel_category_eia930'] == 'natural_gas')].corr()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# calculate the ratio of 930 net generation to cems net generation\n",
+    "# if correct, ratio should be >=1\n",
+    "combined_data[\"ratio\"] = (\n",
+    "    combined_data[\"net_generation_mwh_930\"]\n",
+    "    / combined_data[\"net_generation_mwh\"]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# only keep scaling factors < 1, which means the data needs to be scaled\n",
+    "scaling_factors = combined_data[(combined_data[\"ratio\"] < 1) & (combined_data[\"ratio\"] > 0)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Find scaling factor\n",
+    "# only keep data where the cems data is greater than zero\n",
+    "#scaling_factors = combined_data.copy()[combined_data[\"net_generation_mwh\"] != 0]\n",
+    "\n",
+    "# find the minimum ratio for each ba-fuel\n",
+    "scaling_factors = (\n",
+    "    scaling_factors.groupby([\"ba_code\", \"fuel_category_eia930\"], dropna=False)[\n",
+    "        \"ratio\"\n",
+    "    ]\n",
+    "    .min()\n",
+    "    .reset_index().rename(columns={\"ratio\":\"scaling_factor\"})\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "\n",
+    "# merge the scaling factor into the combined data\n",
+    "# for any BA-fuels without a scaling factor, fill with 1 (scale to 100% of the origina data)\n",
+    "combined_data = combined_data.merge(\n",
+    "    scaling_factors, how=\"left\", on=[\"ba_code\", \"fuel_category_eia930\"]\n",
+    ").fillna(1)\n",
+    "\n",
+    "# calculate the scaled cems data\n",
+    "combined_data[\"cems_scaled\"] = (\n",
+    "    combined_data[\"net_generation_mwh\"] * combined_data[\"scaling_factor\"]\n",
+    ")\n",
+    "\n",
+    "# calculate the residual\n",
+    "combined_data[\"profile\"] = (\n",
+    "    combined_data[\"net_generation_mwh_930\"] - combined_data[\"cems_scaled\"]\n",
+    ")\n",
+    "\n",
+    "# identify the method used to calculate the profile\n",
+    "# if the scaling factor is 1, then the profile was not scaled\n",
+    "combined_data = combined_data.assign(\n",
+    "    profile_method=lambda x: np.where(\n",
+    "        (x.scaling_factor == 1), \"residual\", \"scaled_residual\"\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "combined_data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Test Hourly Profiles"
    ]
   },
   {
@@ -113,7 +420,8 @@
     "path_prefix = ''\n",
     "eia923_allocated = pd.read_csv(f'../data/outputs/{path_prefix}eia923_allocated_{year}.csv', dtype=get_dtypes(), parse_dates=['report_date'])\n",
     "plant_attributes = pd.read_csv(f\"../data/outputs/{path_prefix}plant_static_attributes_{year}.csv\")\n",
-    "primary_fuel_table = plant_attributes.drop_duplicates(subset=\"plant_id_eia\")[[\"plant_id_eia\", \"plant_primary_fuel\"]]\n"
+    "primary_fuel_table = plant_attributes.drop_duplicates(subset=\"plant_id_eia\")[[\"plant_id_eia\", \"plant_primary_fuel\"]]\n",
+    "residual_profiles = pd.read_csv(f'../data/outputs/{path_prefix}residual_profiles_{year}.csv', dtype=get_dtypes(), parse_dates=['report_date'])\n"
    ]
   },
   {
@@ -134,10 +442,76 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "residual_profiles = pd.read_csv(f'../data/outputs/{path_prefix}residual_profiles_{year}.csv', dtype=get_dtypes(), parse_dates=['report_date'])\n",
+    "plant_attributes['ba_code'] = plant_attributes['ba_code'].fillna('RIMS')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
     "hourly_profiles = impute_hourly_profiles.impute_missing_hourly_profiles(\n",
     "    monthly_eia_data_to_shape, residual_profiles, plant_attributes, year\n",
-    ")\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# make sure there is no duplicated data\n",
+    "hourly_profiles[hourly_profiles.duplicated(subset=[\"ba_code\",\"fuel_category\",\"datetime_local\"])]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hourly_profiles[(hourly_profiles['ba_code'] == 'AVRN') & (hourly_profiles['fuel_category'] == 'solar') & (hourly_profiles['report_date'] == '2020-01-01')]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# make sure there is no na or inf data\n",
+    "hourly_profiles[hourly_profiles.isna().any(axis=1)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# validate hourly profiles\n",
+    "# make sure that no profiles are negative\n",
+    "hourly_profiles[(hourly_profiles['profile'] < 0)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hourly_profiles"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "hourly_profiles = impute_hourly_profiles.convert_profile_to_percent(hourly_profiles)"
    ]
   },
@@ -147,8 +521,40 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# make sure there is no na or inf data\n",
+    "hourly_profiles[hourly_profiles.isna().any(axis=1)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hourly_profiles[(hourly_profiles['profile'] == np.inf)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "monthly_eia_data_to_shape_ba = monthly_eia_data_to_shape.merge(\n",
+    "        plant_attributes[[\"plant_id_eia\", \"ba_code\", \"fuel_category\"]],\n",
+    "        how=\"left\",\n",
+    "        on=\"plant_id_eia\",\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Aggregate EIA data to BA/fuel/month, then assign hourly profile per BA/fuel\n",
-    "monthly_eia_data_to_shape = impute_hourly_profiles.aggregate_eia_data_to_ba_fuel(\n",
+    "monthly_eia_data_to_shape_agg = impute_hourly_profiles.aggregate_eia_data_to_ba_fuel(\n",
     "    monthly_eia_data_to_shape, plant_attributes\n",
     ")"
    ]
@@ -159,8 +565,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "hourly_profiles[(hourly_profiles['ba_code'] == 'AEC') & (hourly_profiles['fuel_category'] == 'hydro') & (hourly_profiles['report_date'] == '2020-4-01')]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "shaped_eia_data = impute_hourly_profiles.shape_monthly_eia_data_as_hourly(\n",
-    "        monthly_eia_data_to_shape, hourly_profiles\n",
+    "        monthly_eia_data_to_shape_agg, hourly_profiles\n",
     "    )"
    ]
   },
@@ -170,7 +585,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "shaped_eia_data"
+    "shaped_eia_data[(shaped_eia_data['ba_code'] == 'SWPP') & (shaped_eia_data['fuel_category'] == 'solar') & (hourly_profiles['report_date'] == '2020-4-01')]"
    ]
   },
   {

--- a/src/column_checks.py
+++ b/src/column_checks.py
@@ -129,6 +129,8 @@ COLUMNS = {
         "plant_id_eia",
         "datetime_utc",
         "report_date",
+        "ba_code",
+        "fuel_category",
         "net_generation_mwh",
         "fuel_consumed_mmbtu",
         "fuel_consumed_for_electricity_mmbtu",

--- a/src/data_cleaning.py
+++ b/src/data_cleaning.py
@@ -2196,16 +2196,14 @@ def assign_ba_code_to_plant(df, year):
         6283: "None",
         57206: "None",
         10093: "None",
+        52106: "PAMS",
     }  # TODO: Tesoro Hawaii has no BA assigned, but is connected to the HECO transmission grid - investigate further
 
     plant_ba["ba_code"].update(plant_ba["plant_id_eia"].map(manual_ba_corrections))
     plant_ba["ba_code"] = plant_ba["ba_code"].replace("None", np.NaN)
 
-    # for plants without a BA code located in AK, HI, or PR, assign the miscellaneous BA code
-    for state in ["AK", "HI", "PR"]:
-        plant_ba.loc[
-            plant_ba["ba_code"].isna() & (plant_ba["state"] == state), "ba_code"
-        ] = f"{state}MS"
+    # for plants without a BA code assign the miscellaneous BA code based on the state
+    plant_ba["ba_code"] = plant_ba["ba_code"].fillna(plant_ba["state"] + "MS")
 
     # add a physical ba code based on the owner of the transmission system
     plant_ba["ba_code_physical"] = plant_ba["ba_code"]
@@ -2229,6 +2227,10 @@ def assign_ba_code_to_plant(df, year):
         how="left",
         on="plant_id_eia",
     )
+
+    # replace missing ba codes with NA
+    df["ba_code"] = df["ba_code"].fillna("NA")
+    df["ba_code_physical"] = df["ba_code_physical"].fillna("NA")
 
     return df
 

--- a/src/data_pipeline.py
+++ b/src/data_pipeline.py
@@ -259,16 +259,16 @@ def main():
     # Load raw EIA-930 data, fix timestamp issues, perform physics-based reconciliation
     # Currently implemented in `notebooks/930_lag` and the `gridemissions` repository
     # Output: `data/outputs/EBA_adjusted_elec.csv`
-    eia930_dat = eia930.load_chalendar_for_pipeline(
+    eia930_data = eia930.load_chalendar_for_pipeline(
         "../data/downloads/eia930/chalendar/EBA_adjusted_elec.csv", year=year
     )  # For now, load data in form it will eventually be in
 
     # 10. Calculate Residual Net Generation Profile
     print("Calculating residual net generation profiles from EIA-930")
     residual_profiles = impute_hourly_profiles.calculate_residual(
-        cems, eia930_dat, plant_attributes, year
+        cems, eia930_data, plant_attributes, year
     )
-    del eia930_dat
+    del eia930_data
     output_data.output_intermediate_data(
         residual_profiles, "residual_profiles", path_prefix, year
     )

--- a/src/load_data.py
+++ b/src/load_data.py
@@ -485,8 +485,10 @@ def ba_timezone(ba, type):
     )
     tz = tz.loc[tz["ba_code"] == ba, f"timezone_{type}"]
 
-    if tz.isna().item():
-        raise UserWarning(f'The BA {ba} does not have a timezone specified in data/manual/ba_reference.csv. Please add.')
+    if len(tz) == 0:
+        raise UserWarning(
+            f"The BA {ba} does not have a timezone specified in data/manual/ba_reference.csv. Please add."
+        )
     else:
         tz = tz.item()
 


### PR DESCRIPTION
-------------------------------------------------------------------------------
# Branch greg/ba_aggregation 
-------------------------------------------------------------------------------

Remaining TODO after merging with output updates:
- [ ] Add function to load plant attributes from synthetic plant ids

### Fixes imputation of missing hourly profiles
- Imputes missing profiles for each BA-fuel-month. Previously had only imputed based on BA-fuel, so if a specific month was missing, this was not being imputed
- When imputing missing profiles, we now consider a profile missing if it is all zeros for a specific month
- Fix issues that were causing there to be missing profiles
- Split the imputation function into several sub functions

### Missing BA codes
- Adds a miscellaneous (MS) BA code based on the state. So if a plant is located in Rhode Island but has no BA, its BA code becomes RIMS
- For any plants that are also missing a state, assign a BA code of "NA"
- Each miscellaneous BA is assigned a three-digit ba_number based on the state FIPS code, and starting with 9. So for RI, with FIPS code 44, the number is 944.

### Other
- Adds a user warning to `load_data.ba_timezone()` to alert the user if a timezone is not specified for a BA

# Previous Fixes in this branch (already pulled in #92)

### Improves BA coverage (#66)
- adds additional BAs based on FERC data (#66)
- wherever the ba_name, activation_date, or retirement_date reported in FERC differs from that reported by EIA, we keep both values.
- We do not yet identify time zones for all of the BAs that only exist in FERC. We expect to add these on an ad-hoc basis as needed (i.e. in a year where a plant is assigned to one of these bas). We have added a `UserWarning` to `load_data.ba_timezone()` to alert the user if a timezone needs to be added.

### Addresses plants without BA code (#78)
- Adds BA entries for Alaska, Hawaii and Puerto Rico without an assigned BA. We use AKMS, HIMS, and PRMS as the codes in following with the eGRID subregion codes that are already used for these plants. 
- When creating the static plant attribute table, we now assign these BA codes to any plants located in these states that are missing a ba_code

### Other
- creates synthetic plant id for plant data that is aggregated at the ba-fuel level. Uses a static three-digit numerical code that is now defined in the updated `ba_reference.csv`, and a static two-digit numerical code for each fuel category that is defined in a dictionary in `impute_hourly_profiles.get_synthetic_plant_id_from_ba_fuel()`. The synthetic id number is in the format 9BBBFF where BBB is the three digit BA number and FF is the two-digit fuel number