### PR TITLE
investigate annually-reported data

### DIFF
--- a/notebooks/explore_data/explore_annually_reported_eia_data.ipynb
+++ b/notebooks/explore_data/explore_annually_reported_eia_data.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -20,7 +20,7 @@
     "import load_data\n",
     "from filepaths import *\n",
     "\n",
-    "year = 2019\n",
+    "year = 2020\n",
     "path_prefix = f\"{year}/\""
    ]
   },
@@ -33,27 +33,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "FileNotFoundError",
-     "evalue": "[Errno 2] No such file or directory: 'A:\\\\GitHub\\\\open-grid-emissions\\\\data\\\\outputs\\\\2019//eia923_allocated_2019.csv'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[1;31mFileNotFoundError\u001b[0m                         Traceback (most recent call last)",
-      "\u001b[1;32ma:\\GitHub\\open-grid-emissions\\notebooks\\explore_data\\explore_annually_reported_eia_data.ipynb Cell 3\u001b[0m in \u001b[0;36m<cell line: 6>\u001b[1;34m()\u001b[0m\n\u001b[0;32m      <a href='vscode-notebook-cell:/a%3A/GitHub/open-grid-emissions/notebooks/explore_data/explore_annually_reported_eia_data.ipynb#W1sZmlsZQ%3D%3D?line=2'>3</a>\u001b[0m plant_frequency \u001b[39m=\u001b[39m pudl_out\u001b[39m.\u001b[39mplants_eia860()[[\u001b[39m\"\u001b[39m\u001b[39mplant_id_eia\u001b[39m\u001b[39m\"\u001b[39m,\u001b[39m\"\u001b[39m\u001b[39mrespondent_frequency\u001b[39m\u001b[39m\"\u001b[39m]]\n\u001b[0;32m      <a href='vscode-notebook-cell:/a%3A/GitHub/open-grid-emissions/notebooks/explore_data/explore_annually_reported_eia_data.ipynb#W1sZmlsZQ%3D%3D?line=4'>5</a>\u001b[0m \u001b[39m# load the allocated EIA data\u001b[39;00m\n\u001b[1;32m----> <a href='vscode-notebook-cell:/a%3A/GitHub/open-grid-emissions/notebooks/explore_data/explore_annually_reported_eia_data.ipynb#W1sZmlsZQ%3D%3D?line=5'>6</a>\u001b[0m eia923_allocated \u001b[39m=\u001b[39m pd\u001b[39m.\u001b[39;49mread_csv(\u001b[39mf\u001b[39;49m\u001b[39m'\u001b[39;49m\u001b[39m{\u001b[39;49;00moutputs_folder()\u001b[39m}\u001b[39;49;00m\u001b[39m{\u001b[39;49;00mpath_prefix\u001b[39m}\u001b[39;49;00m\u001b[39m/eia923_allocated_\u001b[39;49m\u001b[39m{\u001b[39;49;00myear\u001b[39m}\u001b[39;49;00m\u001b[39m.csv\u001b[39;49m\u001b[39m'\u001b[39;49m, dtype\u001b[39m=\u001b[39;49mget_dtypes(), parse_dates\u001b[39m=\u001b[39;49m[\u001b[39m'\u001b[39;49m\u001b[39mreport_date\u001b[39;49m\u001b[39m'\u001b[39;49m])\n\u001b[0;32m      <a href='vscode-notebook-cell:/a%3A/GitHub/open-grid-emissions/notebooks/explore_data/explore_annually_reported_eia_data.ipynb#W1sZmlsZQ%3D%3D?line=6'>7</a>\u001b[0m eia923_allocated \u001b[39m=\u001b[39m eia923_allocated\u001b[39m.\u001b[39mmerge(plant_frequency, how\u001b[39m=\u001b[39m\u001b[39m\"\u001b[39m\u001b[39mleft\u001b[39m\u001b[39m\"\u001b[39m, on\u001b[39m=\u001b[39m\u001b[39m\"\u001b[39m\u001b[39mplant_id_eia\u001b[39m\u001b[39m\"\u001b[39m, validate\u001b[39m=\u001b[39m\u001b[39m\"\u001b[39m\u001b[39mm:1\u001b[39m\u001b[39m\"\u001b[39m)\n",
-      "File \u001b[1;32ma:\\miniconda3\\envs\\hourly_egrid\\lib\\site-packages\\pandas\\util\\_decorators.py:311\u001b[0m, in \u001b[0;36mdeprecate_nonkeyword_arguments.<locals>.decorate.<locals>.wrapper\u001b[1;34m(*args, **kwargs)\u001b[0m\n\u001b[0;32m    305\u001b[0m \u001b[39mif\u001b[39;00m \u001b[39mlen\u001b[39m(args) \u001b[39m>\u001b[39m num_allow_args:\n\u001b[0;32m    306\u001b[0m     warnings\u001b[39m.\u001b[39mwarn(\n\u001b[0;32m    307\u001b[0m         msg\u001b[39m.\u001b[39mformat(arguments\u001b[39m=\u001b[39marguments),\n\u001b[0;32m    308\u001b[0m         \u001b[39mFutureWarning\u001b[39;00m,\n\u001b[0;32m    309\u001b[0m         stacklevel\u001b[39m=\u001b[39mstacklevel,\n\u001b[0;32m    310\u001b[0m     )\n\u001b[1;32m--> 311\u001b[0m \u001b[39mreturn\u001b[39;00m func(\u001b[39m*\u001b[39margs, \u001b[39m*\u001b[39m\u001b[39m*\u001b[39mkwargs)\n",
-      "File \u001b[1;32ma:\\miniconda3\\envs\\hourly_egrid\\lib\\site-packages\\pandas\\io\\parsers\\readers.py:680\u001b[0m, in \u001b[0;36mread_csv\u001b[1;34m(filepath_or_buffer, sep, delimiter, header, names, index_col, usecols, squeeze, prefix, mangle_dupe_cols, dtype, engine, converters, true_values, false_values, skipinitialspace, skiprows, skipfooter, nrows, na_values, keep_default_na, na_filter, verbose, skip_blank_lines, parse_dates, infer_datetime_format, keep_date_col, date_parser, dayfirst, cache_dates, iterator, chunksize, compression, thousands, decimal, lineterminator, quotechar, quoting, doublequote, escapechar, comment, encoding, encoding_errors, dialect, error_bad_lines, warn_bad_lines, on_bad_lines, delim_whitespace, low_memory, memory_map, float_precision, storage_options)\u001b[0m\n\u001b[0;32m    665\u001b[0m kwds_defaults \u001b[39m=\u001b[39m _refine_defaults_read(\n\u001b[0;32m    666\u001b[0m     dialect,\n\u001b[0;32m    667\u001b[0m     delimiter,\n\u001b[1;32m   (...)\u001b[0m\n\u001b[0;32m    676\u001b[0m     defaults\u001b[39m=\u001b[39m{\u001b[39m\"\u001b[39m\u001b[39mdelimiter\u001b[39m\u001b[39m\"\u001b[39m: \u001b[39m\"\u001b[39m\u001b[39m,\u001b[39m\u001b[39m\"\u001b[39m},\n\u001b[0;32m    677\u001b[0m )\n\u001b[0;32m    678\u001b[0m kwds\u001b[39m.\u001b[39mupdate(kwds_defaults)\n\u001b[1;32m--> 680\u001b[0m \u001b[39mreturn\u001b[39;00m _read(filepath_or_buffer, kwds)\n",
-      "File \u001b[1;32ma:\\miniconda3\\envs\\hourly_egrid\\lib\\site-packages\\pandas\\io\\parsers\\readers.py:575\u001b[0m, in \u001b[0;36m_read\u001b[1;34m(filepath_or_buffer, kwds)\u001b[0m\n\u001b[0;32m    572\u001b[0m _validate_names(kwds\u001b[39m.\u001b[39mget(\u001b[39m\"\u001b[39m\u001b[39mnames\u001b[39m\u001b[39m\"\u001b[39m, \u001b[39mNone\u001b[39;00m))\n\u001b[0;32m    574\u001b[0m \u001b[39m# Create the parser.\u001b[39;00m\n\u001b[1;32m--> 575\u001b[0m parser \u001b[39m=\u001b[39m TextFileReader(filepath_or_buffer, \u001b[39m*\u001b[39m\u001b[39m*\u001b[39mkwds)\n\u001b[0;32m    577\u001b[0m \u001b[39mif\u001b[39;00m chunksize \u001b[39mor\u001b[39;00m iterator:\n\u001b[0;32m    578\u001b[0m     \u001b[39mreturn\u001b[39;00m parser\n",
-      "File \u001b[1;32ma:\\miniconda3\\envs\\hourly_egrid\\lib\\site-packages\\pandas\\io\\parsers\\readers.py:934\u001b[0m, in \u001b[0;36mTextFileReader.__init__\u001b[1;34m(self, f, engine, **kwds)\u001b[0m\n\u001b[0;32m    931\u001b[0m     \u001b[39mself\u001b[39m\u001b[39m.\u001b[39moptions[\u001b[39m\"\u001b[39m\u001b[39mhas_index_names\u001b[39m\u001b[39m\"\u001b[39m] \u001b[39m=\u001b[39m kwds[\u001b[39m\"\u001b[39m\u001b[39mhas_index_names\u001b[39m\u001b[39m\"\u001b[39m]\n\u001b[0;32m    933\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mhandles: IOHandles \u001b[39m|\u001b[39m \u001b[39mNone\u001b[39;00m \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m\n\u001b[1;32m--> 934\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_engine \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_make_engine(f, \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mengine)\n",
-      "File \u001b[1;32ma:\\miniconda3\\envs\\hourly_egrid\\lib\\site-packages\\pandas\\io\\parsers\\readers.py:1218\u001b[0m, in \u001b[0;36mTextFileReader._make_engine\u001b[1;34m(self, f, engine)\u001b[0m\n\u001b[0;32m   1214\u001b[0m     mode \u001b[39m=\u001b[39m \u001b[39m\"\u001b[39m\u001b[39mrb\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[0;32m   1215\u001b[0m \u001b[39m# error: No overload variant of \"get_handle\" matches argument types\u001b[39;00m\n\u001b[0;32m   1216\u001b[0m \u001b[39m# \"Union[str, PathLike[str], ReadCsvBuffer[bytes], ReadCsvBuffer[str]]\"\u001b[39;00m\n\u001b[0;32m   1217\u001b[0m \u001b[39m# , \"str\", \"bool\", \"Any\", \"Any\", \"Any\", \"Any\", \"Any\"\u001b[39;00m\n\u001b[1;32m-> 1218\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mhandles \u001b[39m=\u001b[39m get_handle(  \u001b[39m# type: ignore[call-overload]\u001b[39;49;00m\n\u001b[0;32m   1219\u001b[0m     f,\n\u001b[0;32m   1220\u001b[0m     mode,\n\u001b[0;32m   1221\u001b[0m     encoding\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49moptions\u001b[39m.\u001b[39;49mget(\u001b[39m\"\u001b[39;49m\u001b[39mencoding\u001b[39;49m\u001b[39m\"\u001b[39;49m, \u001b[39mNone\u001b[39;49;00m),\n\u001b[0;32m   1222\u001b[0m     compression\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49moptions\u001b[39m.\u001b[39;49mget(\u001b[39m\"\u001b[39;49m\u001b[39mcompression\u001b[39;49m\u001b[39m\"\u001b[39;49m, \u001b[39mNone\u001b[39;49;00m),\n\u001b[0;32m   1223\u001b[0m     memory_map\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49moptions\u001b[39m.\u001b[39;49mget(\u001b[39m\"\u001b[39;49m\u001b[39mmemory_map\u001b[39;49m\u001b[39m\"\u001b[39;49m, \u001b[39mFalse\u001b[39;49;00m),\n\u001b[0;32m   1224\u001b[0m     is_text\u001b[39m=\u001b[39;49mis_text,\n\u001b[0;32m   1225\u001b[0m     errors\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49moptions\u001b[39m.\u001b[39;49mget(\u001b[39m\"\u001b[39;49m\u001b[39mencoding_errors\u001b[39;49m\u001b[39m\"\u001b[39;49m, \u001b[39m\"\u001b[39;49m\u001b[39mstrict\u001b[39;49m\u001b[39m\"\u001b[39;49m),\n\u001b[0;32m   1226\u001b[0m     storage_options\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49moptions\u001b[39m.\u001b[39;49mget(\u001b[39m\"\u001b[39;49m\u001b[39mstorage_options\u001b[39;49m\u001b[39m\"\u001b[39;49m, \u001b[39mNone\u001b[39;49;00m),\n\u001b[0;32m   1227\u001b[0m )\n\u001b[0;32m   1228\u001b[0m \u001b[39massert\u001b[39;00m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mhandles \u001b[39mis\u001b[39;00m \u001b[39mnot\u001b[39;00m \u001b[39mNone\u001b[39;00m\n\u001b[0;32m   1229\u001b[0m f \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mhandles\u001b[39m.\u001b[39mhandle\n",
-      "File \u001b[1;32ma:\\miniconda3\\envs\\hourly_egrid\\lib\\site-packages\\pandas\\io\\common.py:786\u001b[0m, in \u001b[0;36mget_handle\u001b[1;34m(path_or_buf, mode, encoding, compression, memory_map, is_text, errors, storage_options)\u001b[0m\n\u001b[0;32m    781\u001b[0m \u001b[39melif\u001b[39;00m \u001b[39misinstance\u001b[39m(handle, \u001b[39mstr\u001b[39m):\n\u001b[0;32m    782\u001b[0m     \u001b[39m# Check whether the filename is to be opened in binary mode.\u001b[39;00m\n\u001b[0;32m    783\u001b[0m     \u001b[39m# Binary mode does not support 'encoding' and 'newline'.\u001b[39;00m\n\u001b[0;32m    784\u001b[0m     \u001b[39mif\u001b[39;00m ioargs\u001b[39m.\u001b[39mencoding \u001b[39mand\u001b[39;00m \u001b[39m\"\u001b[39m\u001b[39mb\u001b[39m\u001b[39m\"\u001b[39m \u001b[39mnot\u001b[39;00m \u001b[39min\u001b[39;00m ioargs\u001b[39m.\u001b[39mmode:\n\u001b[0;32m    785\u001b[0m         \u001b[39m# Encoding\u001b[39;00m\n\u001b[1;32m--> 786\u001b[0m         handle \u001b[39m=\u001b[39m \u001b[39mopen\u001b[39;49m(\n\u001b[0;32m    787\u001b[0m             handle,\n\u001b[0;32m    788\u001b[0m             ioargs\u001b[39m.\u001b[39;49mmode,\n\u001b[0;32m    789\u001b[0m             encoding\u001b[39m=\u001b[39;49mioargs\u001b[39m.\u001b[39;49mencoding,\n\u001b[0;32m    790\u001b[0m             errors\u001b[39m=\u001b[39;49merrors,\n\u001b[0;32m    791\u001b[0m             newline\u001b[39m=\u001b[39;49m\u001b[39m\"\u001b[39;49m\u001b[39m\"\u001b[39;49m,\n\u001b[0;32m    792\u001b[0m         )\n\u001b[0;32m    793\u001b[0m     \u001b[39melse\u001b[39;00m:\n\u001b[0;32m    794\u001b[0m         \u001b[39m# Binary mode\u001b[39;00m\n\u001b[0;32m    795\u001b[0m         handle \u001b[39m=\u001b[39m \u001b[39mopen\u001b[39m(handle, ioargs\u001b[39m.\u001b[39mmode)\n",
-      "\u001b[1;31mFileNotFoundError\u001b[0m: [Errno 2] No such file or directory: 'A:\\\\GitHub\\\\open-grid-emissions\\\\data\\\\outputs\\\\2019//eia923_allocated_2019.csv'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "pudl_out = load_data.initialize_pudl_out(year)\n",
     "\n",
