### PR TITLE
Integrate 930 into pipeline

### DIFF
--- a/config/gridemissions.json
+++ b/config/gridemissions.json
@@ -1,0 +1,6 @@
+{
+    "DATA_PATH": "../data/downloads/eia930/",
+    "TMP_PATH": "../data/downloads/eia930/",
+    "APEN_PATH": "../data/downloads/eia930/",
+    "EIA_API_KEY": ""
+}

--- a/environment.yml
+++ b/environment.yml
@@ -23,6 +23,8 @@ dependencies:
   - statsmodels
   - tabulate
 
+  - cvxpy # used by gridemissions
+
 
   - setuptools # used for pudl
   - geopandas # used for pudl

--- a/src/data_pipeline.py
+++ b/src/data_pipeline.py
@@ -176,8 +176,10 @@ def main():
     ]
     download_data.download_egrid_files(egrid_files_to_download)
     # EIA-930
-    download_data.download_eia930_data(years_to_download=[year])
+    # for `small` run, we'll only clean 1 week, so need chalander file for making profiles
     download_data.download_chalendar_files()
+    # We use balance files for imputing missing hourly profiles. TODO use cleaned instead?
+    download_data.download_eia930_data(years_to_download=[year])
     # Power Sector Data Crosswalk
     # NOTE: Check for new releases at https://github.com/USEPA/camd-eia-crosswalk
     download_data.download_epa_psdc(
@@ -266,13 +268,13 @@ def main():
 
     # 9. Clean and Reconcile EIA-930 data
     print("Cleaning EIA-930 data")
-    # TODO
-    # Load raw EIA-930 data, fix timestamp issues, perform physics-based reconciliation
-    # Currently implemented in `notebooks/930_lag` and the `gridemissions` repository
-    # Output: `data/outputs/EBA_adjusted_elec.csv`
+    # Scrapes and cleans data in data/downloads, outputs cleaned file at EBA_elec.csv
+    eia930.scrape_and_clean_930(year, rescrape=True, small=small)
+    # If running small, we didn't clean the whole year, so need to use the Chalender file to build residual profiles. 
+    clean_930_file = "../data/downloads/eia930/chalendar/EBA_elec.csv" if small else "../data/downloads/eia930/EBA_elec.csv"
     eia930_data = eia930.load_chalendar_for_pipeline(
-        "../data/downloads/eia930/chalendar/EBA_adjusted_elec.csv", year=year
-    )  # For now, load data in form it will eventually be in
+        clean_930_file, year=year
+    )  
 
     # 10. Calculate Residual Net Generation Profile
     print("Calculating residual net generation profiles from EIA-930")
@@ -337,7 +339,7 @@ def main():
 
     # 13. Calculate consumption-based emissions and write carbon accounting results
     hourly_consumed_calc = consumed.HourlyBaDataEmissionsCalc(
-        "../data/downloads/eia930/chalendar/EBA_adjusted_elec.csv",
+        clean_930_file,
         small=args.small,
         path_prefix=path_prefix,
     )

--- a/src/download_data.py
+++ b/src/download_data.py
@@ -93,11 +93,7 @@ def download_chalendar_files():
     TODO: download functions share a lot of code, could refactor
     """
     # if there is not yet a directory for egrid, make it
-    if not os.path.exists("../data/downloads/eia930"):
-        os.mkdir("../data/downloads/eia930")
-    # if there is not a directory for chalendar-formatted files, make it
-    if not os.path.exists("../data/downloads/eia930/chalendar"):
-        os.mkdir("../data/downloads/eia930/chalendar")
+    os.makedirs("../data/downloads/eia930/chalendar", exist_ok=True)
 
     # download the cleaned and raw files
     urls = [

--- a/src/impute_hourly_profiles.py
+++ b/src/impute_hourly_profiles.py
@@ -3,6 +3,22 @@ from src.column_checks import apply_dtypes
 import pandas as pd
 import numpy as np
 
+# specify the ba numbers with leading zeros
+FUEL_NUMBERS = {
+    "biomass": "01",
+    "coal": "02",
+    "geothermal": "03",
+    "hydro": "04",
+    "natural_gas": "05",
+    "nuclear": "06",
+    "other": "07",
+    "petroleum": "08",
+    "solar": "09",
+    "storage": "10",
+    "waste": "11",
+    "wind": "12",
+}
+
 
 def aggregate_for_residual(
     data,
@@ -76,7 +92,7 @@ def calculate_residual(cems, eia930_data, plant_attributes, year: int):
         combined_data["datetime_local"].apply(lambda x: x.year) == year
     ]
 
-    # if there is no cems data for a ba-fuel, replace missing values with zero 
+    # if there is no cems data for a ba-fuel, replace missing values with zero
     combined_data["net_generation_mwh"] = combined_data["net_generation_mwh"].fillna(0)
 
     # Find scaling factor
@@ -263,7 +279,8 @@ def impute_missing_hourly_profiles(
     print("Summary of methods used to estimate missing hourly profiles:")
     print(
         hourly_profiles[["ba_code", "fuel_category", "report_date", "profile_method"]]
-        .drop_duplicates().drop(columns=['ba_code'])
+        .drop_duplicates()
+        .drop(columns=["ba_code"])
         .pivot_table(index="fuel_category", columns="profile_method", aggfunc="count")
         .fillna(0)
         .astype(int)
@@ -428,27 +445,11 @@ def get_synthetic_plant_id_from_ba_fuel(df):
     # convert to a dictionary
     ba_numbers = dict(zip(ba_numbers["ba_code"], ba_numbers["ba_number"]))
 
-    # specify the ba numbers with leading zeros
-    fuel_numbers = {
-        "biomass": "01",
-        "coal": "02",
-        "geothermal": "03",
-        "hydro": "04",
-        "natural_gas": "05",
-        "nuclear": "06",
-        "other": "07",
-        "petroleum": "08",
-        "solar": "09",
-        "storage": "10",
-        "waste": "11",
-        "wind": "12",
-    }
-
     # make sure the ba codes are strings
     df["ba_code"] = df["ba_code"].astype(str)
     # create a new column with the synthetic plant ids
     df["plant_id_eia"] = df.apply(
-        lambda row: f"9{ba_numbers[row['ba_code']]}{fuel_numbers[row['fuel_category']]}",
+        lambda row: f"9{ba_numbers[row['ba_code']]}{FUEL_NUMBERS[row['fuel_category']]}",
         axis=1,
     )
     # convert to an int32 column


### PR DESCRIPTION
Instead of using a hand-imported file for cleaned 930 data, call `gridemissions` (https://github.com/jdechalendar/gridemissions) directly from `data_pipeline.py`. Closes #19 

Note: `impute_missing_hourly_profiles` still uses balance files, not physics-cleaned files, we should switch this over (new issue #104)

For `--small`, there are two time consuming parts of 930 cleaning: 1) downloading all the series from the EIA API and 2) cleaning a full year of data using physics-based cleaning. So for `--small`, we only download two series, then clean a week of Chalendar data. 

In later parts of the pipeline, we use cleaned Chalendar data downloaded from https://gridemissions.jdechalendar.su.domains/#/code, which may be stale but is much faster than cleaning the data for every `--small` run. 

Closes #19 