### PR TITLE
fix gross to net method

### DIFF
--- a/notebooks/data_validation.ipynb
+++ b/notebooks/data_validation.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,7 +29,9 @@
     "# import local modules\n",
     "import src.load_data as load_data\n",
     "from src.data_cleaning import assign_ba_code_to_plant\n",
-    "import src.validation as validation"
+    "import src.validation as validation\n",
+    "\n",
+    "from src.column_checks import get_dtypes, apply_dtypes"
    ]
   },
   {
@@ -179,6 +181,418 @@
    "metadata": {},
    "source": [
     "# Data Quality Metrics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Evalutate data source mismatch"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "year = 2020\n",
+    "cems = pd.read_csv(f'../data/outputs/{year}/cems_{year}.csv', dtype=get_dtypes())\n",
+    "partial_cems_scaled = pd.read_csv(f'../data/outputs/{year}/partial_cems_scaled_{year}.csv', dtype=get_dtypes())\n",
+    "eia923_allocated = pd.read_csv(f'../data/outputs/{year}/eia923_allocated_{year}.csv', dtype=get_dtypes())\n",
+    "\n",
+    "plant_attributes = pd.read_csv(f\"../data/outputs/{year}/plant_static_attributes_{year}.csv\")\n",
+    "eia923_allocated = eia923_allocated.merge(plant_attributes, how=\"left\", on=\"plant_id_eia\")\n",
+    "cems = cems.merge(plant_attributes, how=\"left\", on=\"plant_id_eia\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "partial_cems_scaled = partial_cems_scaled.merge(plant_attributes, how=\"left\", on=\"plant_id_eia\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ba = \"CISO\"\n",
+    "fuel = \"natural_gas\"\n",
+    "test_eia = eia923_allocated[(eia923_allocated[\"ba_code\"] == ba) & (eia923_allocated[\"fuel_category\"] == fuel)]\n",
+    "test_cems = cems[(cems[\"ba_code\"] == ba) & (cems[\"fuel_category\"] == fuel)]\n",
+    "test_pc = partial_cems_scaled[(partial_cems_scaled[\"ba_code\"] == ba) & (partial_cems_scaled[\"fuel_category\"] == fuel)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "hourly_data_source\n",
+       "cems            55542242.5\n",
+       "eia             20288382.6\n",
+       "partial_cems       66089.0\n",
+       "Name: net_generation_mwh, dtype: float64"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test_eia.groupby('hourly_data_source').sum()['net_generation_mwh']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "gross_generation_mwh    5.907727e+07\n",
+       "net_generation_mwh      4.246262e+07\n",
+       "dtype: float64"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test_cems[[\"gross_generation_mwh\",'net_generation_mwh']].sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "net_generation_mwh    51859.426708\n",
+       "dtype: float64"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test_pc[['net_generation_mwh']].sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_pc = test_pc.drop(columns='source')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_cems = test_cems.drop(columns='source')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "partial_cems_subplant_months = test_pc[\n",
+    "    [\"plant_id_eia\", \"subplant_id\", \"report_date\"]\n",
+    "].drop_duplicates()\n",
+    "filtered_cems = test_cems.merge(\n",
+    "    partial_cems_subplant_months,\n",
+    "    how=\"outer\",\n",
+    "    on=[\"plant_id_eia\", \"subplant_id\", \"report_date\"],\n",
+    "    indicator=\"source\",\n",
+    ")\n",
+    "\n",
+    "filtered_cems = filtered_cems[filtered_cems[\"source\"] == \"left_only\"].drop(\n",
+    "    columns=[\"source\"]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "gross_generation_mwh    5.902732e+07\n",
+       "net_generation_mwh      4.243357e+07\n",
+       "dtype: float64"
+      ]
+     },
+     "execution_count": 47,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "filtered_cems[[\"gross_generation_mwh\",'net_generation_mwh']].sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>plant_id_eia</th>\n",
+       "      <th>subplant_id</th>\n",
+       "      <th>source</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>260</td>\n",
+       "      <td>2</td>\n",
+       "      <td>both</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>260</td>\n",
+       "      <td>3</td>\n",
+       "      <td>both</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>315</td>\n",
+       "      <td>2</td>\n",
+       "      <td>both</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>315</td>\n",
+       "      <td>4</td>\n",
+       "      <td>both</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>335</td>\n",
+       "      <td>1</td>\n",
+       "      <td>both</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>138</th>\n",
+       "      <td>7449</td>\n",
+       "      <td>0</td>\n",
+       "      <td>both</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>139</th>\n",
+       "      <td>60698</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>both</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>140</th>\n",
+       "      <td>315</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>right_only</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>141</th>\n",
+       "      <td>335</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>right_only</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>142</th>\n",
+       "      <td>10294</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>right_only</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>143 rows × 3 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     plant_id_eia  subplant_id      source\n",
+       "0             260            2        both\n",
+       "1             260            3        both\n",
+       "2             315            2        both\n",
+       "3             315            4        both\n",
+       "4             335            1        both\n",
+       "..            ...          ...         ...\n",
+       "138          7449            0        both\n",
+       "139         60698         <NA>        both\n",
+       "140           315         <NA>  right_only\n",
+       "141           335         <NA>  right_only\n",
+       "142         10294         <NA>  right_only\n",
+       "\n",
+       "[143 rows x 3 columns]"
+      ]
+     },
+     "execution_count": 56,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "subplants_ided_as_cems = test_eia.loc[test_eia[\"hourly_data_source\"] == 'cems', [\"plant_id_eia\",\"subplant_id\"]].drop_duplicates()\n",
+    "subplants_in_cems = filtered_cems[[\"plant_id_eia\",\"subplant_id\"]].drop_duplicates()\n",
+    "cems_overlap = subplants_ided_as_cems.merge(subplants_in_cems, how=\"outer\", on=[\"plant_id_eia\",\"subplant_id\"], indicator=\"source\")\n",
+    "cems_overlap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>plant_id_eia</th>\n",
+       "      <th>subplant_id</th>\n",
+       "      <th>source</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>55295</td>\n",
+       "      <td>0</td>\n",
+       "      <td>both</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>55748</td>\n",
+       "      <td>0</td>\n",
+       "      <td>left_only</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>56026</td>\n",
+       "      <td>0</td>\n",
+       "      <td>both</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>55333</td>\n",
+       "      <td>0</td>\n",
+       "      <td>both</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>55393</td>\n",
+       "      <td>0</td>\n",
+       "      <td>both</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   plant_id_eia  subplant_id     source\n",
+       "0         55295            0       both\n",
+       "1         55748            0  left_only\n",
+       "2         56026            0       both\n",
+       "3         55333            0       both\n",
+       "4         55393            0       both"
+      ]
+     },
+     "execution_count": 57,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "subplants_ided_as_pc = test_eia.loc[test_eia[\"hourly_data_source\"] == 'partial_cems', [\"plant_id_eia\",\"subplant_id\"]].drop_duplicates()\n",
+    "subplants_in_pc = test_pc[[\"plant_id_eia\",\"subplant_id\"]].drop_duplicates()\n",
+    "pc_overlap = subplants_ided_as_pc.merge(subplants_in_pc, how=\"outer\", on=[\"plant_id_eia\",\"subplant_id\"], indicator=\"source\")\n",
+    "pc_overlap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "249125.05209945003"
+      ]
+     },
+     "execution_count": 61,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test_cems.loc[test_cems['plant_id_eia'] == 55748, \"net_generation_mwh\"].sum()"
    ]
   },
   {

--- a/notebooks/test_data_pipeline.ipynb
+++ b/notebooks/test_data_pipeline.ipynb
@@ -31,7 +31,6 @@
     "\n",
     "# import local modules\n",
     "import src.data_cleaning as data_cleaning\n",
-    "import src.gross_to_net_generation as gross_to_net_generation\n",
     "import src.load_data as load_data\n",
     "import src.impute_hourly_profiles as impute_hourly_profiles\n",
     "import src.eia930 as eia930\n",
@@ -41,19 +40,56 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Run the Pipeline"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
+    "%cd ../src\n",
+    "%run data_pipeline --year 2020"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%cd ../src\n",
+    "%run data_pipeline --small SMALL --year 2020"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Functions for loading intermediate outputs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
     "# load data from csv\n",
     "year = 2020\n",
-    "path_prefix = 'small/'\n",
+    "path_prefix = ''\n",
+    "\n",
     "cems = pd.read_csv(f'../data/outputs/{path_prefix}cems_{year}.csv', dtype=get_dtypes(), parse_dates=['datetime_utc', 'report_date'])\n",
     "partial_cems_scaled = pd.read_csv(f'../data/outputs/{path_prefix}partial_cems_scaled_{year}.csv', dtype=get_dtypes(), parse_dates=['datetime_utc', 'report_date'])\n",
     "eia923_allocated = pd.read_csv(f'../data/outputs/{path_prefix}eia923_allocated_{year}.csv', dtype=get_dtypes(), parse_dates=['report_date'])\n",
     "plant_attributes = pd.read_csv(f\"../data/outputs/{path_prefix}plant_static_attributes_{year}.csv\")\n",
-    "primary_fuel_table = plant_attributes.drop_duplicates(subset=\"plant_id_eia\")[[\"plant_id_eia\", \"plant_primary_fuel\"]]"
+    "primary_fuel_table = plant_attributes.drop_duplicates(subset=\"plant_id_eia\")[[\"plant_id_eia\", \"plant_primary_fuel\"]]\n",
+    "residual_profiles = pd.read_csv(f\"../data/outputs/{path_prefix}residual_profiles_{year}.csv\")"
    ]
   },
   {
@@ -93,87 +129,6 @@
     "    \"validation_metrics/\",\n",
     "    path_prefix,\n",
     ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "combined_plant_data = pd.read_csv(f\"../data/results/{path_prefix}plant_data/hourly_plant_data.csv\", )"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plant_attributes = pd.read_csv(f\"../data/outputs/{path_prefix}plant_static_attributes_{year}.csv\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "combined_plant_data"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(\"Aggregating to BA-fuel\")\n",
-    "# 12. Aggregate CEMS data to BA-fuel and write power sector results\n",
-    "ba_fuel_data = data_cleaning.aggregate_plant_data_to_ba_fuel(\n",
-    "    combined_plant_data, plant_attributes\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "data_columns = [\n",
-    "    \"net_generation_mwh\",\n",
-    "    \"fuel_consumed_mmbtu\",\n",
-    "    \"fuel_consumed_for_electricity_mmbtu\",\n",
-    "    \"co2_mass_lb\",\n",
-    "    \"ch4_mass_lb\",\n",
-    "    \"n2o_mass_lb\",\n",
-    "    \"nox_mass_lb\",\n",
-    "    \"so2_mass_lb\",\n",
-    "    \"co2_mass_lb_for_electricity\",\n",
-    "    \"ch4_mass_lb_for_electricity\",\n",
-    "    \"n2o_mass_lb_for_electricity\",\n",
-    "    \"nox_mass_lb_for_electricity\",\n",
-    "    \"so2_mass_lb_for_electricity\",\n",
-    "    \"co2_mass_lb_adjusted\",\n",
-    "    \"ch4_mass_lb_adjusted\",\n",
-    "    \"n2o_mass_lb_adjusted\",\n",
-    "    \"nox_mass_lb_adjusted\",\n",
-    "    \"so2_mass_lb_adjusted\",\n",
-    "]\n",
-    "\n",
-    "ba_fuel_data = combined_plant_data.merge(\n",
-    "    plant_attributes, how=\"left\", on=[\"plant_id_eia\"]\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ba_fuel_data"
    ]
   },
   {
@@ -586,33 +541,6 @@
    "outputs": [],
    "source": [
     "shaped_eia_data[(shaped_eia_data['ba_code'] == 'SWPP') & (shaped_eia_data['fuel_category'] == 'solar') & (hourly_profiles['report_date'] == '2020-4-01')]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Run the pipeline"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%cd ../src\n",
-    "%run data_pipeline --year 2020"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%cd ../src\n",
-    "%run data_pipeline --small SMALL --year 2020"
    ]
   },
   {

--- a/notebooks/test_gross_to_net.ipynb
+++ b/notebooks/test_gross_to_net.ipynb
@@ -1,35 +1,10 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Perform a regression on gross and net generation data from multiple years\n",
-    "\n",
-    "We want to run a regression on multiple years of CEMS and EIA data. We can do by month, and also on an annual basis\n",
-    "\n",
-    "We should probably aggregate by plant-prime mover-environmental equipment.\n",
-    "\n",
-    "Steps:\n",
-    "1. Load and clean gross generation data for multiple years\n",
-    "2. Load and distribute net generation data from EIA for multiple years\n",
-    "3. Aggregate / map data from both source"
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/milo.knowles/.envs/hourly-egrid-pFG5h226/lib/python3.10/site-packages/geopandas/_compat.py:111: UserWarning: The Shapely GEOS version (3.10.2-CAPI-1.16.0) is incompatible with the GEOS version PyGEOS was compiled with (3.10.1-CAPI-1.16.0). Conversions between both will be slow.\n",
-      "  warnings.warn(\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Tell python where to look for modules. \n",
     "# Depending on how your jupyter handles working directories, this may not be needed.\n",
@@ -57,12 +32,328 @@
     "# local packages\n",
     "import src.data_cleaning as data_cleaning\n",
     "from src.gross_to_net_generation import *\n",
-    "import src.load_data as load_data\n"
+    "import src.load_data as load_data\n",
+    "\n",
+    "from src.column_checks import get_dtypes\n",
+    "\n",
+    "year = 2020\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Test updated approach to GTN conversion"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load data from csv\n",
+    "year = 2020\n",
+    "path_prefix = 'small/'\n",
+    "cems = pd.read_csv(f'../data/outputs/{path_prefix}cems_{year}.csv', dtype=get_dtypes(), parse_dates=['report_date'])\n",
+    "eia923_allocated = pd.read_csv(f'../data/outputs/{path_prefix}eia923_allocated_{year}.csv', dtype=get_dtypes(), parse_dates=['report_date'])\n",
+    "plant_attributes = pd.read_csv(f\"../data/outputs/{path_prefix}plant_static_attributes_{year}.csv\", dtype=get_dtypes())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems, gtn_conversions = data_cleaning.convert_gross_to_net_generation(cems, eia923_allocated, plant_attributes)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems.groupby(\"gtn_method\", dropna=False).count()['net_generation_mwh'] / len(cems)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems.groupby(\"gtn_method\", dropna=False).sum()['net_generation_mwh'] / cems[['net_generation_mwh']].sum().item()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# validate method\n",
+    "\n",
+    "# merge together monthly subplant totals from EIA and calculated from CEMS\n",
+    "eia_ng_by_subplant = eia923_allocated.groupby(['plant_id_eia',\"subplant_id\",\"report_date\"], dropna=False).sum(min_count=1)['net_generation_mwh'].reset_index().dropna(subset=\"net_generation_mwh\")\n",
+    "calculated_ng_by_subplant = cems.groupby(['plant_id_eia',\"subplant_id\",\"report_date\",\"gtn_method\"]).sum()['net_generation_mwh'].reset_index()\n",
+    "validated_ng = eia_ng_by_subplant.merge(calculated_ng_by_subplant, how=\"inner\", on=['plant_id_eia',\"subplant_id\",\"report_date\"], suffixes=(\"_eia\",\"_calc\"))\n",
+    "\n",
+    "validated_ng['squared_error'] = (validated_ng['net_generation_mwh_eia'] - validated_ng['net_generation_mwh_calc'])**2\n",
+    "validated_ng['pct_error'] = (validated_ng['net_generation_mwh_calc'] - validated_ng['net_generation_mwh_eia']) / validated_ng['net_generation_mwh_eia']\n",
+    "validated_ng['abs_pct_error'] = abs(validated_ng['pct_error'])\n",
+    "validated_ng = validated_ng.round(2)\n",
+    "validated_ng\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validated_ng[(validated_ng[\"pct_error\"] != 0) & (validated_ng[\"net_generation_mwh_calc\"] != 0) & (validated_ng[\"net_generation_mwh_eia\"] != 0)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gtn_conversions[(gtn_conversions['plant_id_eia'] == 3) & (gtn_conversions['subplant_id'] == 4)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems[(cems['plant_id_eia'] == 60) & (cems['subplant_id'] == 0) & (cems['report_date'] == \"2020-03-01\")]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_to_graph = cems[cems['plant_id_eia'] == 2953].groupby([\"plant_id_eia\",\"datetime_utc\"]).sum()[[\"gross_generation_mwh\",\"net_generation_mwh\"]].reset_index()\n",
+    "px.line(data_to_graph, x=\"datetime_utc\", y=[\"gross_generation_mwh\",\"net_generation_mwh\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Refine Assumption for assumed gross to net generation ratio"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load data from csv\n",
+    "year = 2020\n",
+    "path_prefix = ''\n",
+    "cems = pd.read_csv(f'../data/outputs/{path_prefix}cems_{year}.csv', dtype=get_dtypes(), parse_dates=['report_date'])\n",
+    "plant_attributes = pd.read_csv(f\"../data/outputs/{path_prefix}plant_static_attributes_{year}.csv\", dtype=get_dtypes())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eia923_allocated = pd.read_csv(f'../data/outputs/{path_prefix}eia923_allocated_{year}.csv', dtype=get_dtypes(), parse_dates=['report_date'])\n",
+    "eia_ng_by_plant = eia923_allocated.groupby(['plant_id_eia',\"subplant_id\",\"report_date\"], dropna=False).sum()['net_generation_mwh'].reset_index()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# remove net generation columns from cems\n",
+    "cems = cems.drop(columns=[\"net_generation_mwh\",\"gtn_method\"])\n",
+    "cems = data_cleaning.convert_gross_to_net_generation(cems, plant_attributes, year, method_order=[\n",
+    "        \"subplant_ratio\",\n",
+    "        \"subplant_regression\",\n",
+    "        \"plant_ratio\",\n",
+    "        \"plant_regression\",\n",
+    "    ])\n",
+    "\n",
+    "cems.groupby(\"gtn_method\").sum()[\"net_generation_mwh\"] / cems[['net_generation_mwh']].sum().item()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems.groupby(\"gtn_method\").sum()[\"net_generation_mwh\"] / cems[['net_generation_mwh']].sum().item()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "calculated_ng_by_plant = cems.groupby(['plant_id_eia',\"subplant_id\",\"report_date\",'gtn_method'], dropna=False).sum()['net_generation_mwh'].reset_index()\n",
+    "validated_ng = eia_ng_by_plant.merge(calculated_ng_by_plant, how=\"inner\", on=['plant_id_eia',\"report_date\"], suffixes=(\"_eia\",\"_calc\"))\n",
+    "validated_ng"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "validated_ng['squared_error'] = (validated_ng['net_generation_mwh_eia'] - validated_ng['net_generation_mwh_calc'])**2\n",
+    "validated_ng['pct_error'] = (validated_ng['net_generation_mwh_calc'] - validated_ng['net_generation_mwh_eia']) / validated_ng['net_generation_mwh_eia']\n",
+    "validated_ng['abs_pct_error'] = abs(validated_ng['pct_error'])\n",
+    "validated_ng = validated_ng.round(2)\n",
+    "validated_ng[validated_ng['net_generation_mwh_eia'] != 0].mean().round(2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validated_ng[validated_ng['net_generation_mwh_eia'] != 0].groupby('gtn_method', dropna=False).mean()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# remove net generation columns from cems\n",
+    "#cems = cems.drop(columns=[\"net_generation_mwh\",\"gtn_method\"])\n",
+    "cems = data_cleaning.convert_gross_to_net_generation(cems, plant_attributes, year, method_order=[\n",
+    "        \"subplant_ratio\",\n",
+    "        \"subplant_regression\",\n",
+    "        \"plant_ratio\",\n",
+    "        \"plant_regression\",\n",
+    "    ])\n",
+    "\n",
+    "cems.groupby(\"gtn_method\").sum()[\"net_generation_mwh\"] / cems[['net_generation_mwh']].sum().item()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validated_ng = eia_ng_by_plant.merge(calculated_ng_by_plant, how=\"inner\", on='plant_id_eia', suffixes=(\"_eia\",\"_calc\"))\n",
+    "validated_ng['squared_error'] = (validated_ng['net_generation_mwh_eia'] - validated_ng['net_generation_mwh_calc'])**2\n",
+    "validated_ng['pct_error'] = (validated_ng['net_generation_mwh_calc'] - validated_ng['net_generation_mwh_eia']) / validated_ng['net_generation_mwh_eia']\n",
+    "validated_ng['abs_pct_error'] = abs(validated_ng['pct_error'])\n",
+    "validated_ng = validated_ng.round(2)\n",
+    "validated_ng[validated_ng['net_generation_mwh_eia'] != 0].mean().round(2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# remove net generation columns from cems\n",
+    "cems = cems.drop(columns=[\"net_generation_mwh\",\"gtn_method\"])\n",
+    "cems = data_cleaning.convert_gross_to_net_generation(cems, plant_attributes, year, method_order=[\n",
+    "        \"plant_ratio\",\n",
+    "        \"plant_regression\",\n",
+    "        \"subplant_ratio\",\n",
+    "        \"subplant_regression\",\n",
+    "    ])\n",
+    "\n",
+    "calculated_ng_by_plant = cems.groupby(['plant_id_eia']).sum()['net_generation_mwh'].reset_index()\n",
+    "\n",
+    "cems.groupby(\"gtn_method\").sum()[\"net_generation_mwh\"] / cems[['net_generation_mwh']].sum().item()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validated_ng = eia_ng_by_plant.merge(calculated_ng_by_plant, how=\"inner\", on='plant_id_eia', suffixes=(\"_eia\",\"_calc\"))\n",
+    "validated_ng['squared_error'] = (validated_ng['net_generation_mwh_eia'] - validated_ng['net_generation_mwh_calc'])**2\n",
+    "validated_ng['pct_error'] = (validated_ng['net_generation_mwh_calc'] - validated_ng['net_generation_mwh_eia']) / validated_ng['net_generation_mwh_eia']\n",
+    "validated_ng['abs_pct_error'] = abs(validated_ng['pct_error'])\n",
+    "validated_ng = validated_ng.round(2)\n",
+    "validated_ng[validated_ng['net_generation_mwh_eia'] != 0].mean().round(2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# remove net generation columns from cems\n",
+    "cems = cems.drop(columns=[\"net_generation_mwh\",\"gtn_method\"])\n",
+    "cems = data_cleaning.convert_gross_to_net_generation(cems, plant_attributes, year, method_order=[\n",
+    "        \"subplant_ratio\",\n",
+    "        \"plant_ratio\",\n",
+    "        \"subplant_regression\",\n",
+    "        \"plant_regression\",\n",
+    "    ])\n",
+    "\n",
+    "calculated_ng_by_plant = cems.groupby(['plant_id_eia']).sum()['net_generation_mwh'].reset_index()\n",
+    "\n",
+    "cems.groupby(\"gtn_method\").sum()[\"net_generation_mwh\"] / cems[['net_generation_mwh']].sum().item()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validated_ng = eia_ng_by_plant.merge(calculated_ng_by_plant, how=\"inner\", on='plant_id_eia', suffixes=(\"_eia\",\"_calc\"))\n",
+    "validated_ng['squared_error'] = (validated_ng['net_generation_mwh_eia'] - validated_ng['net_generation_mwh_calc'])**2\n",
+    "validated_ng['pct_error'] = (validated_ng['net_generation_mwh_calc'] - validated_ng['net_generation_mwh_eia']) / validated_ng['net_generation_mwh_eia']\n",
+    "validated_ng['abs_pct_error'] = abs(validated_ng['pct_error'])\n",
+    "validated_ng = validated_ng.round(2)\n",
+    "validated_ng[validated_ng['net_generation_mwh_eia'] != 0].mean().round(2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Perform a regression on gross and net generation data from multiple years\n",
+    "\n",
+    "We want to run a regression on multiple years of CEMS and EIA data. We can do by month, and also on an annual basis\n",
+    "\n",
+    "We should probably aggregate by plant-prime mover-environmental equipment.\n",
+    "\n",
+    "Steps:\n",
+    "1. Load and clean gross generation data for multiple years\n",
+    "2. Load and distribute net generation data from EIA for multiple years\n",
+    "3. Aggregate / map data from both source"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -77,318 +368,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "loading 2001 CEMS data\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/milo.knowles/.envs/hourly-egrid-pFG5h226/lib/python3.10/site-packages/pandas/core/arrays/datetimes.py:1162: UserWarning: Converting to PeriodArray/Index representation will drop timezone information.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "loading 2002 CEMS data\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/milo.knowles/.envs/hourly-egrid-pFG5h226/lib/python3.10/site-packages/pandas/core/arrays/datetimes.py:1162: UserWarning: Converting to PeriodArray/Index representation will drop timezone information.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "loading 2003 CEMS data\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/milo.knowles/.envs/hourly-egrid-pFG5h226/lib/python3.10/site-packages/pandas/core/arrays/datetimes.py:1162: UserWarning: Converting to PeriodArray/Index representation will drop timezone information.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "loading 2004 CEMS data\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/milo.knowles/.envs/hourly-egrid-pFG5h226/lib/python3.10/site-packages/pandas/core/arrays/datetimes.py:1162: UserWarning: Converting to PeriodArray/Index representation will drop timezone information.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "loading 2005 CEMS data\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/milo.knowles/.envs/hourly-egrid-pFG5h226/lib/python3.10/site-packages/pandas/core/arrays/datetimes.py:1162: UserWarning: Converting to PeriodArray/Index representation will drop timezone information.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "loading 2006 CEMS data\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/milo.knowles/.envs/hourly-egrid-pFG5h226/lib/python3.10/site-packages/pandas/core/arrays/datetimes.py:1162: UserWarning: Converting to PeriodArray/Index representation will drop timezone information.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "loading 2007 CEMS data\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/milo.knowles/.envs/hourly-egrid-pFG5h226/lib/python3.10/site-packages/pandas/core/arrays/datetimes.py:1162: UserWarning: Converting to PeriodArray/Index representation will drop timezone information.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "loading 2008 CEMS data\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/milo.knowles/.envs/hourly-egrid-pFG5h226/lib/python3.10/site-packages/pandas/core/arrays/datetimes.py:1162: UserWarning: Converting to PeriodArray/Index representation will drop timezone information.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "loading 2009 CEMS data\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/milo.knowles/.envs/hourly-egrid-pFG5h226/lib/python3.10/site-packages/pandas/core/arrays/datetimes.py:1162: UserWarning: Converting to PeriodArray/Index representation will drop timezone information.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "loading 2010 CEMS data\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/milo.knowles/.envs/hourly-egrid-pFG5h226/lib/python3.10/site-packages/pandas/core/arrays/datetimes.py:1162: UserWarning: Converting to PeriodArray/Index representation will drop timezone information.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "loading 2011 CEMS data\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/milo.knowles/.envs/hourly-egrid-pFG5h226/lib/python3.10/site-packages/pandas/core/arrays/datetimes.py:1162: UserWarning: Converting to PeriodArray/Index representation will drop timezone information.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "loading 2012 CEMS data\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/milo.knowles/.envs/hourly-egrid-pFG5h226/lib/python3.10/site-packages/pandas/core/arrays/datetimes.py:1162: UserWarning: Converting to PeriodArray/Index representation will drop timezone information.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "loading 2013 CEMS data\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/milo.knowles/.envs/hourly-egrid-pFG5h226/lib/python3.10/site-packages/pandas/core/arrays/datetimes.py:1162: UserWarning: Converting to PeriodArray/Index representation will drop timezone information.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "loading 2014 CEMS data\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/milo.knowles/.envs/hourly-egrid-pFG5h226/lib/python3.10/site-packages/pandas/core/arrays/datetimes.py:1162: UserWarning: Converting to PeriodArray/Index representation will drop timezone information.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "loading 2015 CEMS data\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/milo.knowles/.envs/hourly-egrid-pFG5h226/lib/python3.10/site-packages/pandas/core/arrays/datetimes.py:1162: UserWarning: Converting to PeriodArray/Index representation will drop timezone information.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "loading 2016 CEMS data\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/milo.knowles/.envs/hourly-egrid-pFG5h226/lib/python3.10/site-packages/pandas/core/arrays/datetimes.py:1162: UserWarning: Converting to PeriodArray/Index representation will drop timezone information.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "loading 2017 CEMS data\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/milo.knowles/.envs/hourly-egrid-pFG5h226/lib/python3.10/site-packages/pandas/core/arrays/datetimes.py:1162: UserWarning: Converting to PeriodArray/Index representation will drop timezone information.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "loading 2018 CEMS data\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/milo.knowles/.envs/hourly-egrid-pFG5h226/lib/python3.10/site-packages/pandas/core/arrays/datetimes.py:1162: UserWarning: Converting to PeriodArray/Index representation will drop timezone information.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "loading 2019 CEMS data\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/milo.knowles/.envs/hourly-egrid-pFG5h226/lib/python3.10/site-packages/pandas/core/arrays/datetimes.py:1162: UserWarning: Converting to PeriodArray/Index representation will drop timezone information.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "loading 2020 CEMS data\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/milo.knowles/.envs/hourly-egrid-pFG5h226/lib/python3.10/site-packages/pandas/core/arrays/datetimes.py:1162: UserWarning: Converting to PeriodArray/Index representation will drop timezone information.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Allocating EIA-923 generation data\n",
-      "Creating subplant IDs\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# load 5 years of monthly data from CEMS and EIA-923\n",
     "cems_monthly, gen_fuel_allocated = load_monthly_gross_and_net_generation(\n",
@@ -404,189 +386,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>plant_id_eia</th>\n",
-       "      <th>subplant_id</th>\n",
-       "      <th>report_date</th>\n",
-       "      <th>gross_generation_mwh</th>\n",
-       "      <th>net_generation_mwh</th>\n",
-       "      <th>hours_in_month</th>\n",
-       "      <th>gross_generation_mw</th>\n",
-       "      <th>net_generation_mw</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>3</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>2019-03-01</td>\n",
-       "      <td>2128.5</td>\n",
-       "      <td>68.032782</td>\n",
-       "      <td>744</td>\n",
-       "      <td>2.860887</td>\n",
-       "      <td>0.091442</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>3</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>2019-05-01</td>\n",
-       "      <td>7656.0</td>\n",
-       "      <td>480.035503</td>\n",
-       "      <td>744</td>\n",
-       "      <td>10.290323</td>\n",
-       "      <td>0.645209</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>3</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>2019-07-01</td>\n",
-       "      <td>4859.0</td>\n",
-       "      <td>163.881712</td>\n",
-       "      <td>744</td>\n",
-       "      <td>6.530914</td>\n",
-       "      <td>0.220271</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>3</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>2019-09-01</td>\n",
-       "      <td>11188.0</td>\n",
-       "      <td>1232.974148</td>\n",
-       "      <td>720</td>\n",
-       "      <td>15.538889</td>\n",
-       "      <td>1.712464</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>3</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>2019-10-01</td>\n",
-       "      <td>3586.5</td>\n",
-       "      <td>81.273993</td>\n",
-       "      <td>744</td>\n",
-       "      <td>4.820565</td>\n",
-       "      <td>0.109239</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>72275</th>\n",
-       "      <td>61242</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>2019-05-01</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>744</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>72276</th>\n",
-       "      <td>61242</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>2020-09-01</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>3359.802500</td>\n",
-       "      <td>720</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>4.666392</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>72277</th>\n",
-       "      <td>61242</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>2020-10-01</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>2905.441500</td>\n",
-       "      <td>744</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>3.905163</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>72278</th>\n",
-       "      <td>61242</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>2020-11-01</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>2275.763500</td>\n",
-       "      <td>720</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>3.160783</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>72279</th>\n",
-       "      <td>61242</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>2020-12-01</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>2501.130000</td>\n",
-       "      <td>744</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>3.361734</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "<p>72280 rows × 8 columns</p>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "       plant_id_eia  subplant_id report_date  gross_generation_mwh  net_generation_mwh  hours_in_month  gross_generation_mw  net_generation_mw\n",
-       "0                 3          0.0  2019-03-01                2128.5           68.032782             744             2.860887           0.091442\n",
-       "1                 3          0.0  2019-05-01                7656.0          480.035503             744            10.290323           0.645209\n",
-       "2                 3          0.0  2019-07-01                4859.0          163.881712             744             6.530914           0.220271\n",
-       "3                 3          0.0  2019-09-01               11188.0         1232.974148             720            15.538889           1.712464\n",
-       "4                 3          0.0  2019-10-01                3586.5           81.273993             744             4.820565           0.109239\n",
-       "...             ...          ...         ...                   ...                 ...             ...                  ...                ...\n",
-       "72275         61242          1.0  2019-05-01                   NaN                 NaN             744                  NaN                NaN\n",
-       "72276         61242          1.0  2020-09-01                   NaN         3359.802500             720                  NaN           4.666392\n",
-       "72277         61242          1.0  2020-10-01                   NaN         2905.441500             744                  NaN           3.905163\n",
-       "72278         61242          1.0  2020-11-01                   NaN         2275.763500             720                  NaN           3.160783\n",
-       "72279         61242          1.0  2020-12-01                   NaN         2501.130000             744                  NaN           3.361734\n",
-       "\n",
-       "[72280 rows x 8 columns]"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "gen_data, plant_aggregation_columns = combine_gross_and_net_generation_data(\n",
     "    cems_monthly, gen_fuel_allocated, 'subplant'\n",
@@ -606,101 +408,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table class=\"simpletable\">\n",
-       "<caption>OLS Regression Results</caption>\n",
-       "<tr>\n",
-       "  <th>Dep. Variable:</th>    <td>net_generation_mw</td> <th>  R-squared (uncentered):</th>      <td>   1.000</td> \n",
-       "</tr>\n",
-       "<tr>\n",
-       "  <th>Model:</th>                   <td>OLS</td>        <th>  Adj. R-squared (uncentered):</th> <td>   1.000</td> \n",
-       "</tr>\n",
-       "<tr>\n",
-       "  <th>Method:</th>             <td>Least Squares</td>   <th>  F-statistic:       </th>          <td>1.776e+06</td>\n",
-       "</tr>\n",
-       "<tr>\n",
-       "  <th>Date:</th>             <td>Thu, 26 May 2022</td>  <th>  Prob (F-statistic):</th>          <td>1.77e-55</td> \n",
-       "</tr>\n",
-       "<tr>\n",
-       "  <th>Time:</th>                 <td>17:58:59</td>      <th>  Log-Likelihood:    </th>          <td> -51.245</td> \n",
-       "</tr>\n",
-       "<tr>\n",
-       "  <th>No. Observations:</th>      <td>    23</td>       <th>  AIC:               </th>          <td>   104.5</td> \n",
-       "</tr>\n",
-       "<tr>\n",
-       "  <th>Df Residuals:</th>          <td>    22</td>       <th>  BIC:               </th>          <td>   105.6</td> \n",
-       "</tr>\n",
-       "<tr>\n",
-       "  <th>Df Model:</th>              <td>     1</td>       <th>                     </th>              <td> </td>    \n",
-       "</tr>\n",
-       "<tr>\n",
-       "  <th>Covariance Type:</th>      <td>nonrobust</td>     <th>                     </th>              <td> </td>    \n",
-       "</tr>\n",
-       "</table>\n",
-       "<table class=\"simpletable\">\n",
-       "<tr>\n",
-       "           <td></td>              <th>coef</th>     <th>std err</th>      <th>t</th>      <th>P>|t|</th>  <th>[0.025</th>    <th>0.975]</th>  \n",
-       "</tr>\n",
-       "<tr>\n",
-       "  <th>gross_generation_mw</th> <td>    0.6590</td> <td>    0.000</td> <td> 1332.688</td> <td> 0.000</td> <td>    0.658</td> <td>    0.660</td>\n",
-       "</tr>\n",
-       "</table>\n",
-       "<table class=\"simpletable\">\n",
-       "<tr>\n",
-       "  <th>Omnibus:</th>       <td> 5.348</td> <th>  Durbin-Watson:     </th> <td>   1.389</td>\n",
-       "</tr>\n",
-       "<tr>\n",
-       "  <th>Prob(Omnibus):</th> <td> 0.069</td> <th>  Jarque-Bera (JB):  </th> <td>   3.246</td>\n",
-       "</tr>\n",
-       "<tr>\n",
-       "  <th>Skew:</th>          <td>-0.724</td> <th>  Prob(JB):          </th> <td>   0.197</td>\n",
-       "</tr>\n",
-       "<tr>\n",
-       "  <th>Kurtosis:</th>      <td> 4.137</td> <th>  Cond. No.          </th> <td>    1.00</td>\n",
-       "</tr>\n",
-       "</table><br/><br/>Notes:<br/>[1] R² is computed without centering (uncentered) since the model does not contain a constant.<br/>[2] Standard Errors assume that the covariance matrix of the errors is correctly specified."
-      ],
-      "text/plain": [
-       "<class 'statsmodels.iolib.summary.Summary'>\n",
-       "\"\"\"\n",
-       "                                 OLS Regression Results                                \n",
-       "=======================================================================================\n",
-       "Dep. Variable:      net_generation_mw   R-squared (uncentered):                   1.000\n",
-       "Model:                            OLS   Adj. R-squared (uncentered):              1.000\n",
-       "Method:                 Least Squares   F-statistic:                          1.776e+06\n",
-       "Date:                Thu, 26 May 2022   Prob (F-statistic):                    1.77e-55\n",
-       "Time:                        17:58:59   Log-Likelihood:                         -51.245\n",
-       "No. Observations:                  23   AIC:                                      104.5\n",
-       "Df Residuals:                      22   BIC:                                      105.6\n",
-       "Df Model:                           1                                                  \n",
-       "Covariance Type:            nonrobust                                                  \n",
-       "=======================================================================================\n",
-       "                          coef    std err          t      P>|t|      [0.025      0.975]\n",
-       "---------------------------------------------------------------------------------------\n",
-       "gross_generation_mw     0.6590      0.000   1332.688      0.000       0.658       0.660\n",
-       "==============================================================================\n",
-       "Omnibus:                        5.348   Durbin-Watson:                   1.389\n",
-       "Prob(Omnibus):                  0.069   Jarque-Bera (JB):                3.246\n",
-       "Skew:                          -0.724   Prob(JB):                        0.197\n",
-       "Kurtosis:                       4.137   Cond. No.                         1.00\n",
-       "==============================================================================\n",
-       "\n",
-       "Notes:\n",
-       "[1] R² is computed without centering (uncentered) since the model does not contain a constant.\n",
-       "[2] Standard Errors assume that the covariance matrix of the errors is correctly specified.\n",
-       "\"\"\""
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# test regression\n",
     "id = 3\n",
@@ -713,21 +423,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "gross_generation_mw    0.659006\n",
-       "dtype: float64"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "model.params"
    ]
@@ -898,21 +596,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'identify_subplants' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "Input \u001b[0;32mIn [5]\u001b[0m, in \u001b[0;36m<cell line: 1>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0m subplant_crosswalk \u001b[38;5;241m=\u001b[39m \u001b[43midentify_subplants\u001b[49m(start_year, end_year, gen_fuel_allocated, cems_monthly)\n\u001b[1;32m      2\u001b[0m \u001b[38;5;66;03m# export the crosswalk to csv\u001b[39;00m\n\u001b[1;32m      3\u001b[0m subplant_crosswalk\u001b[38;5;241m.\u001b[39mto_csv(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m../data/outputs/subplant_crosswalk.csv\u001b[39m\u001b[38;5;124m'\u001b[39m, index\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mFalse\u001b[39;00m)\n",
-      "\u001b[0;31mNameError\u001b[0m: name 'identify_subplants' is not defined"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "subplant_crosswalk = identify_subplants(start_year, end_year, gen_fuel_allocated, cems_monthly)\n",
     "# export the crosswalk to csv\n",
@@ -1487,7 +1173,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.1"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/src/column_checks.py
+++ b/src/column_checks.py
@@ -114,7 +114,7 @@ COLUMNS = {
         "state",
         "distribution_flag",
         "timezone",
-        "source",
+        "data_availability",
     },
     "residual_profiles_": {
         "ba_code",
@@ -181,6 +181,23 @@ COLUMNS = {
         "generated_n2o_rate_lb_per_mwh_adjusted",
         "generated_nox_rate_lb_per_mwh_adjusted",
         "generated_so2_rate_lb_per_mwh_adjusted",
+    },
+    "gross_to_net_conversions_": {
+        "plant_id_eia",
+        "subplant_id",
+        "report_date",
+        "gross_generation_mwh",
+        "net_generation_mwh",
+        "source",
+        "hours_in_month",
+        "monthly_subplant_ratio",
+        "hourly_shift_mw_monthly",
+        "annual_subplant_ratio",
+        "hourly_shift_mw_annual",
+        "monthly_plant_ratio",
+        "annual_plant_ratio",
+        "plant_primary_fuel",
+        "annual_fuel_ratio",
     },
 }
 

--- a/src/data_pipeline.py
+++ b/src/data_pipeline.py
@@ -184,14 +184,12 @@ def main():
         psdc_url="https://github.com/USEPA/camd-eia-crosswalk/releases/download/v0.2.1/epa_eia_crosswalk.csv"
     )
 
-    # 2. Identify subplants and gross-to net ratios
+    # 2. Identify subplants
     # GTN ratios are saved for reloading, as this is computationally intensive
-    if not os.path.isdir("../data/outputs/gross_to_net/"):
+    if not os.path.exists(f"../data/outputs/{year}/subplant_crosswalk.csv"):
         print("Generating subplant IDs and gross to net calcuations")
         number_of_years = args.gtn_years
-        gross_to_net_generation.identify_subplants_and_gtn_conversions(
-            year, number_of_years
-        )
+        gross_to_net_generation.identify_subplants(year, number_of_years)
 
     # 3. Clean EIA-923 Generation and Fuel Data at the Monthly Level
     print("Cleaning EIA-923 data")
@@ -209,17 +207,35 @@ def main():
     print("Cleaning CEMS data")
     cems = data_cleaning.clean_cems(year, args.small)
 
-    # 5. Convert CEMS Hourly Gross Generation to Hourly Net Generation
-    print("Converting CEMS gross generation to net generation")
-    cems = data_cleaning.convert_gross_to_net_generation(cems)
+    # 5. Assign static characteristics to CEMS and EIA data to aid in aggregation
+    plant_attributes = data_cleaning.create_plant_attributes_table(
+        cems, eia923_allocated, year, primary_fuel_table
+    )
+    output_data.output_intermediate_data(
+        plant_attributes, "plant_static_attributes", path_prefix, year
+    )
+    output_data.output_to_results(
+        plant_attributes, "plant_static_attributes", "plant_data/", path_prefix,
+    )
 
-    # 6. Crosswalk CEMS and EIA data
+    # 6. Convert CEMS Hourly Gross Generation to Hourly Net Generation
+    print("Converting CEMS gross generation to net generation")
+    cems, gtn_conversions = data_cleaning.convert_gross_to_net_generation(
+        cems, eia923_allocated, plant_attributes
+    )
+
+    # export the gtn conversion data
+    output_data.output_intermediate_data(
+        gtn_conversions, "gross_to_net_conversions", path_prefix, year
+    )
+
+    # 7. Crosswalk CEMS and EIA data
     print("Identifying source for hourly data")
     eia923_allocated = data_cleaning.identify_hourly_data_source(
         eia923_allocated, cems, year
     )
 
-    # 7. Calculate hourly data for partial_cems plants
+    # 8. Calculate hourly data for partial_cems plants
     print("Scaling partial CEMS data")
     (
         partial_cems_scaled,
@@ -241,17 +257,6 @@ def main():
 
     # aggregate cems data to subplant level
     cems = data_cleaning.aggregate_cems_to_subplant(cems)
-
-    # 8. Assign static characteristics to CEMS and EIA data to aid in aggregation
-    plant_attributes = data_cleaning.create_plant_attributes_table(
-        cems, eia923_allocated, year, primary_fuel_table
-    )
-    output_data.output_intermediate_data(
-        plant_attributes, "plant_static_attributes", path_prefix, year
-    )
-    output_data.output_to_results(
-        plant_attributes, "plant_static_attributes", "plant_data/", path_prefix,
-    )
 
     # 8b. split all data into three non-overlapping dataframes
     # drop data from cems that is now in partial_cems

--- a/src/impute_hourly_profiles.py
+++ b/src/impute_hourly_profiles.py
@@ -623,7 +623,7 @@ def scale_partial_cems_data(cems, eia923_allocated):
     )
     eia923_allocated.loc[
         eia923_allocated["source"] == "both", "hourly_data_source"
-    ] == "cems"
+    ] = "cems"
     eia923_allocated = eia923_allocated.drop(columns="source")
     partial_cems = partial_cems[
         (partial_cems.fuel_consumed_mmbtu_cems < partial_cems.fuel_consumed_mmbtu_eia)


### PR DESCRIPTION
### Validate gross to net generation conversion method (Closes #53)
This PR substantially revises the approach for converting CEMS hourly gross generation to net generation.
- up to now, we've been assuming that the CEMS gross generation numbers are more accurate than the EIA net generation numbers, so for example if more net generation is reported in a month than gross generation, we assume that is wrong and still adjust the CEMS values down. 
- However, the eGRID methodology completely ignore the CEMS gross generation data, and all of their results are based on EIA net generation. 
- Thus, our approach should trust the EIA net generation numbers over the CEMS gross generation numbers when available

We abandon the multi-year regression approach for now, instead calculating month-specific conversion factors, which means that in step 2 of the pipeline, we only need to identify subplant ids instead of also doing gross to net calculations. 

Previously, when we were adjusting gross to net generation, our favored approach was to get the gross generation data to match the net generation by scaling it using a ratio that we multiplied by gross generation. However, this approach had trouble dealing with negative net generation, and also changed the shape of the data if the ratio was very high or very low (e.g. a low ratio close to zero would essentially flatten the generation profile, and a high ratio greater than 1 would lead to tall peaks in the data that might exceed the plant's nameplate capacity).

Instead, our new approach prefers to shift the gross generation profile up or down by adding an hourly shift factor that can be positive or negative. This method seems to produce more reasonable values than scaling in extreme cases such as intermittent generation and negative generation. 

We do continue to calculate ratio values as backup methods to apply if for some reason a shift factor is not available. 

Our new hierarchy is to try converting gross generation in the following order:
1. Add a subplant and month-specific hourly shift factor to each hour
2. Add a subplant-specific but annual-average hourly shift factor to each hour (used when a subplant has certain months of data missing)
3. Multiply by a plant-specific annual-average GTN ratio (generally used when subplant-specific data is not available)
4. Multiply by a national-average fuel-specific GTN ratio (fixes #54)
5. Assume that net generation equals gross generation (i.e. a 1:1 ratio)

Because the shift factors are initially calculated using monthly subplant-level data, but need to be applied to hourly unit-level data, we divide each factor by the number of hours in each month and the number of units in each subplant. This approach assumes that all GTN losses are spread evenly over all hours, and split equally among units in a subplant. This might mean that the unit-level net generation data might not have high confidence, but when aggregated up to the subplant or plant level we would be more confident in the values.

This new method will deviate from the eGRID totals in one important way: Certain plants/generators report missing net generation data for a month in EIA-923, and my understanding is that this data is also missing from the final eGRID results. However, where we have non-missing CEMS gross generation data for that month, we can still convert the gross generation to net generation and fill those missing values. Thus in some cases, our net generation totals will exceed eGRID's net generation totals where EIA-923 has missing data.


### Refines assumption for assumed GTN ratio (Closes #54)
- When all other methods fail for calculating a gross to net generation ratio, instead of using an assumed ratio of 0.85, we the average value for all plants of the same fuel type nationally.