@@ -61,101 +43,27 @@
     "\n",
     "# load the allocated EIA data\n",
     "eia923_allocated = pd.read_csv(f'{outputs_folder()}{path_prefix}/eia923_allocated_{year}.csv', dtype=get_dtypes(), parse_dates=['report_date'])\n",
-    "eia923_allocated = eia923_allocated.merge(plant_frequency, how=\"left\", on=\"plant_id_eia\", validate=\"m:1\")\n",
-    "\n"
+    "eia923_allocated = eia923_allocated.merge(plant_frequency, how=\"left\", on=\"plant_id_eia\", validate=\"m:1\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>fuel_consumed_mmbtu</th>\n",
-       "      <th>net_generation_mwh</th>\n",
-       "      <th>co2_mass_lb</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>respondent_frequency</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>A</th>\n",
-       "      <td>9.743375</td>\n",
-       "      <td>9.744905</td>\n",
-       "      <td>3.140016</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>AM</th>\n",
-       "      <td>4.361269</td>\n",
-       "      <td>2.881034</td>\n",
-       "      <td>7.352079</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>M</th>\n",
-       "      <td>85.574484</td>\n",
-       "      <td>87.129550</td>\n",
-       "      <td>89.011431</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>&lt;NA&gt;</th>\n",
-       "      <td>0.320871</td>\n",
-       "      <td>0.244511</td>\n",
-       "      <td>0.496474</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>Total Percent</th>\n",
-       "      <td>100.000000</td>\n",
-       "      <td>100.000000</td>\n",
-       "      <td>100.000000</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                      fuel_consumed_mmbtu  net_generation_mwh  co2_mass_lb\n",
-       "respondent_frequency                                                      \n",
-       "A                                9.743375            9.744905     3.140016\n",
-       "AM                               4.361269            2.881034     7.352079\n",
-       "M                               85.574484           87.129550    89.011431\n",
-       "<NA>                             0.320871            0.244511     0.496474\n",
-       "Total Percent                  100.000000          100.000000   100.000000"
-      ]
-     },
-     "execution_count": 67,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "data_from_annual = eia923_allocated.groupby([\"respondent_frequency\"], dropna=False)[[\"fuel_consumed_mmbtu\", \"net_generation_mwh\",\"co2_mass_lb\"]].sum() / eia923_allocated[[\"fuel_consumed_mmbtu\", \"net_generation_mwh\",\"co2_mass_lb\"]].sum() * 100\n",
     "data_from_annual.loc[\"Total Percent\"] = data_from_annual.sum()\n",
     "data_from_annual"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_from_annual.loc[\"A\",:].rename(\"% of EIA-923 input data from EIA annual reporters\")"
    ]
   },
   {
@@ -168,95 +76,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>fuel_consumed_mmbtu</th>\n",
-       "      <th>net_generation_mwh</th>\n",
-       "      <th>co2_mass_lb</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>respondent_frequency</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>A</th>\n",
-       "      <td>8.680985</td>\n",
-       "      <td>8.874646</td>\n",
-       "      <td>1.868628</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>AM</th>\n",
-       "      <td>2.404752</td>\n",
-       "      <td>0.870232</td>\n",
-       "      <td>4.654741</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>M</th>\n",
-       "      <td>36.387153</td>\n",
-       "      <td>33.407622</td>\n",
-       "      <td>9.971367</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>&lt;NA&gt;</th>\n",
-       "      <td>0.124723</td>\n",
-       "      <td>0.070856</td>\n",
-       "      <td>0.164541</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>Total Percent</th>\n",
-       "      <td>47.597613</td>\n",
-       "      <td>43.223356</td>\n",
-       "      <td>16.659277</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                      fuel_consumed_mmbtu  net_generation_mwh  co2_mass_lb\n",
-       "respondent_frequency                                                      \n",
-       "A                                8.680985            8.874646     1.868628\n",
-       "AM                               2.404752            0.870232     4.654741\n",
-       "M                               36.387153           33.407622     9.971367\n",
-       "<NA>                             0.124723            0.070856     0.164541\n",
-       "Total Percent                   47.597613           43.223356    16.659277"
-      ]
-     },
-     "execution_count": 66,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "annual_eia_used = eia923_allocated[eia923_allocated[\"hourly_data_source\"] != \"cems\"].groupby([\"respondent_frequency\"], dropna=False)[[\"fuel_consumed_mmbtu\", \"net_generation_mwh\",\"co2_mass_lb\"]].sum() / eia923_allocated[[\"fuel_consumed_mmbtu\", \"net_generation_mwh\",\"co2_mass_lb\"]].sum() * 100\n",
     "annual_eia_used.loc[\"Total Percent\"] = annual_eia_used.sum()\n",
     "annual_eia_used"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "annual_eia_used.loc[\"A\",:].rename(\"% of output data from EIA annual reporters\")"
    ]
   },
   {
@@ -269,7 +104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -286,96 +121,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>fuel_consumed_mmbtu</th>\n",
-       "      <th>net_generation_mwh</th>\n",
-       "      <th>co2_mass_lb</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>respondent_frequency</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>A</th>\n",
-       "      <td>0.724816</td>\n",
-       "      <td>0.531644</td>\n",
-       "      <td>0.870369</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>AM</th>\n",
-       "      <td>0.904512</td>\n",
-       "      <td>0.814791</td>\n",
-       "      <td>1.208854</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>M</th>\n",
-       "      <td>15.159077</td>\n",
-       "      <td>14.420226</td>\n",
-       "      <td>26.512067</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>&lt;NA&gt;</th>\n",
-       "      <td>0.115595</td>\n",
-       "      <td>0.116639</td>\n",
-       "      <td>0.152573</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>Total</th>\n",
-       "      <td>16.904001</td>\n",
-       "      <td>15.883300</td>\n",
-       "      <td>28.743863</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                      fuel_consumed_mmbtu  net_generation_mwh  co2_mass_lb\n",
-       "respondent_frequency                                                      \n",
-       "A                                0.724816            0.531644     0.870369\n",
-       "AM                               0.904512            0.814791     1.208854\n",
-       "M                               15.159077           14.420226    26.512067\n",
-       "<NA>                             0.115595            0.116639     0.152573\n",
-       "Total                           16.904001           15.883300    28.743863"
-      ]
-     },
-     "execution_count": 65,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# what percent of the total EIA-923 data comes from subplants with annually-reported data and multiple sources?\n",
     "multi_source_summary = (multi_source_subplants.groupby([\"respondent_frequency\"], dropna=False)[[\"fuel_consumed_mmbtu\", \"net_generation_mwh\",\"co2_mass_lb\"]].sum() / eia923_allocated[[\"fuel_consumed_mmbtu\", \"net_generation_mwh\",\"co2_mass_lb\"]].sum() * 100)\n",
     "multi_source_summary.loc[\"Total Percent\"] = multi_source_summary.sum()\n",
     "multi_source_summary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "multi_source_summary.loc[\"A\",:].rename(\"% of output data mixing CEMS and annually-reported EIA data\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd.concat([pd.DataFrame(data_from_annual.loc[\"A\",:].rename(\"% of EIA-923 input data from EIA annual reporters\").round(2)).T, pd.DataFrame(annual_eia_used.loc[\"A\",:].rename(\"% of output data from EIA annual reporters\").round(2)).T, pd.DataFrame(multi_source_summary.loc[\"A\",:].rename(\"% of output data mixing CEMS and annually-reported EIA data\").round(2)).T], axis=0)"
    ]
   }
  ],

