### PR TITLE
Fix CHP calculations

### DIFF
--- a/notebooks/investigate_cems_steam_load.ipynb
+++ b/notebooks/investigate_cems_steam_load.ipynb
@@ -1,0 +1,306 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# import packages\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import argparse\n",
+    "import os\n",
+    "\n",
+    "%reload_ext autoreload\n",
+    "%autoreload 2\n",
+    "\n",
+    "# # Tell python where to look for modules.\n",
+    "import sys\n",
+    "\n",
+    "sys.path.append(\"../../hourly-egrid/\")\n",
+    "\n",
+    "# import local modules\n",
+    "import src.data_cleaning as data_cleaning\n",
+    "import src.load_data as load_data\n",
+    "import src.impute_hourly_profiles as impute_hourly_profiles\n",
+    "import src.eia930 as eia930\n",
+    "import src.output_data as output_data\n",
+    "\n",
+    "from src.column_checks import get_dtypes\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Investigate CEMS plants that report steam load"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load data from csv\n",
+    "year = 2020\n",
+    "path_prefix = ''\n",
+    "\n",
+    "cems = pd.read_csv(f'../data/outputs/{path_prefix}{year}/cems_{year}.csv', dtype=get_dtypes())\n",
+    "eia923_allocated = pd.read_csv(f'../data/outputs/{path_prefix}{year}/eia923_allocated_{year}.csv', dtype=get_dtypes())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems_agg = cems.groupby([\"plant_id_eia\",\"subplant_id\",\"report_date\"]).sum()[[\"gross_generation_mwh\",\"net_generation_mwh\",\"steam_load_1000_lb\",\"fuel_consumed_mmbtu\", \"fuel_consumed_for_electricity_mmbtu\"]].reset_index()\n",
+    "eia_agg = eia923_allocated.groupby([\"plant_id_eia\",\"subplant_id\",\"report_date\"]).sum()[[\"net_generation_mwh\",\"fuel_consumed_mmbtu\", \"fuel_consumed_for_electricity_mmbtu\"]].reset_index()\n",
+    "\n",
+    "cems_steam = cems_agg[cems_agg[\"steam_load_1000_lb\"] > 0]\n",
+    "cems_steam = cems_steam.merge(eia_agg, how=\"left\", on=[\"plant_id_eia\",\"subplant_id\",\"report_date\"], suffixes=(\"_cems\",\"_eia\"))\n",
+    "cems_steam"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Get a list of all CHP plants"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get a list of all plants that are identified as CHP by sector in EIA-860\n",
+    "pudl_out = load_data.initialize_pudl_out(year)\n",
+    "chp_sectors = ['IPP CHP', 'Industrial CHP', 'Commercial CHP',]\n",
+    "chp_plants = pudl_out.plants_eia860()[[\"plant_id_eia\",\"sector_name_eia\"]]\n",
+    "chp_plants = chp_plants[chp_plants.sector_name_eia.isin(chp_sectors)]\n",
+    "\n",
+    "# get a list of all plants that have a CHP flag associated with the generator in EIA-860\n",
+    "chp_gens = pudl_out.gens_eia860()[[\"plant_id_eia\",\"generator_id\",\"associated_combined_heat_power\"]]\n",
+    "chp_gens = chp_gens[chp_gens[\"associated_combined_heat_power\"] == True]\n",
+    "plants_with_chp_gens = chp_gens[[\"plant_id_eia\",\"associated_combined_heat_power\"]].drop_duplicates()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plants_with_chp_gens.merge(chp_plants, how=\"outer\", on=\"plant_id_eia\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Fix CHP Allocation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eia923_allocated = data_cleaning.calculate_electric_allocation_factor(eia923_allocated)\n",
+    "eia923_allocated"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems[(cems[\"plant_id_eia\"] == 126)]#.sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eia923_allocated[(eia923_allocated[\"plant_id_eia\"] == 126) & (eia923_allocated[\"prime_mover_code\"] == \"IC\")].sum() #& (eia923_allocated[\"hourly_data_source\"] == \"cems\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plant_chp_allocation = eia923_allocated.groupby([\"plant_id_eia\",\"report_date\"], dropna=False).sum()[[\"net_generation_mwh\",\"fuel_consumed_mmbtu\",\"fuel_consumed_for_electricity_mmbtu\"]].reset_index()\n",
+    "plant_chp_allocation[\"fuel_ratio\"] = plant_chp_allocation[\"fuel_consumed_for_electricity_mmbtu\"] / plant_chp_allocation[\"fuel_consumed_mmbtu\"]\n",
+    "plant_chp_allocation.loc[(plant_chp_allocation[\"fuel_consumed_for_electricity_mmbtu\"] == 0) & (plant_chp_allocation[\"fuel_consumed_mmbtu\"] == 0),\"fuel_ratio\"] = 1\n",
+    "plant_chp_allocation = data_cleaning.calculate_electric_allocation_factor(plant_chp_allocation)\n",
+    "plant_chp_allocation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# calculate a subplant fuel ratio\n",
+    "subplant_fuel_ratio = eia923_allocated.groupby([\"plant_id_eia\", \"subplant_id\",\"report_date\"], dropna=False).sum()[[\"fuel_consumed_mmbtu\",\"fuel_consumed_for_electricity_mmbtu\"]].reset_index()\n",
+    "subplant_fuel_ratio[\"subplant_fuel_ratio\"] = subplant_fuel_ratio[\"fuel_consumed_for_electricity_mmbtu\"] / subplant_fuel_ratio[\"fuel_consumed_mmbtu\"]\n",
+    "subplant_fuel_ratio.loc[(subplant_fuel_ratio[\"fuel_consumed_for_electricity_mmbtu\"] == 0) & (subplant_fuel_ratio[\"fuel_consumed_mmbtu\"] == 0),\"subplant_fuel_ratio\"] = 1\n",
+    "# calculate a plant fuel ratio to fill missing values where there is not a matching subplant in CEMS\n",
+    "plant_fuel_ratio = eia923_allocated.groupby([\"plant_id_eia\", \"report_date\"], dropna=False).sum()[[\"fuel_consumed_mmbtu\",\"fuel_consumed_for_electricity_mmbtu\"]].reset_index()\n",
+    "plant_fuel_ratio[\"plant_fuel_ratio\"] = plant_fuel_ratio[\"fuel_consumed_for_electricity_mmbtu\"] / plant_fuel_ratio[\"fuel_consumed_mmbtu\"]\n",
+    "plant_fuel_ratio.loc[(plant_fuel_ratio[\"fuel_consumed_for_electricity_mmbtu\"] == 0) & (plant_fuel_ratio[\"fuel_consumed_mmbtu\"] == 0),\"plant_fuel_ratio\"] = 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subplant_fuel_ratio[subplant_fuel_ratio[\"plant_id_eia\"] == 7]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plant_fuel_ratio[plant_fuel_ratio[\"plant_id_eia\"] == 7]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def adjust_cems_for_chp(cems, eia923_allocated):\n",
+    "    \"\"\"\n",
+    "    Adjusts CEMS fuel consumption and emissions data for CHP.\n",
+    "\n",
+    "    Steps:\n",
+    "        1. Calculate the ratio between `fuel_consumed_for_electricity_mmbtu` and `fuel_consumed_mmbtu` in EIA-923\n",
+    "        2. Use this ratio to calculate a `fuel_consumed_for_electricity_mmbtu` from the `fuel_consumed_mmbtu` data reported in CEMS\n",
+    "        3. Calculate an electric allocation factor using the fuel and net generation data\n",
+    "        4. Use the allocation factor to adjust emissions\n",
+    "    Args:\n",
+    "        cems: dataframe of hourly cems data after cleaning and gross to net calculations\n",
+    "        eia923_allocated: dataframe of EIA-923 data after allocation\n",
+    "    \"\"\"\n",
+    "    # calculate a subplant fuel ratio\n",
+    "    subplant_fuel_ratio = eia923_allocated.groupby([\"plant_id_eia\", \"subplant_id\",\"report_date\"], dropna=False).sum()[[\"fuel_consumed_mmbtu\",\"fuel_consumed_for_electricity_mmbtu\"]].reset_index()\n",
+    "    subplant_fuel_ratio[\"subplant_fuel_ratio\"] = subplant_fuel_ratio[\"fuel_consumed_for_electricity_mmbtu\"] / subplant_fuel_ratio[\"fuel_consumed_mmbtu\"]\n",
+    "    subplant_fuel_ratio.loc[(subplant_fuel_ratio[\"fuel_consumed_for_electricity_mmbtu\"] == 0) & (subplant_fuel_ratio[\"fuel_consumed_mmbtu\"] == 0),\"subplant_fuel_ratio\"] = 1\n",
+    "    # calculate a plant fuel ratio to fill missing values where there is not a matching subplant in CEMS\n",
+    "    plant_fuel_ratio = eia923_allocated.groupby([\"plant_id_eia\", \"report_date\"], dropna=False).sum()[[\"fuel_consumed_mmbtu\",\"fuel_consumed_for_electricity_mmbtu\"]].reset_index()\n",
+    "    plant_fuel_ratio[\"plant_fuel_ratio\"] = plant_fuel_ratio[\"fuel_consumed_for_electricity_mmbtu\"] / plant_fuel_ratio[\"fuel_consumed_mmbtu\"]\n",
+    "    plant_fuel_ratio.loc[(plant_fuel_ratio[\"fuel_consumed_for_electricity_mmbtu\"] == 0) & (plant_fuel_ratio[\"fuel_consumed_mmbtu\"] == 0),\"plant_fuel_ratio\"] = 1\n",
+    "\n",
+    "    # merge the fuel ratios into cems and fill missing subplant ratios with plant ratios\n",
+    "    cems = cems.merge(subplant_fuel_ratio[[\"plant_id_eia\", \"subplant_id\",\"report_date\", \"subplant_fuel_ratio\"]], how=\"left\", on=[\"plant_id_eia\", \"subplant_id\",\"report_date\"])\n",
+    "    cems = cems.merge(plant_fuel_ratio[[\"plant_id_eia\", \"report_date\", \"plant_fuel_ratio\"]], how=\"left\", on=[\"plant_id_eia\", \"report_date\"])\n",
+    "    cems[\"subplant_fuel_ratio\"] = cems[\"subplant_fuel_ratio\"].fillna(cems[\"plant_fuel_ratio\"])\n",
+    "\n",
+    "    # if there are any missing ratios, assume that the ratio is 1\n",
+    "    cems[\"subplant_fuel_ratio\"] = cems[\"subplant_fuel_ratio\"].fillna(1)\n",
+    "\n",
+    "    # calculate fuel_consumed_for_electricity_mmbtu\n",
+    "    cems[\"fuel_consumed_for_electricity_mmbtu\"] = cems[\"fuel_consumed_mmbtu\"] * cems[\"subplant_fuel_ratio\"]\n",
+    "\n",
+    "    # add adjusted emissions columns\n",
+    "    # TODO: remove data_cleaning\n",
+    "    cems = data_cleaning.adjust_emissions_for_CHP(cems)\n",
+    "\n",
+    "    return cems\n",
+    "    \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems = cems.drop(columns=[\"fuel_consumed_for_electricity_mmbtu\",\"co2_mass_lb_for_electricity\",\"ch4_mass_lb_for_electricity\",\"n2o_mass_lb_for_electricity\",\"nox_mass_lb_for_electricity\",\"so2_mass_lb_for_electricity\",\"fuel_ratio\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems = adjust_cems_for_chp(cems, eia923_allocated)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eia923_allocated[eia923_allocated[\"plant_id_eia\"] == 2018].sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems[(cems[\"plant_id_eia\"] == 7)]#.sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plant_fuel_ratio = eia923_allocated.groupby([\"plant_id_eia\", \"report_date\"], dropna=False).sum()[[\"fuel_consumed_mmbtu\",\"fuel_consumed_for_electricity_mmbtu\"]].reset_index()\n",
+    "plant_fuel_ratio[\"fuel_ratio\"] = plant_fuel_ratio[\"fuel_consumed_for_electricity_mmbtu\"] / plant_fuel_ratio[\"fuel_consumed_mmbtu\"]\n",
+    "plant_fuel_ratio.loc[(plant_fuel_ratio[\"fuel_consumed_for_electricity_mmbtu\"] == 0) & (plant_fuel_ratio[\"fuel_consumed_mmbtu\"] == 0),\"fuel_ratio\"] = 1"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.9.12 ('hourly_egrid')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "4103f3cd497821eca917ea303dbe10c590d787eb7d2dc3fd4e15dec0356e7931"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/test_data_pipeline.ipynb
+++ b/notebooks/test_data_pipeline.ipynb
@@ -55,7 +55,7 @@
    "outputs": [],
    "source": [
     "%cd ../src\n",
-    "%run data_pipeline --year 2020"
+    "%run data_pipeline --year 2019"
    ]
   },
   {

--- a/notebooks/validate_vs_egrid.ipynb
+++ b/notebooks/validate_vs_egrid.ipynb
@@ -22,10 +22,9 @@
     "\n",
     "# import local modules\n",
     "import src.load_data as load_data\n",
-    "from src.data_cleaning import assign_ba_code_to_plant\n",
     "import src.validation as validation\n",
     "\n",
-    "from src.column_checks import get_dtypes, apply_dtypes"
+    "from src.column_checks import get_dtypes"
    ]
   },
   {
@@ -41,7 +40,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "year = 2020\n"
+    "year = 2020"
    ]
   },
   {
@@ -99,31 +98,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# identify any plants that are in egrid but not our totals, and any plants that are in our totals, but not egrid\n",
-    "PLANTS_MISSING_FROM_CALCULATION = list(\n",
-    "    set(egrid_plant[\"plant_id_eia\"].unique())\n",
-    "    - set(annual_plant_results[\"plant_id_eia\"].unique())\n",
-    ")\n",
-    "\n",
-    "# Which plants are included in eGRID but are missing from our calculations?\n",
-    "missing_from_calc = egrid_plant[\n",
-    "    egrid_plant[\"plant_id_egrid\"].isin(PLANTS_MISSING_FROM_CALCULATION)\n",
-    "]\n",
-    "\n",
-    "# see if any of these plants are retired\n",
-    "generators_eia860 = load_data.load_pudl_table(\"generators_eia860\", year=year)\n",
-    "missing_from_calc.merge(\n",
-    "    generators_eia860[\n",
-    "        [\n",
-    "            \"plant_id_eia\",\n",
-    "            \"operational_status\",\n",
-    "            \"current_planned_operating_date\",\n",
-    "            \"retirement_date\",\n",
-    "        ]\n",
-    "    ].drop_duplicates(),\n",
-    "    how=\"left\",\n",
-    "    on=\"plant_id_eia\",\n",
-    ")"
+    "missing_from_calc, PLANTS_MISSING_FROM_CALCULATION = validation.identify_plants_missing_from_our_calculations(egrid_plant, annual_plant_results, year)\n",
+    "missing_from_calc"
    ]
   },
   {
@@ -139,20 +115,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Which plants are in our calculations, but are missing from eGRID?\n",
-    "PLANTS_MISSING_FROM_EGRID = list(\n",
-    "    set(annual_plant_results[\"plant_id_egrid\"].unique())\n",
-    "    - set(egrid_plant[\"plant_id_egrid\"].unique())\n",
-    ")\n",
-    "\n",
-    "plant_names = load_data.load_pudl_table(\"plants_entity_eia\")[\n",
-    "    [\"plant_id_eia\", \"plant_name_eia\", \"sector_name_eia\"]\n",
-    "]\n",
-    "missing_from_egrid = annual_plant_results[\n",
-    "    annual_plant_results[\"plant_id_egrid\"].isin(PLANTS_MISSING_FROM_EGRID)\n",
-    "].merge(plant_names, how=\"left\", on=\"plant_id_eia\")\n",
-    "\n",
-    "missing_from_egrid\n"
+    "missing_from_egrid, PLANTS_MISSING_FROM_EGRID = validation.identify_plants_missing_from_egrid(egrid_plant, annual_plant_results)\n"
    ]
   },
   {
@@ -162,8 +125,7 @@
    "outputs": [],
    "source": [
     "# how many of the plants missing from egrid have non-zero data\n",
-    "missing_from_egrid[missing_from_egrid[\"fuel_consumed_mmbtu\"] != 0]\n",
-    "\n"
+    "missing_from_egrid[missing_from_egrid[\"fuel_consumed_mmbtu\"] != 0]"
    ]
   },
   {
@@ -237,8 +199,7 @@
     "ba_code_match[\n",
     "    (ba_code_match[\"ba_code_calc\"] != ba_code_match[\"ba_code_egrid\"])\n",
     "    & ~(ba_code_match[\"ba_code_egrid\"].isna())\n",
-    "]\n",
-    "\n"
+    "]"
    ]
   },
   {
@@ -300,87 +261,10 @@
     "    f\"../data/outputs/{year}/eia923_allocated_{year}.csv\",\n",
     "    dtype=get_dtypes(),\n",
     "    parse_dates=[\"report_date\"],\n",
-    ")\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "all_other_plants = annual_plant_results.copy()\n",
-    "\n",
-    "# missing plants\n",
-    "missing_plants = annual_plant_results[\n",
-    "    annual_plant_results[\"plant_id_eia\"].isin(PLANTS_MISSING_FROM_EGRID)\n",
-    "]\n",
-    "all_other_plants = all_other_plants[\n",
-    "    ~all_other_plants[\"plant_id_eia\"].isin(list(missing_plants.plant_id_eia.unique()))\n",
-    "]\n",
-    "\n",
-    "# geothermal\n",
-    "geothermal_plants = annual_plant_results[\n",
-    "    annual_plant_results[\"plant_primary_fuel\"] == \"GEO\"\n",
-    "]\n",
-    "all_other_plants = all_other_plants[\n",
-    "    ~all_other_plants[\"plant_id_eia\"].isin(\n",
-    "        list(geothermal_plants.plant_id_eia.unique())\n",
-    "    )\n",
-    "]\n",
-    "\n",
-    "# nuclear\n",
-    "nuclear_plants = annual_plant_results[\n",
-    "    annual_plant_results[\"plant_primary_fuel\"] == \"NUC\"\n",
-    "]\n",
-    "all_other_plants = all_other_plants[\n",
-    "    ~all_other_plants[\"plant_id_eia\"].isin(list(nuclear_plants.plant_id_eia.unique()))\n",
-    "]\n",
-    "\n",
-    "# fuel cells\n",
-    "gens_eia860 = pudl_out.gens_eia860()\n",
-    "PLANTS_WITH_FUEL_CELLS = list(\n",
-    "    gens_eia860.loc[gens_eia860[\"prime_mover_code\"] == \"FC\", \"plant_id_eia\"].unique()\n",
     ")\n",
-    "fuel_cell_plants = annual_plant_results[\n",
-    "    annual_plant_results[\"plant_id_eia\"].isin(PLANTS_WITH_FUEL_CELLS)\n",
-    "]\n",
-    "all_other_plants = all_other_plants[\n",
-    "    ~all_other_plants[\"plant_id_eia\"].isin(list(fuel_cell_plants.plant_id_eia.unique()))\n",
-    "]\n",
     "\n",
-    "# ozone season reporters\n",
-    "# identify all of the plants with generators that report data from both EIA and CEMS\n",
-    "multi_source_reporters = eia923_allocated[\n",
-    "    [\"plant_id_eia\", \"generator_id\", \"hourly_data_source\"]\n",
-    "].drop_duplicates()\n",
-    "MULTI_SOURCE_PLANTS = list(\n",
-    "    multi_source_reporters.loc[\n",
-    "        multi_source_reporters.duplicated(\n",
-    "            subset=[\"plant_id_eia\", \"generator_id\"], keep=False\n",
-    "        ),\n",
-    "        \"plant_id_eia\",\n",
-    "    ].unique()\n",
-    ")\n",
-    "ozone_season_plants = annual_plant_results[\n",
-    "    annual_plant_results[\"plant_id_eia\"].isin(MULTI_SOURCE_PLANTS)\n",
-    "]\n",
-    "all_other_plants = all_other_plants[\n",
-    "    ~all_other_plants[\"plant_id_eia\"].isin(\n",
-    "        list(ozone_season_plants.plant_id_eia.unique())\n",
-    "    )\n",
-    "]\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "PLANTS_IN_ALL_OTHER_PLANTS = list(all_other_plants[\"plant_id_egrid\"].unique())\n",
-    "\n"
+    "missing_plants, geothermal_plants, nuclear_plants, fuel_cell_plants, ozone_season_plants, chp_plants, all_other_plants = validation.segment_plants_by_known_issues(annual_plant_results, egrid_plant, eia923_allocated, pudl_out, PLANTS_MISSING_FROM_EGRID)\n",
+    "PLANTS_IN_ALL_OTHER_PLANTS = list(all_other_plants[\"plant_id_egrid\"].unique())"
    ]
   },
   {
@@ -397,93 +281,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pudl_out = load_data.initialize_pudl_out(year)\n",
-    "\n",
-    "# load the EIA generator fuel data\n",
-    "IDX_PM_ESC = [\"report_date\", \"plant_id_eia\", \"energy_source_code\", \"prime_mover_code\"]\n",
-    "gf = pudl_out.gf_eia923().loc[\n",
-    "    :,\n",
-    "    IDX_PM_ESC\n",
-    "    + [\n",
-    "        \"net_generation_mwh\",\n",
-    "        \"fuel_consumed_mmbtu\",\n",
-    "        \"fuel_consumed_for_electricity_mmbtu\",\n",
-    "    ],\n",
-    "]\n",
-    "\n",
-    "# add egrid plant ids\n",
-    "egrid_crosswalk = pd.read_csv(\n",
-    "    \"../data/manual/egrid_static_tables/table_C5_crosswalk_of_EIA_ID_to_EPA_ID.csv\"\n",
-    ")\n",
-    "eia_to_egrid_id = dict(\n",
-    "    zip(list(egrid_crosswalk[\"plant_id_eia\"]), list(egrid_crosswalk[\"plant_id_egrid\"]))\n",
-    ")\n",
-    "gf[\"plant_id_egrid\"] = gf[\"plant_id_eia\"]\n",
-    "gf[\"plant_id_egrid\"].update(gf[\"plant_id_egrid\"].map(eia_to_egrid_id))\n",
-    "\n",
-    "# calculate an annual total for each plant\n",
-    "gf_total = gf.groupby([\"plant_id_egrid\"]).sum().reset_index()\n",
-    "\n",
-    "# choose a metric to compare\n",
-    "metric = \"fuel_consumed_mmbtu\"\n",
-    "\n",
-    "# merge the annual EIA-923 data into the egrid data\n",
-    "egrid_eia_comparison = (\n",
-    "    egrid_plant[\n",
-    "        [\"plant_id_egrid\", \"plant_name\", \"ba_code\", \"plant_primary_fuel\", metric]\n",
-    "    ]\n",
-    "    .merge(\n",
-    "        gf_total[[\"plant_id_egrid\", metric]],\n",
-    "        how=\"outer\",\n",
-    "        on=\"plant_id_egrid\",\n",
-    "        suffixes=(\"_egrid\", \"_eia923\"),\n",
-    "        indicator=\"source\",\n",
-    "    )\n",
-    "    .round(0)\n",
-    ")\n",
-    "egrid_eia_comparison[f\"{metric}_egrid\"] = egrid_eia_comparison[\n",
-    "    f\"{metric}_egrid\"\n",
-    "].fillna(0)\n",
-    "# calculate an absolute difference and percent difference between the two values\n",
-    "egrid_eia_comparison[\"difference\"] = (\n",
-    "    egrid_eia_comparison[f\"{metric}_egrid\"] - egrid_eia_comparison[f\"{metric}_eia923\"]\n",
-    ")\n",
-    "egrid_eia_comparison[\"percent_difference\"] = (\n",
-    "    egrid_eia_comparison[f\"{metric}_egrid\"] - egrid_eia_comparison[f\"{metric}_eia923\"]\n",
-    ") / egrid_eia_comparison[f\"{metric}_eia923\"]\n",
-    "egrid_eia_comparison.loc[\n",
-    "    egrid_eia_comparison[\"difference\"] == 0, \"percent_difference\"\n",
-    "] = 0\n",
-    "\n",
-    "# add cems data so that we can compare fuel totals\n",
-    "cems = pd.read_csv(\n",
-    "    f\"../data/outputs/{year}/cems_{year}.csv\",\n",
-    "    dtype=get_dtypes(),\n",
-    "    parse_dates=[\"report_date\"],\n",
-    ")\n",
-    "cems_total = cems.copy()[[\"plant_id_eia\", metric]]\n",
-    "cems_total[\"plant_id_egrid\"] = cems_total[\"plant_id_eia\"]\n",
-    "cems_total[\"plant_id_egrid\"].update(cems_total[\"plant_id_egrid\"].map(eia_to_egrid_id))\n",
-    "cems_total = (\n",
-    "    cems_total.groupby(\"plant_id_egrid\")\n",
-    "    .sum()[metric]\n",
-    "    .reset_index()\n",
-    "    .rename(columns={metric: f\"{metric}_cems\"})\n",
-    ")\n",
-    "\n",
-    "# merge cems data into egrid\n",
-    "egrid_eia_comparison = egrid_eia_comparison.merge(\n",
-    "    cems_total, how=\"outer\", on=\"plant_id_egrid\"\n",
-    ")\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "# where is egrid missing data?\n",
+    "\n",
+    "egrid_eia_comparison = validation.identify_potential_missing_fuel_in_egrid(pudl_out, year, egrid_plant)\n",
+    "\n",
     "plants_missing_more_than_1_percent_fuel = egrid_eia_comparison[\n",
     "    (egrid_eia_comparison[\"percent_difference\"] < -0.01)\n",
     "    & (egrid_eia_comparison[\"plant_primary_fuel\"] != \"NUC\")\n",
@@ -536,215 +337,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def compare_plant_level_results(plant_data, egrid_plant, PLANTS_MISSING_FROM_EGRID):\n",
-    "    # standardize column names and index so that the two dfs can be divided\n",
-    "    calculated_to_compare = (\n",
-    "        plant_data.groupby(\"plant_id_egrid\", dropna=False)\n",
-    "        .sum()\n",
-    "        .drop(columns=[\"plant_id_eia\"])\n",
-    "    )\n",
-    "\n",
-    "    # drop the plants that have no data in eGRID\n",
-    "    plants_with_no_data_in_egrid = list(\n",
-    "        egrid_plant[\n",
-    "            egrid_plant[\n",
-    "                [\n",
-    "                    \"net_generation_mwh\",\n",
-    "                    \"fuel_consumed_mmbtu\",\n",
-    "                    \"fuel_consumed_for_electricity_mmbtu\",\n",
-    "                    \"co2_mass_lb\",\n",
-    "                    \"co2_mass_lb_adjusted\",\n",
-    "                ]\n",
-    "            ].sum(axis=1)\n",
-    "            == 0\n",
-    "        ][\"plant_id_egrid\"]\n",
-    "    )\n",
-    "    egrid_plant = egrid_plant[\n",
-    "        ~egrid_plant[\"plant_id_eia\"].isin(plants_with_no_data_in_egrid)\n",
-    "    ]\n",
-    "\n",
-    "    egrid_to_compare = egrid_plant.set_index([\"plant_id_egrid\"]).drop(\n",
-    "        columns=[\"ba_code\", \"state\", \"plant_name\", \"plant_id_eia\"]\n",
-    "    )\n",
-    "    # only keep plants that are in the comparison data\n",
-    "    egrid_to_compare = egrid_to_compare[\n",
-    "        egrid_to_compare.index.isin(list(calculated_to_compare.index.unique()))\n",
-    "    ]\n",
-    "\n",
-    "    # divide calculated value by egrid value\n",
-    "    compared = (\n",
-    "        calculated_to_compare.div(egrid_to_compare)\n",
-    "        .merge(\n",
-    "            egrid_plant[[\"plant_id_egrid\", \"plant_name\", \"ba_code\", \"state\"]],\n",
-    "            how=\"left\",\n",
-    "            left_index=True,\n",
-    "            right_on=\"plant_id_egrid\",\n",
-    "        )\n",
-    "        .set_index(\"plant_id_egrid\")\n",
-    "    )\n",
-    "    compared[\"plant_name\"] = compared[\"plant_name\"].fillna(\"unknown\")\n",
-    "\n",
-    "    # create a dataframe that merges the two sources of data together\n",
-    "    compared_merged = calculated_to_compare.merge(\n",
-    "        egrid_to_compare, how=\"left\", on=\"plant_id_egrid\", suffixes=(\"_calc\", \"_egrid\")\n",
-    "    )\n",
-    "\n",
-    "    # for each column, change missing values to zero if both values are zero (only nan b/c divide by zero)\n",
-    "    for col in [\n",
-    "        \"net_generation_mwh\",\n",
-    "        \"fuel_consumed_mmbtu\",\n",
-    "        \"fuel_consumed_for_electricity_mmbtu\",\n",
-    "        \"co2_mass_lb_adjusted\",\n",
-    "        \"co2_mass_lb\",\n",
-    "    ]:\n",
-    "        # identify plants with zero values for both\n",
-    "        plant_ids = list(\n",
-    "            compared_merged[\n",
-    "                (compared_merged[f\"{col}_calc\"] == 0)\n",
-    "                & (compared_merged[f\"{col}_egrid\"] == 0)\n",
-    "            ].index\n",
-    "        )\n",
-    "        compared.loc[compared.index.isin(plant_ids), col] = 1\n",
-    "\n",
-    "    # for each column, categorize the data based on how far it is off from egrid\n",
-    "    for col in [\n",
-    "        \"net_generation_mwh\",\n",
-    "        \"fuel_consumed_mmbtu\",\n",
-    "        \"fuel_consumed_for_electricity_mmbtu\",\n",
-    "        \"co2_mass_lb_adjusted\",\n",
-    "        \"co2_mass_lb\",\n",
-    "    ]:\n",
-    "        # add a new column\n",
-    "        compared[f\"{col}_status\"] = pd.cut(\n",
-    "            x=compared[col],\n",
-    "            bins=[\n",
-    "                -999999999,\n",
-    "                -0.0001,\n",
-    "                0.5,\n",
-    "                0.9,\n",
-    "                0.99,\n",
-    "                0.9999,\n",
-    "                1,\n",
-    "                1.0001,\n",
-    "                1.01,\n",
-    "                1.1,\n",
-    "                1.5,\n",
-    "                999999999,\n",
-    "            ],\n",
-    "            labels=[\n",
-    "                \"negative\",\n",
-    "                \"<50%\",\n",
-    "                \"-50% to -10%\",\n",
-    "                \"-10% to -1%\",\n",
-    "                \"+/-1%\",\n",
-    "                \"!exact\",\n",
-    "                \"!exact\",\n",
-    "                \"+/-1%\",\n",
-    "                \"+1% to 10%\",\n",
-    "                \"+10% to 50%\",\n",
-    "                \">50%\",\n",
-    "            ],\n",
-    "            ordered=False,\n",
-    "        )\n",
-    "        # replace any missing values with missing\n",
-    "        compared[f\"{col}_status\"] = compared[f\"{col}_status\"].astype(str)\n",
-    "        compared[f\"{col}_status\"] = compared[f\"{col}_status\"].fillna(\"missing\")\n",
-    "        compared[f\"{col}_status\"] = compared[f\"{col}_status\"].replace(\"nan\", \"missing\")\n",
-    "        compared.loc[\n",
-    "            (compared.index.isin(PLANTS_MISSING_FROM_EGRID)), f\"{col}_status\"\n",
-    "        ] = \"not_in_egrid\"\n",
-    "\n",
-    "        # identify which plants are missing from egrid vs calculated values\n",
-    "    for col in [\n",
-    "        \"net_generation_mwh\",\n",
-    "        \"fuel_consumed_mmbtu\",\n",
-    "        \"fuel_consumed_for_electricity_mmbtu\",\n",
-    "        \"co2_mass_lb_adjusted\",\n",
-    "        \"co2_mass_lb\",\n",
-    "    ]:\n",
-    "        # identify plants that are missing in egrid\n",
-    "        plants_missing_egrid = list(\n",
-    "            compared_merged[\n",
-    "                (compared_merged[f\"{col}_calc\"] > 0)\n",
-    "                & (compared_merged[f\"{col}_egrid\"].isna())\n",
-    "            ].index\n",
-    "        )\n",
-    "        compared.loc[\n",
-    "            compared.index.isin(plants_missing_egrid), f\"{col}_status\"\n",
-    "        ] = \"missing_in_egrid\"\n",
-    "        # identify plants that are missing from our calculations\n",
-    "        plants_missing_calc = list(\n",
-    "            compared_merged[\n",
-    "                (compared_merged[f\"{col}_calc\"].isna())\n",
-    "                & (compared_merged[f\"{col}_egrid\"] > 0)\n",
-    "            ].index\n",
-    "        )\n",
-    "        compared.loc[\n",
-    "            compared.index.isin(plants_missing_calc), f\"{col}_status\"\n",
-    "        ] = \"missing_in_calc\"\n",
-    "        # identify where our calculations are missing a zero value\n",
-    "        plants_missing_zero_calc = list(\n",
-    "            compared_merged[\n",
-    "                (compared_merged[f\"{col}_calc\"].isna())\n",
-    "                & (compared_merged[f\"{col}_egrid\"] == 0)\n",
-    "            ].index\n",
-    "        )\n",
-    "        compared.loc[\n",
-    "            compared.index.isin(plants_missing_zero_calc), f\"{col}_status\"\n",
-    "        ] = \"calc_missing_zero_value_from_egrid\"\n",
-    "        # identify where egrid has a missing value instead of a zero\n",
-    "        plants_missing_zero_egrid = list(\n",
-    "            compared_merged[\n",
-    "                (compared_merged[f\"{col}_calc\"] == 0)\n",
-    "                & (compared_merged[f\"{col}_egrid\"].isna())\n",
-    "            ].index\n",
-    "        )\n",
-    "        compared.loc[\n",
-    "            compared.index.isin(plants_missing_zero_egrid), f\"{col}_status\"\n",
-    "        ] = \"egrid_missing_zero_value_from_calc\"\n",
-    "        # identify where egrid has a zero value where we have a positive value\n",
-    "        plants_incorrect_zero_egrid = list(\n",
-    "            compared_merged[\n",
-    "                (compared_merged[f\"{col}_calc\"] > 0)\n",
-    "                & (compared_merged[f\"{col}_egrid\"] == 0)\n",
-    "            ].index\n",
-    "        )\n",
-    "        compared.loc[\n",
-    "            compared.index.isin(plants_incorrect_zero_egrid), f\"{col}_status\"\n",
-    "        ] = \"calc_positive_but_egrid_zero\"\n",
-    "\n",
-    "    # create a dataframe that counts how many plants are in each category\n",
-    "    comparison_count = []\n",
-    "    for col in [\n",
-    "        \"net_generation_mwh\",\n",
-    "        \"fuel_consumed_mmbtu\",\n",
-    "        \"fuel_consumed_for_electricity_mmbtu\",\n",
-    "        \"co2_mass_lb_adjusted\",\n",
-    "        \"co2_mass_lb\",\n",
-    "    ]:\n",
-    "        count = (\n",
-    "            compared.groupby(f\"{col}_status\", dropna=False)\n",
-    "            .count()[\"plant_name\"]\n",
-    "            .rename(col)\n",
-    "        )\n",
-    "        count.index = count.index.rename(\"status\")\n",
-    "        comparison_count.append(count)\n",
-    "\n",
-    "    comparison_count = pd.concat(comparison_count, axis=1).fillna(0).astype(int)\n",
-    "    comparison_count = pd.concat(\n",
-    "        [comparison_count, pd.DataFrame(comparison_count.sum().rename(\"Total\")).T],\n",
-    "        axis=0,\n",
-    "    )\n",
-    "    return comparison_count, compared\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "nuclear_comparison_count, compared_nuclear = compare_plant_level_results(\n",
+    "nuclear_comparison_count, compared_nuclear = validation.compare_plant_level_results_to_egrid(\n",
     "    nuclear_plants, egrid_plant, PLANTS_MISSING_FROM_EGRID\n",
     ")\n",
     "nuclear_comparison_count\n"
@@ -756,7 +349,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "geothermal_comparison_count, compared_geothermal = compare_plant_level_results(\n",
+    "geothermal_comparison_count, compared_geothermal = validation.compare_plant_level_results_to_egrid(\n",
     "    geothermal_plants, egrid_plant, PLANTS_MISSING_FROM_EGRID\n",
     ")\n",
     "geothermal_comparison_count\n"
@@ -768,7 +361,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fuel_cell_comparison_count, compared_fuel_cell = compare_plant_level_results(\n",
+    "fuel_cell_comparison_count, compared_fuel_cell = validation.compare_plant_level_results_to_egrid(\n",
     "    fuel_cell_plants, egrid_plant, PLANTS_MISSING_FROM_EGRID\n",
     ")\n",
     "fuel_cell_comparison_count\n"
@@ -780,7 +373,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "missing_comparison_count, compared_missing = compare_plant_level_results(\n",
+    "missing_comparison_count, compared_missing = validation.compare_plant_level_results_to_egrid(\n",
     "    missing_plants, egrid_plant, PLANTS_MISSING_FROM_EGRID\n",
     ")\n",
     "missing_comparison_count\n"
@@ -792,7 +385,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ozone_comparison_count, compared_ozone = compare_plant_level_results(\n",
+    "ozone_comparison_count, compared_ozone = validation.compare_plant_level_results_to_egrid(\n",
     "    ozone_season_plants, egrid_plant, PLANTS_MISSING_FROM_EGRID\n",
     ")\n",
     "ozone_comparison_count\n"
@@ -804,10 +397,45 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "all_other_comparison_count, compared_all_other = compare_plant_level_results(\n",
+    "chp_comparison_count, compared_chp = validation.compare_plant_level_results_to_egrid(\n",
+    "    chp_plants, egrid_plant, PLANTS_MISSING_FROM_EGRID\n",
+    ")\n",
+    "chp_comparison_count"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "all_other_comparison_count, compared_all_other = validation.compare_plant_level_results_to_egrid(\n",
     "    all_other_plants, egrid_plant, PLANTS_MISSING_FROM_EGRID\n",
     ")\n",
     "all_other_comparison_count\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Explore a specific set of plants"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# specify the dataframe, metric, and status to explore\n",
+    "comparison_df = compared_chp\n",
+    "metric = \"fuel_consumed_for_electricity_mmbtu\"\n",
+    "status = \"-50% to -10%\"\n",
+    "\n",
+    "# show the data\n",
+    "columns_to_show = [\"plant_name\",\"ba_code\",\"state\", metric, f\"{metric}_status\"]\n",
+    "comparison_df.loc[(comparison_df[f\"{metric}_status\"] == status), columns_to_show]"
    ]
   },
   {
@@ -985,7 +613,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plant_to_explore = 58380\n"
+    "subplant_crosswalk = pd.read_csv(f\"../data/outputs/{year}/subplant_crosswalk.csv\")\n",
+    "cems_unit_monthly = (\n",
+    "    cems.groupby([\"plant_id_eia\", \"unitid\", \"report_date\"], dropna=False).sum().reset_index()\n",
+    ")\n",
+    "cems_unit = cems.groupby([\"plant_id_eia\", \"unitid\"], dropna=False).sum().reset_index()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plant_to_explore = 58223\n"
    ]
   },
   {
@@ -1004,8 +645,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "annual_plant_results[annual_plant_results[\"plant_id_eia\"] == plant_to_explore]\n",
-    "\n"
+    "annual_plant_results[annual_plant_results[\"plant_id_eia\"] == plant_to_explore]"
    ]
   },
   {
@@ -1014,8 +654,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "eia923_allocated[eia923_allocated[\"plant_id_eia\"] == plant_to_explore].sum()\n",
-    "\n"
+    "eia923_allocated[eia923_allocated[\"plant_id_eia\"] == plant_to_explore]"
    ]
   },
   {
@@ -1024,9 +663,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cems_unit_monthly = (\n",
-    "    cems.groupby([\"plant_id_eia\", \"unitid\", \"report_date\"]).sum().reset_index()\n",
-    ")\n"
+    "eia923_allocated[eia923_allocated[\"plant_id_eia\"] == plant_to_explore].sum()"
    ]
   },
   {
@@ -1035,8 +672,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cems_unit_monthly[cems_unit_monthly[\"plant_id_eia\"] == plant_to_explore].sum()\n",
-    "\n"
+    "cems_unit[cems_unit[\"plant_id_eia\"] == plant_to_explore]"
    ]
   },
   {
@@ -1045,8 +681,52 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cems[(cems[\"plant_id_eia\"] == plant_to_explore) & (cems[\"operating_time_hours\"] > 0)]\n",
-    "\n"
+    "cems_unit_monthly[cems_unit_monthly[\"plant_id_eia\"] == plant_to_explore].sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems[(cems[\"plant_id_eia\"] == plant_to_explore)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems[(cems[\"gross_generation_mwh\"] == 0) & (cems[\"fuel_consumed_mmbtu\"] == 0)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subplant_crosswalk.loc[subplant_crosswalk[\"plant_id_eia\"] == plant_to_explore, [\"unitid\",\"generator_id\",\"subplant_id\"]].drop_duplicates()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eia923_allocated.loc[eia923_allocated[\"plant_id_eia\"] == plant_to_explore, [\"generator_id\",\"subplant_id\"]].drop_duplicates()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems_unit_monthly.loc[cems_unit_monthly[\"plant_id_eia\"] == plant_to_explore, [\"unitid\",\"subplant_id\"]].drop_duplicates()"
    ]
   }
  ],

--- a/src/column_checks.py
+++ b/src/column_checks.py
@@ -1,21 +1,21 @@
 """
-Check columns for standard data files output by data_pipeline. 
+Check columns for standard data files output by data_pipeline.
 
 Since file names and column names are hardcoded across several files, calling these checks
-during file creation (data_pipeline.py) ensures that changes to file names and 
-column names are not made accidentally. 
+during file creation (data_pipeline.py) ensures that changes to file names and
+column names are not made accidentally.
 
-To make an intentional change in a file or column name, search the project for all 
+To make an intentional change in a file or column name, search the project for all
 uses of that column/file, update all of them to the new column name, and then change
-the name here. 
+the name here.
 
-To add a column, add the name here. 
+To add a column, add the name here.
 
-To remove a column, search the project for all uses of that column and remove 
-those files or uses, then remove it here. 
+To remove a column, search the project for all uses of that column and remove
+those files or uses, then remove it here.
 
-After any change, re-run data_pipeline to regenerate all files and re-run these 
-checks. 
+After any change, re-run data_pipeline to regenerate all files and re-run these
+checks.
 """
 
 COLUMNS = {

--- a/src/consumed.py
+++ b/src/consumed.py
@@ -2,8 +2,6 @@ import numpy as np
 import pandas as pd
 import os
 
-from sqlalchemy import TIME
-
 from gridemissions.emissions import BaDataEmissionsCalc, EMISSIONS_FACTORS
 from gridemissions.load import BaData
 from gridemissions.eia_api import KEYS, SRC
@@ -118,7 +116,7 @@ def get_column(poll: str, adjustment: str, ba: str = ""):
 
 def get_rate_column(poll: str, adjustment: str, generated: bool = True, ba: str = ""):
     """
-    Return either generated or consumed output file rate column 
+    Return either generated or consumed output file rate column
     for pollutant `poll` and adjustment `adjustment`
     """
     assert poll in POLLS
@@ -150,7 +148,7 @@ KEYS["N2O"] = {
 }
 
 
-def get_average_emission_factors(prefix: str = "", year:int = 2020):
+def get_average_emission_factors(prefix: str = "", year: int = 2020):
     """
         Edit EMISSIONS dict with per-fuel, per-adjustment, per-poll emission factors.
         Used to fill in emissions from BAs outside of US, where we have generation by
@@ -213,7 +211,7 @@ class HourlyBaDataEmissionsCalc(BaDataEmissionsCalc):
 
     def _drop_pol_cols(self, poll):
         """
-            For repeated processing with different pols, need to drop pollutant columns 
+            For repeated processing with different pols, need to drop pollutant columns
 
         """
         pol_cols = [c for c in self.df.columns if c[0 : len(poll)] == poll]
@@ -256,8 +254,8 @@ class HourlyBaDataEmissionsCalc(BaDataEmissionsCalc):
 
     def output_data(self, path_prefix: str):
         """
-            Run after process. 
-            Follows output_data format for results files. 
+            Run after process.
+            Follows output_data format for results files.
             Outputs per-ba consumed emissions and rate data
         """
         for ba in self.output_regions:
@@ -292,14 +290,14 @@ class HourlyBaDataEmissionsCalc(BaDataEmissionsCalc):
 
     def _replace_generation(self):
         """
-            Helper function to set up generation and rate data. 
-            1) Find list of regions to use 
-            2) Drop columns: all columns from regions we are not using, all generation columns 
+            Helper function to set up generation and rate data.
+            1) Find list of regions to use
+            2) Drop columns: all columns from regions we are not using, all generation columns
             3) Load default values from eGRID for zero rates (TODO: Fix once we know that zero rates are real)
