### PR TITLE
fix dropped data

### DIFF
--- a/src/eia930.py
+++ b/src/eia930.py
@@ -320,6 +320,7 @@ def remove_months_with_zero_data(eia930_data):
         how="outer",
         on=["ba_code", "fuel_category_eia930", "report_date"],
         indicator="zero_filter",
+        validate="m:1",
     )
     eia930_data = eia930_data[eia930_data["zero_filter"] == "left_only"].drop(
         columns="zero_filter"

--- a/src/gross_to_net_generation.py
+++ b/src/gross_to_net_generation.py
@@ -48,12 +48,8 @@ def convert_gross_to_net_generation(cems, eia923_allocated, plant_attributes, ye
         ],
         how="left",
         on=["plant_id_eia", "subplant_id", "report_date"],
+        validate="m:1",
     )
-
-    """units_in_subplant = count_cems_units_in_subplant(cems)
-    cems = cems.merge(
-        units_in_subplant, how="left", on=["plant_id_eia", "subplant_id", "report_date"]
-    )"""
 
     cems["gtn_method"] = "1_annual_subplant_shift_factor"
     cems["net_generation_mwh"] = (
@@ -121,7 +117,7 @@ def calculate_gross_to_net_conversion_factors(
             "datetime_utc",
             "gross_generation_mwh",
         ]
-    ]
+    ].copy()
     # identify the 2nd percentile lowest hourly gross generation value in a month
     min_gross = (
         gross_gen_data.groupby(

--- a/src/impute_hourly_profiles.py
+++ b/src/impute_hourly_profiles.py
@@ -895,7 +895,7 @@ def aggregate_eia_data_to_ba_fuel(
     )
 
     # Add BA code and fuel type for synthetic plants into plant_attributes.
-    plant_attributes.merge(
+    plant_attributes = plant_attributes.merge(
         synthetic_id_map, how="left", on="plant_id_eia", validate="1:1"
     )
 
@@ -971,7 +971,7 @@ def shape_partial_cems_data(cems, eia923_allocated):
     SUBPLANT_KEYS = ["report_date", "plant_id_eia", "subplant_id"]
 
     # identify all of the partial cems plants and group by subplant-month
-    eia_data_to_shape = eia923_allocated.loc[
+    eia_data_to_shape = eia923_allocated.copy().loc[
         eia923_allocated.hourly_data_source == "partial_cems"
     ]
     # if there is no data in the partial cems dataframe, skip.


### PR DESCRIPTION
This PR fixes an issue where all of the synthetic plant data was being dropped from the final power sector results due to changes in how synthetic plant ids were being added to the plant attributes table. 

Also adds a validation check so that this should not be able to happen without being flagged.

Updates a few other small bits and pieces.