### PR TITLE
Fix bug where consumed.py did not have enough 930 hours at end of year

### DIFF
--- a/src/consumed.py
+++ b/src/consumed.py
@@ -417,9 +417,15 @@ class HourlyConsumed:
                         axis=1,
                     )
 
+                # Cut off emissions at 9 hours after UTC year
+                emissions = emissions[:f"{self.year+1}-01-01 09:00:00+00:00"]
                 rates[((adj, pol))] = emissions
 
-        return rates, pd.DataFrame(data=gens)
+        # Make generation data frame
+        generation = pd.DataFrame(data=gens)
+        generation = generation[:f"{self.year+1}-01-01 09:00:00+00:00"]
+
+        return rates, generation
 
     def build_matrices(self, pol: str, adj: str, date):
         # return emissions, interchange, and generation

--- a/src/eia930.py
+++ b/src/eia930.py
@@ -135,8 +135,8 @@ def clean_930(year: int, small: bool = False, path_prefix: str = ""):
 
     # if not small, scrape 2 months before start of year for rolling window cleaning
     start = f"{year}0101T00Z" if small else f"{year-1}1001T00Z"
-    # Scrape 1 week if small, else 1 year
-    end = f"{year}0107T23Z" if small else f"{year}1231T23Z"
+    # Scrape 1 week if small, else 1 year (plus one day for timezone flexibility)
+    end = f"{year}0107T23Z" if small else f"{year+1}0101T23Z"
     if small:
         df = df.loc[start:end]  # Don't worry about processing everything
 


### PR DESCRIPTION
Full run was failing when using 930 data cleaned by our own pipeline because we extended the range of hours to capture a full local time year. We now cut off the consumed calc at Jan 1, year + 1 + 9 hours, which gets us one hour past west coast end of year. 

Also added an extra day of 930 cleaning for a buffer, but the code will work without re-running 930 cleaning. 