-            4/5) Load hourly generation data into BaData structure using KEYS as columns 
+            4/5) Load hourly generation data into BaData structure using KEYS as columns
                  Load hourly rate data into rates data structure using `<ba>_<GENERATED_EMISSION_RATE_COLS>` as columns
 
-            TODO: make demand sum of generation and net interchange 
+            TODO: make demand sum of generation and net interchange
         """
 
         # 1: Find region list

--- a/src/data_pipeline.py
+++ b/src/data_pipeline.py
@@ -97,6 +97,7 @@ import os
 # import local modules
 # # Tell python where to look for modules.
 import sys
+
 sys.path.append("../../hourly-egrid/")
 import src.download_data as download_data
 import src.data_cleaning as data_cleaning
@@ -156,6 +157,7 @@ def main():
                 )
 
     # 1. Download data
+    ####################################################################################
     print("1. Downloading data")
     # PUDL
     download_data.download_pudl_data(
@@ -164,6 +166,7 @@ def main():
     # eGRID
     # the 2019 and 2020 data appear to be hosted on different urls
     egrid_files_to_download = [
+        "https://www.epa.gov/sites/default/files/2020-03/egrid2018_data_v2.xlsx",
         "https://www.epa.gov/sites/default/files/2021-02/egrid2019_data.xlsx",
         "https://www.epa.gov/system/files/documents/2022-01/egrid2020_data.xlsx",
     ]
@@ -181,6 +184,7 @@ def main():
     )
 
     # 2. Identify subplants
+    ####################################################################################
     print("2. Identifying subplant IDs")
     # GTN ratios are saved for reloading, as this is computationally intensive
     if not os.path.exists(f"../data/outputs/{year}/subplant_crosswalk.csv"):
@@ -191,9 +195,9 @@ def main():
         print("   Subplant IDs already created")
 
     # 3. Clean EIA-923 Generation and Fuel Data at the Monthly Level
+    ####################################################################################
     print("3. Cleaning EIA-923 data")
     eia923_allocated, primary_fuel_table = data_cleaning.clean_eia923(year, args.small)
-
     # Add primary fuel data to each generator
     eia923_allocated = eia923_allocated.merge(
         primary_fuel_table,
@@ -203,10 +207,12 @@ def main():
     )
 
     # 4. Clean Hourly Data from CEMS
+    ####################################################################################
     print("4. Cleaning CEMS data")
     cems = data_cleaning.clean_cems(year, args.small)
 
     # 5. Assign static characteristics to CEMS and EIA data to aid in aggregation
+    ####################################################################################
     print("5. Loading plant static attributes")
     plant_attributes = data_cleaning.create_plant_attributes_table(
         cems, eia923_allocated, year, primary_fuel_table
@@ -216,30 +222,36 @@ def main():
     )
 
     # 6. Convert CEMS Hourly Gross Generation to Hourly Net Generation
+    ####################################################################################
     print("6. Converting CEMS gross generation to net generation")
     cems, gtn_conversions = data_cleaning.convert_gross_to_net_generation(
         cems, eia923_allocated, plant_attributes
     )
-
     # export the gtn conversion data
     output_data.output_intermediate_data(
         gtn_conversions, "gross_to_net_conversions", path_prefix, year
     )
+
+    # 7. Adjust CEMS emission data for CHP and biomass
+    ####################################################################################
+    print("7. Adjusting CEMS emissions for CHP and biomass")
+    cems = data_cleaning.adjust_cems_emissions(cems, eia923_allocated)
     output_data.output_intermediate_data(cems, "cems", path_prefix, year)
 
-    # 7. Crosswalk CEMS and EIA data
-    print("7. Identifying source for hourly data")
+    # 8. Crosswalk CEMS and EIA data
+    ####################################################################################
+    print("8. Identifying source for hourly data")
     eia923_allocated = data_cleaning.identify_hourly_data_source(
         eia923_allocated, cems, year
     )
 
-    # 8. Calculate hourly data for partial_cems plants
-    print("8. Scaling partial CEMS data")
+    # 9. Calculate hourly data for partial_cems plants
+    ####################################################################################
+    print("9. Scaling partial CEMS data")
     (
         partial_cems_scaled,
         eia923_allocated,
     ) = impute_hourly_profiles.scale_partial_cems_data(cems, eia923_allocated)
-
     # Export data cleaned by above for later validation, visualization, analysis
     output_data.output_intermediate_data(
         eia923_allocated.drop(columns="plant_primary_fuel"),
@@ -251,21 +263,18 @@ def main():
         partial_cems_scaled, "partial_cems_scaled", path_prefix, year
     )
 
-    print("9. Exporting monthly and annual plant-level results")
-
+    ####################################################################################
+    print("10. Exporting monthly and annual plant-level results")
     # aggregate cems data to subplant level
     cems = data_cleaning.aggregate_cems_to_subplant(cems)
-
     # drop data from cems that is now in partial_cems
     cems = data_cleaning.filter_unique_cems_data(cems, partial_cems_scaled)
-
     # create a separate dataframe containing only the EIA data that is missing from cems
     monthly_eia_data_to_shape = eia923_allocated[
         (eia923_allocated["hourly_data_source"] == "eia")
         & ~(eia923_allocated["fuel_consumed_mmbtu"].isna())
     ]
     del eia923_allocated
-
     # combine and export plant data at monthly and annual level
     monthly_plant_data = data_cleaning.combine_plant_data(
         cems, partial_cems_scaled, monthly_eia_data_to_shape, "monthly"
@@ -274,8 +283,9 @@ def main():
     output_data.output_plant_data(monthly_plant_data, path_prefix, "annual")
     del monthly_plant_data
 
-    # 9. Clean and Reconcile EIA-930 data
-    print("10. Cleaning EIA-930 data")
+    # 11. Clean and Reconcile EIA-930 data
+    ####################################################################################
+    print("11. Cleaning EIA-930 data")
     # Scrapes and cleans data in data/downloads, outputs cleaned file at EBA_elec.csv
     if args.small or not (
         os.path.exists(f"../data/outputs/{path_prefix}/eia930/eia930_elec.csv")
@@ -296,9 +306,9 @@ def main():
     eia930_data = eia930.remove_imputed_ones(eia930_data)
     eia930_data = eia930.remove_months_with_zero_data(eia930_data)
 
-    # 10. Calculate hourly profiles for monthly EIA data
-    print("11. Estimating hourly residual generation profiles")
-    # 10. Calculate Residual Net Generation Profile
+    # 12. Calculate hourly profiles for monthly EIA data
+    ####################################################################################
+    print("12. Estimating hourly residual generation profiles")
     hourly_profiles = impute_hourly_profiles.calculate_hourly_profiles(
         cems,
         eia930_data,
@@ -309,16 +319,14 @@ def main():
         ba_column_name="ba_code",
     )
     del eia930_data
-
     output_data.output_intermediate_data(
         hourly_profiles, "hourly_profiles", path_prefix, year
     )
 
-    # 11. Assign hourly profile to monthly data
-    print("12. Assigning hourly profile to monthly EIA-923 data")
-
+    # 13. Assign hourly profile to monthly data
+    ####################################################################################
+    print("13. Assigning hourly profile to monthly EIA-923 data")
     hourly_profiles = impute_hourly_profiles.convert_profile_to_percent(hourly_profiles)
-
     # Aggregate EIA data to BA/fuel/month, then assign hourly profile per BA/fuel
     (
         monthly_eia_data_to_shape,
@@ -336,12 +344,12 @@ def main():
     plant_attributes.to_csv(
         f"../data/results/{path_prefix}plant_data/plant_static_attributes.csv"
     )
-
     # validate that the shaping did not alter data at the monthly level
     validation.validate_shaped_totals(shaped_eia_data, monthly_eia_data_to_shape)
 
-    # 12. Combine plant-level data from all sources
-    print("13. Combining and exporting plant-level hourly results")
+    # 14. Combine plant-level data from all sources
+    ####################################################################################
+    print("14. Combining and exporting plant-level hourly results")
     # write metadata and remove metadata columns
     cems, partial_cems_scaled, shaped_eia_data = output_data.write_plant_metadata(
         cems, partial_cems_scaled, shaped_eia_data, path_prefix
@@ -350,25 +358,24 @@ def main():
         cems, partial_cems_scaled, shaped_eia_data, "hourly"
     )
     del shaped_eia_data, cems, partial_cems_scaled  # free memory back to python
-
     # export to a csv.
     output_data.output_plant_data(combined_plant_data, path_prefix, "hourly")
 
-    # 13. Aggregate CEMS data to BA-fuel and write power sector results
-    print("14. Creating and exporting BA-level power sector results")
+    # 15. Aggregate CEMS data to BA-fuel and write power sector results
+    ####################################################################################
+    print("15. Creating and exporting BA-level power sector results")
     ba_fuel_data = data_cleaning.aggregate_plant_data_to_ba_fuel(
         combined_plant_data, plant_attributes
     )
     del combined_plant_data
-
     # Output intermediate data: produced per-fuel annual averages
     output_data.write_generated_averages(ba_fuel_data, year, path_prefix)
-
     # Output final data: per-ba hourly generation and rate
     output_data.write_power_sector_results(ba_fuel_data, path_prefix)
 
-    # 14. Calculate consumption-based emissions and write carbon accounting results
-    print("15. Calculating and exporting consumption-based results")
+    # 16. Calculate consumption-based emissions and write carbon accounting results
+    ####################################################################################
+    print("16. Calculating and exporting consumption-based results")
     hourly_consumed_calc = consumed.HourlyBaDataEmissionsCalc(
         clean_930_file, small=args.small, path_prefix=path_prefix,
     )

--- a/src/download_data.py
+++ b/src/download_data.py
@@ -204,4 +204,3 @@ def download_epa_psdc(psdc_url):
         with open(f"../data/downloads/epa/{filename}", "wb") as fd:
             for chunk in r.iter_content(chunk_size=1024):
                 fd.write(chunk)
-

--- a/src/eia930.py
+++ b/src/eia930.py
@@ -1,17 +1,15 @@
 import pandas as pd
 import re
 from datetime import timedelta
-import src.data_cleaning as data_cleaning
 import src.load_data as load_data
 from src.column_checks import get_dtypes
 import os
-from os.path import join, exists
+from os.path import join
 
 # Tell gridemissions where to find config before we load gridemissions
 os.environ["GRIDEMISSIONS_CONFIG_FILE_PATH"] = "../config/gridemissions.json"
 
 from gridemissions.workflows import make_dataset
-from gridemissions.eia_api import EBA_data_scraper, load_eia_columns
 
 
 def balance_to_gridemissions(year: int, small: bool = False):
@@ -119,9 +117,9 @@ def balance_to_gridemissions(year: int, small: bool = False):
 
 def clean_930(year: int, small: bool = False, path_prefix: str = ""):
     """