--- a/notebooks/explore_data/explore_final_results.ipynb
+++ b/notebooks/explore_data/explore_final_results.ipynb
@@ -6,7 +6,89 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import plotly.express as px\n"
+    "import plotly.express as px\n",
+    "import pandas as pd\n",
+    "\n",
+    "%reload_ext autoreload\n",
+    "%autoreload 2\n",
+    "\n",
+    "# # Tell python where to look for modules.\n",
+    "import sys\n",
+    "sys.path.append('../../../open-grid-emissions/src/')\n",
+    "\n",
+    "from filepaths import *\n",
+    "import validation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Visualize data for a single BA"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ba = \"LDWP\"\n",
+    "year = 2020\n",
+    "\n",
+    "\n",
+    "egrid_ba = pd.read_excel(\n",
+    "    f\"{downloads_folder()}egrid/egrid{year}_data.xlsx\",\n",
+    "    sheet_name=f\"BA{str(year)[-2:]}\",\n",
+    "    header=1,\n",
+    "    usecols=[\"BANAME\", \"BACODE\", \"BANOXRTO\",\"BASO2RTA\",\"BACO2RTA\",\"BAC2ERTA\"],\n",
+    ").rename(\n",
+    "    columns={\n",
+    "        \"BANAME\": \"ba_name\",\n",
+    "        \"BACODE\": \"ba_code\",\n",
+    "        \"BANOXRTO\": \"generated_nox_rate_lb_per_mwh_for_electricity_adjusted\",\n",
+    "        \"BASO2RTA\": \"generated_so2_rate_lb_per_mwh_for_electricity_adjusted\",\n",
+    "        \"BACO2RTA\": \"generated_co2_rate_lb_per_mwh_for_electricity_adjusted\",\n",
+    "        \"BAC2ERTA\":\"generated_co2e_rate_lb_per_mwh_for_electricity_adjusted\"\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "hourly_consumed = pd.read_csv(f\"{results_folder()}{year}/carbon_accounting/hourly/us_units/{ba}.csv\", parse_dates=[\"datetime_local\"]).set_index(\"datetime_local\")\n",
+    "hourly_produced = pd.read_csv(f\"{results_folder()}{year}/power_sector_data/hourly/us_units/{ba}.csv\", parse_dates=[\"datetime_local\"]).set_index(\"datetime_local\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pollutant = \"co2e\"\n",
+    "rate_type = \"for_electricity_adjusted\"\n",
+    "\n",
+    "egrid_value = egrid_ba.loc[egrid_ba[\"ba_code\"] == ba, f\"generated_{pollutant}_rate_lb_per_mwh_{rate_type}\"].item()\n",
+    "data_to_graph = hourly_consumed[[f\"consumed_{pollutant}_rate_lb_per_mwh_{rate_type}\"]].rename(columns={f\"consumed_{pollutant}_rate_lb_per_mwh_{rate_type}\":\"hourly_consumed\"})\n",
+    "data_to_graph[\"annual_consumed\"] = data_to_graph[[\"hourly_consumed\"]].mean().item()\n",
+    "data_to_graph = data_to_graph.merge(hourly_produced.loc[hourly_produced[\"fuel_category\"] == \"total\", f\"generated_{pollutant}_rate_lb_per_mwh_{rate_type}\"], how=\"inner\", left_index=True, right_index=True).rename(columns={f\"generated_{pollutant}_rate_lb_per_mwh_{rate_type}\":\"hourly_produced\"})\n",
+    "data_to_graph[\"annual_produced\"] = data_to_graph[[\"hourly_produced\"]].mean().item()\n",
+    "data_to_graph[\"egrid_value\"] = egrid_value\n",
+    "data_to_graph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "px.line(data_to_graph, x=data_to_graph.index, y=[\"egrid_value\",\"annual_produced\",\"annual_consumed\",\"hourly_produced\",\"hourly_consumed\"])"
    ]
   },
   {
@@ -92,10 +174,29 @@
   }
  ],
  "metadata": {
-  "language_info": {
-   "name": "python"
+  "kernelspec": {
+   "display_name": "Python 3.10.5 ('hourly_egrid')",
+   "language": "python",
+   "name": "python3"
   },
-  "orig_nbformat": 4
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.5"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "4103f3cd497821eca917ea303dbe10c590d787eb7d2dc3fd4e15dec0356e7931"
+   }
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/src/data_pipeline.py
+++ b/src/data_pipeline.py
@@ -252,6 +252,13 @@ def main():
     eia923_allocated = data_cleaning.identify_hourly_data_source(
         eia923_allocated, cems, year
     )
+    # output data quality metrics about annually-reported EIA-923 data
+    output_data.output_data_quality_metrics(
+        validation.identify_annually_reported_eia_data(eia923_allocated, year),
+        "annually_reported_eia_data",
+        path_prefix,
+        args.skip_outputs,
+    )
 
     # 7. Aggregating CEMS data to subplant
     ####################################################################################


### PR DESCRIPTION
This PR is meant to advance https://github.com/singularity-energy/open-grid-emissions/issues/170.

This PR:
- Adds a notebook `explore_annually_reported_eia_data.ipynb` to explore this issue
- Adds summary data quality metrics to the data pipeline that summarize the percent of input EIA data that was reported annually, the percent of output data that uses the annually-reported EIA data, and the percent of output data that uses mixed CEMS and annually-reported EIA data
- Expands the `explore_final_results.ipynb` notebook to visualize annual and hourly data trends in the output data.