-        Scrape and process EIA data. 
-    
-    Arguments: 
+        Scrape and process EIA data.
+
+    Arguments:
         `year`: Year to process. Prior years, downloaded from chalendar-hosted files, are used for rolling cleaning
 
     """
@@ -141,14 +139,14 @@ def clean_930(year: int, small: bool = False, path_prefix: str = ""):
         df = df.loc[start:end]  # Don't worry about processing everything
 
     # Adjust
-    print("Adjusting EIA-930 time stamps")
+    print("   Adjusting EIA-930 time stamps")
     df = manual_930_adjust(df)
     df.to_csv(
         join(data_folder, "eia930_raw.csv")
     )  # Will be read by gridemissions workflow
 
     # Run cleaning
-    print("Running physics-based data cleaning")
+    print("   Running physics-based data cleaning")
     make_dataset(
         start,
         end,
@@ -393,7 +391,7 @@ def manual_930_adjust(raw: pd.DataFrame):
             - PJM: + 1 hour
             - CISO: + 1 hour
             - TEPC: + 1 hour
-            - SC: -4 hours during daylight savings hours; -5 hours during 
+            - SC: -4 hours during daylight savings hours; -5 hours during
                 standard hours (this happens to = the Eastern <-> UTC offset)
         - Interchange
             - PJM: + 4 hours
@@ -404,7 +402,7 @@ def manual_930_adjust(raw: pd.DataFrame):
                     Oct 31, 2019, 4:00 UTC
                 - this is all interchange partners except OVEC, and excluding
                     total interchange
-            - PJM-OVEC, all time. Based on OVEC demand - generation, OVEC 
+            - PJM-OVEC, all time. Based on OVEC demand - generation, OVEC
                 should be a net exporter to PJM
                 - Note: OVEC's data repeats daily starting in 2018...
     - Make all start-of-hour

--- a/src/gross_to_net_generation.py
+++ b/src/gross_to_net_generation.py
@@ -19,7 +19,7 @@ def identify_subplants(year, number_of_years):
     start_year = year - (number_of_years - 1)
     end_year = year
 
-    print("Creating subplant IDs")
+    print("   Creating subplant IDs")
     # load 5 years of monthly data from CEMS and EIA-923
     cems_monthly, gen_fuel_allocated = load_monthly_gross_and_net_generation(
         start_year, end_year
@@ -69,7 +69,10 @@ def calculate_gtn_conversions(year, number_of_years):
 
     # calculate monthly ratios at plant level
     gross_to_net_ratio(
-        gross_gen_data=cems_monthly, net_gen_data=gen_fuel_allocated, agg_level="plant", year=year,
+        gross_gen_data=cems_monthly,
+        net_gen_data=gen_fuel_allocated,
+        agg_level="plant",
+        year=year,
     )
 
 
@@ -89,7 +92,7 @@ def load_monthly_gross_and_net_generation(start_year, end_year):
     )
 
     # allocate net generation and heat input to each generator-fuel grouping
-    print("Allocating EIA-923 generation data")
+    print("   Allocating EIA-923 generation data")
     gen_fuel_allocated = allocate_gen_fuel.allocate_gen_fuel_by_generator_energy_source(
         pudl_out, drop_interim_cols=True
     )
@@ -106,7 +109,7 @@ def load_cems_gross_generation(start_year, end_year):
     cems_all = []
 
     for year in range(start_year, end_year + 1):
-        print(f"loading {year} CEMS data")
+        print(f"   loading {year} CEMS data")
         # specify the path to the CEMS data
         cems_path = f"../data/downloads/pudl/pudl_data/parquet/epacems/year={year}"
 
@@ -233,7 +236,6 @@ def generate_subplant_ids(start_year, end_year, cems_monthly, gen_fuel_allocated
     Returns:
         exports the subplant crosswalk to a csv file
         cems_monthly and gen_fuel_allocated with subplant_id added
-    
     """
 
     ids = cems_monthly[["plant_id_eia", "unitid", "unit_id_epa"]].drop_duplicates()
@@ -503,7 +505,7 @@ def model_gross_to_net(df):
     """
     Performs a linear regression model of monthly gross to net generation.
 
-    Performs recursive outlier removal up to two times if the absolute value of 
+    Performs recursive outlier removal up to two times if the absolute value of
     the studentizes residual > 3
 
     Args:
@@ -581,4 +583,3 @@ def model_gross_to_net(df):
 
         except ValueError:
             pass
-

--- a/src/validation.py
+++ b/src/validation.py
@@ -24,6 +24,7 @@ def load_egrid_plant_file(year):
             "UNCO2",
             "UNHTIT",
             "PLCO2AN",
+            "CHPFLAG",
         ],
     )
     # calculate total net generation from reported renewable and nonrenewable generation
@@ -43,6 +44,7 @@ def load_egrid_plant_file(year):
             "PLHTIANT": "fuel_consumed_for_electricity_mmbtu",
             "UNCO2": "co2_mass_lb",  # this is actually in tons, but we are converting in the next step
             "PLCO2AN": "co2_mass_lb_adjusted",  # this is actually in tons, but we are converting in the next step
+            "CHPFLAG": "chp_flag",
         }
     )
 
@@ -75,6 +77,7 @@ def load_egrid_plant_file(year):
             "plant_id_egrid",
             "plant_name",
             "plant_primary_fuel",
+            "chp_flag",
             "net_generation_mwh",
             "fuel_consumed_mmbtu",
             "fuel_consumed_for_electricity_mmbtu",
@@ -602,3 +605,447 @@ def validate_shaped_totals(shaped_eia_data, monthly_eia_data_to_shape):
             "The EIA process is changing the monthly total values compared to reported EIA values. This process should only shape the data, not alter it."
         )
 
+
+def compare_plant_level_results_to_egrid(
+    plant_data, egrid_plant, PLANTS_MISSING_FROM_EGRID
+):
+    # standardize column names and index so that the two dfs can be divided
+    calculated_to_compare = (
+        plant_data.groupby("plant_id_egrid", dropna=False)
+        .sum()
+        .drop(columns=["plant_id_eia"])
+    )
+
+    # drop the plants that have no data in eGRID
+    plants_with_no_data_in_egrid = list(
+        egrid_plant[
+            egrid_plant[
+                [
+                    "net_generation_mwh",
+                    "fuel_consumed_mmbtu",
+                    "fuel_consumed_for_electricity_mmbtu",
+                    "co2_mass_lb",
+                    "co2_mass_lb_adjusted",
+                ]
+            ].sum(axis=1)
+            == 0
+        ]["plant_id_egrid"]
+    )
+    egrid_plant = egrid_plant[
+        ~egrid_plant["plant_id_eia"].isin(plants_with_no_data_in_egrid)
+    ]
+
+    egrid_to_compare = egrid_plant.set_index(["plant_id_egrid"]).drop(
+        columns=["ba_code", "state", "plant_name", "plant_id_eia"]
+    )
+    # only keep plants that are in the comparison data
+    egrid_to_compare = egrid_to_compare[
+        egrid_to_compare.index.isin(list(calculated_to_compare.index.unique()))
+    ]
+
+    # divide calculated value by egrid value
+    compared = (
+        calculated_to_compare.div(egrid_to_compare)
+        .merge(
+            egrid_plant[["plant_id_egrid", "plant_name", "ba_code", "state"]],
+            how="left",
+            left_index=True,
+            right_on="plant_id_egrid",
+        )
+        .set_index("plant_id_egrid")
+    )
+    compared["plant_name"] = compared["plant_name"].fillna("unknown")
+
+    # create a dataframe that merges the two sources of data together
+    compared_merged = calculated_to_compare.merge(
+        egrid_to_compare, how="left", on="plant_id_egrid", suffixes=("_calc", "_egrid")
+    )
+
+    # for each column, change missing values to zero if both values are zero (only nan b/c divide by zero)
+    for col in [
+        "net_generation_mwh",
+        "fuel_consumed_mmbtu",
+        "fuel_consumed_for_electricity_mmbtu",
+        "co2_mass_lb_adjusted",
+        "co2_mass_lb",
+    ]:
+        # identify plants with zero values for both
+        plant_ids = list(
+            compared_merged[
+                (compared_merged[f"{col}_calc"] == 0)
+                & (compared_merged[f"{col}_egrid"] == 0)
+            ].index
+        )
+        compared.loc[compared.index.isin(plant_ids), col] = 1
+
+    # for each column, categorize the data based on how far it is off from egrid
+    for col in [
+        "net_generation_mwh",
+        "fuel_consumed_mmbtu",
+        "fuel_consumed_for_electricity_mmbtu",
+        "co2_mass_lb_adjusted",
+        "co2_mass_lb",
+    ]:
+        # add a new column
+        compared[f"{col}_status"] = pd.cut(
+            x=compared[col],
+            bins=[
+                -999999999,
+                -0.0001,
+                0.5,
+                0.9,
+                0.99,
+                0.9999,
+                1,
+                1.0001,
+                1.01,
+                1.1,
+                1.5,
+                999999999,
+            ],
+            labels=[
+                "negative",
+                "<50%",
+                "-50% to -10%",
+                "-10% to -1%",
+                "+/-1%",
+                "!exact",
+                "!exact",
+                "+/-1%",
+                "+1% to 10%",
+                "+10% to 50%",
+                ">50%",
+            ],
+            ordered=False,
+        )
+        # replace any missing values with missing
+        compared[f"{col}_status"] = compared[f"{col}_status"].astype(str)
+        compared[f"{col}_status"] = compared[f"{col}_status"].fillna("missing")
+        compared[f"{col}_status"] = compared[f"{col}_status"].replace("nan", "missing")
+        compared.loc[
+            (compared.index.isin(PLANTS_MISSING_FROM_EGRID)), f"{col}_status"
+        ] = "not_in_egrid"
+
+        # identify which plants are missing from egrid vs calculated values
+    for col in [
+        "net_generation_mwh",
+        "fuel_consumed_mmbtu",
+        "fuel_consumed_for_electricity_mmbtu",
+        "co2_mass_lb_adjusted",
+        "co2_mass_lb",
+    ]:
+        # identify plants that are missing in egrid
+        plants_missing_egrid = list(
+            compared_merged[
+                (compared_merged[f"{col}_calc"] > 0)
+                & (compared_merged[f"{col}_egrid"].isna())
+            ].index
+        )
+        compared.loc[
+            compared.index.isin(plants_missing_egrid), f"{col}_status"
+        ] = "missing_in_egrid"
+        # identify plants that are missing from our calculations
+        plants_missing_calc = list(
+            compared_merged[
+                (compared_merged[f"{col}_calc"].isna())
+                & (compared_merged[f"{col}_egrid"] > 0)
+            ].index
+        )
+        compared.loc[
+            compared.index.isin(plants_missing_calc), f"{col}_status"
+        ] = "missing_in_calc"
+        # identify where our calculations are missing a zero value
+        plants_missing_zero_calc = list(
+            compared_merged[
+                (compared_merged[f"{col}_calc"].isna())
+                & (compared_merged[f"{col}_egrid"] == 0)
+            ].index
+        )
+        compared.loc[
+            compared.index.isin(plants_missing_zero_calc), f"{col}_status"
+        ] = "calc_missing_zero_value_from_egrid"
+        # identify where egrid has a missing value instead of a zero
+        plants_missing_zero_egrid = list(
+            compared_merged[
+                (compared_merged[f"{col}_calc"] == 0)
+                & (compared_merged[f"{col}_egrid"].isna())
+            ].index
+        )
+        compared.loc[
+            compared.index.isin(plants_missing_zero_egrid), f"{col}_status"
+        ] = "egrid_missing_zero_value_from_calc"
+        # identify where egrid has a zero value where we have a positive value
+        plants_incorrect_zero_egrid = list(
+            compared_merged[
+                (compared_merged[f"{col}_calc"] > 0)
+                & (compared_merged[f"{col}_egrid"] == 0)
+            ].index
+        )
+        compared.loc[
+            compared.index.isin(plants_incorrect_zero_egrid), f"{col}_status"
+        ] = "calc_positive_but_egrid_zero"
+
+    # create a dataframe that counts how many plants are in each category
+    comparison_count = []
+    for col in [
+        "net_generation_mwh",
+        "fuel_consumed_mmbtu",
+        "fuel_consumed_for_electricity_mmbtu",
+        "co2_mass_lb_adjusted",
+        "co2_mass_lb",
+    ]:
+        count = (
+            compared.groupby(f"{col}_status", dropna=False)
+            .count()["plant_name"]
+            .rename(col)
+        )
+        count.index = count.index.rename("status")
+        comparison_count.append(count)
+
+    comparison_count = pd.concat(comparison_count, axis=1).fillna(0).astype(int)
+    comparison_count = pd.concat(
+        [comparison_count, pd.DataFrame(comparison_count.sum().rename("Total")).T],
+        axis=0,
+    )
+    return comparison_count, compared
+
+
+def identify_plants_missing_from_our_calculations(
+    egrid_plant, annual_plant_results, year
+):
+    # identify any plants that are in egrid but not our totals, and any plants that are in our totals, but not egrid
+    PLANTS_MISSING_FROM_CALCULATION = list(
+        set(egrid_plant["plant_id_eia"].unique())
+        - set(annual_plant_results["plant_id_eia"].unique())
+    )
+
+    # Which plants are included in eGRID but are missing from our calculations?
+    missing_from_calc = egrid_plant[
+        egrid_plant["plant_id_egrid"].isin(PLANTS_MISSING_FROM_CALCULATION)
+    ]
+
+    # see if any of these plants are retired
+    generators_eia860 = load_data.load_pudl_table("generators_eia860", year=year)
+    missing_from_calc.merge(
+        generators_eia860[
+            [
+                "plant_id_eia",
+                "operational_status",
+                "current_planned_operating_date",
+                "retirement_date",
+            ]
+        ].drop_duplicates(),
+        how="left",
+        on="plant_id_eia",
+    )
+
+    return missing_from_calc, PLANTS_MISSING_FROM_CALCULATION
+
+
+def identify_plants_missing_from_egrid(egrid_plant, annual_plant_results):
+    # Which plants are in our calculations, but are missing from eGRID?
+    PLANTS_MISSING_FROM_EGRID = list(
+        set(annual_plant_results["plant_id_egrid"].unique())
+        - set(egrid_plant["plant_id_egrid"].unique())
+    )
+
+    plant_names = load_data.load_pudl_table("plants_entity_eia")[
+        ["plant_id_eia", "plant_name_eia", "sector_name_eia"]
+    ]
+    missing_from_egrid = annual_plant_results[
+        annual_plant_results["plant_id_egrid"].isin(PLANTS_MISSING_FROM_EGRID)
+    ].merge(plant_names, how="left", on="plant_id_eia")
+
+    return missing_from_egrid, PLANTS_MISSING_FROM_EGRID
+
+
+def segment_plants_by_known_issues(
+    annual_plant_results,
+    egrid_plant,
+    eia923_allocated,
+    pudl_out,
+    PLANTS_MISSING_FROM_EGRID,
+):
+    all_other_plants = annual_plant_results.copy()
+
+    # missing plants
+    missing_plants = annual_plant_results[
+        annual_plant_results["plant_id_eia"].isin(PLANTS_MISSING_FROM_EGRID)
+    ]
+    all_other_plants = all_other_plants[
+        ~all_other_plants["plant_id_eia"].isin(
+            list(missing_plants.plant_id_eia.unique())
+        )
+    ]
+
+    # geothermal
+    geothermal_plants = annual_plant_results[
+        annual_plant_results["plant_primary_fuel"] == "GEO"
+    ]
+    all_other_plants = all_other_plants[
+        ~all_other_plants["plant_id_eia"].isin(
+            list(geothermal_plants.plant_id_eia.unique())
+        )
+    ]
+
+    # nuclear
+    nuclear_plants = annual_plant_results[
+        annual_plant_results["plant_primary_fuel"] == "NUC"
+    ]
+    all_other_plants = all_other_plants[
+        ~all_other_plants["plant_id_eia"].isin(
+            list(nuclear_plants.plant_id_eia.unique())
+        )
+    ]
+
+    # fuel cells
+    gens_eia860 = pudl_out.gens_eia860()
+    PLANTS_WITH_FUEL_CELLS = list(
+        gens_eia860.loc[
+            gens_eia860["prime_mover_code"] == "FC", "plant_id_eia"
+        ].unique()
+    )
+    fuel_cell_plants = annual_plant_results[
+        annual_plant_results["plant_id_eia"].isin(PLANTS_WITH_FUEL_CELLS)
+    ]
+    all_other_plants = all_other_plants[
+        ~all_other_plants["plant_id_eia"].isin(
+            list(fuel_cell_plants.plant_id_eia.unique())
+        )
+    ]
+
+    # ozone season reporters
+    # identify all of the plants with generators that report data from both EIA and CEMS
+    multi_source_reporters = eia923_allocated[
+        ["plant_id_eia", "generator_id", "hourly_data_source"]
+    ].drop_duplicates()
+    MULTI_SOURCE_PLANTS = list(
+        multi_source_reporters.loc[
+            multi_source_reporters.duplicated(
+                subset=["plant_id_eia", "generator_id"], keep=False
+            ),
+            "plant_id_eia",
+        ].unique()
+    )
+    ozone_season_plants = annual_plant_results[
+        annual_plant_results["plant_id_eia"].isin(MULTI_SOURCE_PLANTS)
+    ]
+    all_other_plants = all_other_plants[
+        ~all_other_plants["plant_id_eia"].isin(
+            list(ozone_season_plants.plant_id_eia.unique())
+        )
+    ]
+
+    # CHP plants
+    PLANTS_WITH_CHP = list(
+        egrid_plant.loc[egrid_plant["chp_flag"] == "Yes", "plant_id_eia"].unique()
+    )
+    chp_plants = annual_plant_results[
+        annual_plant_results["plant_id_eia"].isin(PLANTS_WITH_CHP)
+    ]
+    all_other_plants = all_other_plants[
+        ~all_other_plants["plant_id_eia"].isin(list(chp_plants.plant_id_eia.unique()))
+    ]
+
+    return (
+        missing_plants,
+        geothermal_plants,
+        nuclear_plants,
+        fuel_cell_plants,
+        ozone_season_plants,
+        chp_plants,
+        all_other_plants,
+    )
+
+
+def identify_potential_missing_fuel_in_egrid(pudl_out, year, egrid_plant):
+    # load the EIA generator fuel data
+    IDX_PM_ESC = [
+        "report_date",
+        "plant_id_eia",
+        "energy_source_code",
+        "prime_mover_code",
+    ]
+    gf = pudl_out.gf_eia923().loc[
+        :,
+        IDX_PM_ESC
+        + [
+            "net_generation_mwh",
+            "fuel_consumed_mmbtu",
+            "fuel_consumed_for_electricity_mmbtu",
+        ],
+    ]
+
+    # add egrid plant ids
+    egrid_crosswalk = pd.read_csv(
+        "../data/manual/egrid_static_tables/table_C5_crosswalk_of_EIA_ID_to_EPA_ID.csv"
+    )
+    eia_to_egrid_id = dict(
+        zip(
+            list(egrid_crosswalk["plant_id_eia"]),
+            list(egrid_crosswalk["plant_id_egrid"]),
+        )
+    )
+    gf["plant_id_egrid"] = gf["plant_id_eia"]
+    gf["plant_id_egrid"].update(gf["plant_id_egrid"].map(eia_to_egrid_id))
+
+    # calculate an annual total for each plant
+    gf_total = gf.groupby(["plant_id_egrid"]).sum().reset_index()
+
+    # choose a metric to compare
+    metric = "fuel_consumed_mmbtu"
+
+    # merge the annual EIA-923 data into the egrid data
+    egrid_eia_comparison = (
+        egrid_plant[
+            ["plant_id_egrid", "plant_name", "ba_code", "plant_primary_fuel", metric]
+        ]
+        .merge(
+            gf_total[["plant_id_egrid", metric]],
+            how="outer",
+            on="plant_id_egrid",
+            suffixes=("_egrid", "_eia923"),
+            indicator="source",
+        )
+        .round(0)
+    )
+    egrid_eia_comparison[f"{metric}_egrid"] = egrid_eia_comparison[
+        f"{metric}_egrid"
+    ].fillna(0)
+    # calculate an absolute difference and percent difference between the two values
+    egrid_eia_comparison["difference"] = (
+        egrid_eia_comparison[f"{metric}_egrid"]
+        - egrid_eia_comparison[f"{metric}_eia923"]
+    )
+    egrid_eia_comparison["percent_difference"] = (
+        egrid_eia_comparison[f"{metric}_egrid"]
+        - egrid_eia_comparison[f"{metric}_eia923"]
+    ) / egrid_eia_comparison[f"{metric}_eia923"]
+    egrid_eia_comparison.loc[
+        egrid_eia_comparison["difference"] == 0, "percent_difference"
+    ] = 0
+
+    # add cems data so that we can compare fuel totals
+    cems = pd.read_csv(
+        f"../data/outputs/{year}/cems_{year}.csv",
+        dtype=get_dtypes(),
+        parse_dates=["report_date"],
+    )
+    cems_total = cems.copy()[["plant_id_eia", metric]]
+    cems_total["plant_id_egrid"] = cems_total["plant_id_eia"]
+    cems_total["plant_id_egrid"].update(
+        cems_total["plant_id_egrid"].map(eia_to_egrid_id)
+    )
+    cems_total = (
+        cems_total.groupby("plant_id_egrid")
+        .sum()[metric]
+        .reset_index()
+        .rename(columns={metric: f"{metric}_cems"})
+    )
+
+    # merge cems data into egrid
+    egrid_eia_comparison = egrid_eia_comparison.merge(
+        cems_total, how="outer", on="plant_id_egrid"
+    )
+
+    return egrid_eia_comparison

--- a/src/visualization.py
+++ b/src/visualization.py
@@ -2,7 +2,6 @@
 Helper functions for visualization
 
 """
-import numpy as np
 import pandas as pd
 
 """


### PR DESCRIPTION
This PR closes https://github.com/singularity-energy/hourly-egrid/issues/103

We had been assuming that the reported hourly steam load reported in CEMS represented steam that was used for heating (as part of a CHP plant) and not for electricity generation. However, a more careful read of the EPA [power sector data user guide](https://www.epa.gov/sites/default/files/2020-02/documents/camds_power_sector_emissions_data_user_guide.pdf) suggests that this steam could just represent steam generated as part of a combined cycle turbine. Thus, we will no longer use CEMS-reported steam data to inform our CHP allocation.

### Calculating Fuel Consumed for Electricity
Previously, our approach had calculated this based on the heat-content (mmbtu) weighted ratio between `gross_generation_mwh` and `steam_load_1000lb` in each hour. However, this approach assumed that steam load represented thermal output, and that none of it was used in combined-cycle power generation. 

Our new approach uses the data in EIA-923 and appears to be more consistent with the methodology used by eGRID. Our specific steps are to:
        1. Calculate the ratio between `fuel_consumed_for_electricity_mmbtu` and `fuel_consumed_mmbtu` in EIA-923 for each subplant-month
        2. Calculate the same ratio at the plant-month level instead of the subplant-month level
        3. Merge these fuel ratios into the CEMS data
        4. Use this ratio to calculate a `fuel_consumed_for_electricity_mmbtu` from the `fuel_consumed_mmbtu` data reported in CEMS. If available, we use the subplant-month specific ratio. Otherwise, we use the plant-month specific ratio. Otherwise, we assume a ratio of 1 (essentially that there is no allocation to heat output).

### Calculating the electric allocation factor and adjusted emissions
This approach remains mostly the same as before. However, previously, we had used the CEMS gross generation in the electric allocation factor formula, instead of using net generation, as is used when doing this calculation for the EIA-923 data. To ensure greater consistency, we now use the net generation number instead of gross generation. This means that we had to move these adjustment calculations out of `data_cleaning.clean_cems()` and into a separate function that is executed after we calculate net generation for the CEMS data. 

### Calculating adjusted fuel consumption for electricity
So it turns out that eGRID not only adjusts emissions using the electric allocation factor, but also re-calculates `fuel_consumed_for_electricity` as well by multiplying the electric allocation factor by the total fuel consumption. 

### Cleaning zero-reported data in CEMS
Previously we had been removing data for unit-months in CEMS that reported all zeros for the entire month. We had defined this as if all of the gross generation, fuel consumption, and co2/nox/so2 data was zero. However, we found that there are certain units that report non-zero nox data but zeros for all other columns, resulting in our totals undercounting fuel and emissions data because it thought there was complete CEMS data. To fix this, we now remove unit-months from CEMS if only the gross generation and fuel consumption is zero for the entire month. Although we lose some measured NOx data for a small number of unit-months, these totals can be calculated using the EIA-932 data. 

### Other updates
- updates the egrid validation notebook to finish out work on https://github.com/singularity-energy/hourly-egrid/issues/62
- fixes formatting/linting issues in all src files
