### PR TITLE
Gailin/azps patch

### DIFF
--- a/notebooks/validation/validate_vs_egrid.ipynb
+++ b/notebooks/validation/validate_vs_egrid.ipynb
@@ -191,7 +191,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ba_code_match = egrid_plant.set_index(\"plant_id_eia\")[[\"plant_name\", \"ba_code\"]].merge(\n",
+    "ba_code_match = egrid_plant.set_index(\"plant_id_eia\")[[\"plant_name_eia\", \"ba_code\"]].merge(\n",
     "    annual_plant_results.set_index(\"plant_id_eia\")[[\"ba_code\"]],\n",
     "    how=\"inner\",\n",
     "    left_index=True,\n",
@@ -231,7 +231,7 @@
    "outputs": [],
    "source": [
     "fuel_match = egrid_plant.set_index(\"plant_id_eia\")[\n",
-    "    [\"plant_name\", \"plant_primary_fuel\"]\n",
+    "    [\"plant_name_eia\", \"plant_primary_fuel\"]\n",
     "].merge(\n",
     "    annual_plant_results.set_index(\"plant_id_eia\")[[\"plant_primary_fuel\"]],\n",
     "    how=\"inner\",\n",
@@ -418,7 +418,7 @@
     "    \"fuel_consumed_mmbtu\",\n",
     "    \"fuel_consumed_for_electricity_mmbtu\",\n",
     "    \"co2_mass_lb\",\n",
-    "    \"co2_mass_lb_adjusted\",\n",
+    "    \"co2_mass_lb_for_electricity_adjusted\",\n",
     "]\n",
     "egrid_plant_ba_agg = egrid_plant.groupby([\"ba_code\"]).sum()[data_columns].reset_index()\n"
    ]
@@ -587,7 +587,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.4 ('open_grid_emissions')",
+   "display_name": "Python 3.10.5 ('hourly_egrid')",
    "language": "python",
    "name": "python3"
   },
@@ -601,11 +601,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.10.5"
   },
   "vscode": {
    "interpreter": {
-    "hash": "25e36f192ecdbe5da57d9bea009812e7b11ef0e0053366a845a2802aae1b29d2"
+    "hash": "65c02dfd2dc2ef471c0b5088763a28c1faaa7cad28937ca42fadf51e669fd8e8"
    }
   }
  },

--- a/src/eia930.py
+++ b/src/eia930.py
@@ -441,12 +441,19 @@ def manual_930_adjust(raw: pd.DataFrame):
     ovec_col = get_int_columns("PJM", raw.columns, ["OVEC"])
     raw.loc[:, ovec_col] = raw.loc[:, ovec_col] * -1
 
-    # Interchange AZPS - SRP is wonky. Use SRP - AZPS (inverted)
+    # Interchange AZPS - SRP is wonky before 6/1/2020 7:00 UTC. Use SRP - AZPS (inverted)
     azps_srp = get_int_columns("AZPS", raw.columns, ["SRP"])
     srp_azps = get_int_columns("SRP", raw.columns, ["AZPS"])
-    raw.loc[:, azps_srp] = (raw.loc[:, srp_azps] * (-1)).rename(
+    replacement = (raw.loc[:, srp_azps] * (-1)).rename(
         columns={srp_azps[0]: azps_srp[0]}  # rename so Pandas will do the right thing
     )
+    raw.loc[raw.index < "2020-06-01T07:00+00", azps_srp] = replacement[
+        raw.index < "2020-06-01T07:00+00"
+    ]
+    # Update total interchange
+    all_cols = [c for c in get_int_columns("AZPS", raw.columns) if "ALL" not in c]
+    total_col = "EBA.AZPS-ALL.TI.H"
+    raw.loc[:, total_col] = raw.loc[:, all_cols].sum(axis=1)
 
     # Interchange TEPC is uniformly lagged
     cols = get_int_columns("TEPC", raw.columns)

--- a/src/eia930.py
+++ b/src/eia930.py
@@ -401,6 +401,10 @@ def manual_930_adjust(raw: pd.DataFrame):
             - PJM-OVEC, all time. Based on OVEC demand - generation, OVEC
                 should be a net exporter to PJM
                 - Note: OVEC's data repeats daily starting in 2018...
+        - Interchange mysterious
+            - AZPS - SRP flips gradually in Nov 2019, then abruptly back in June 2020.
+                throughout, SRP - AZPS remains constant around 3000 lb imported to AZPS from SRP
+                We assume SRP - AZPS is correct, and assign AZPS - SRP to be the inverse
     - Make all start-of-hour
         - Generation
             - - 1 hour
@@ -436,6 +440,13 @@ def manual_930_adjust(raw: pd.DataFrame):
     # OVEC sign still appears to be wrong
     ovec_col = get_int_columns("PJM", raw.columns, ["OVEC"])
     raw.loc[:, ovec_col] = raw.loc[:, ovec_col] * -1
+
+    # Interchange AZPS - SRP is wonky. Use SRP - AZPS (inverted)
+    azps_srp = get_int_columns("AZPS", raw.columns, ["SRP"])
+    srp_azps = get_int_columns("SRP", raw.columns, ["AZPS"])
+    raw.loc[:, azps_srp] = (raw.loc[:, srp_azps] * (-1)).rename(
+        columns={srp_azps[0]: azps_srp[0]}  # rename so Pandas will do the right thing
+    )
 
     # Interchange TEPC is uniformly lagged
     cols = get_int_columns("TEPC", raw.columns)

--- a/src/eia930.py
+++ b/src/eia930.py
@@ -447,13 +447,13 @@ def manual_930_adjust(raw: pd.DataFrame):
     replacement = (raw.loc[:, srp_azps] * (-1)).rename(
         columns={srp_azps[0]: azps_srp[0]}  # rename so Pandas will do the right thing
     )
-    raw.loc[raw.index < "2020-06-01T07:00+00", azps_srp] = replacement[
-        raw.index < "2020-06-01T07:00+00"
-    ]
+    raw.loc[:"2020-06-01T07:00+00", azps_srp] = replacement[:"2020-06-01T07:00+00"]
     # Update total interchange
     all_cols = [c for c in get_int_columns("AZPS", raw.columns) if "ALL" not in c]
     total_col = "EBA.AZPS-ALL.TI.H"
-    raw.loc[:, total_col] = raw.loc[:, all_cols].sum(axis=1)
+    raw.loc[:"2020-06-01T07:00+00", total_col] = raw.loc[
+        :"2020-06-01T07:00+00", all_cols
+    ].sum(axis=1)
 
     # Interchange TEPC is uniformly lagged
     cols = get_int_columns("TEPC", raw.columns)

--- a/src/output_data.py
+++ b/src/output_data.py
@@ -49,7 +49,7 @@ def prepare_files_for_upload(years):
 
     This should only be run when releasing a new minor or major version of the repo.
     """
-    # zip_data_for_zenodo()
+    zip_data_for_zenodo()
     for year in years:
         zip_results_for_s3(year)
 

--- a/src/output_data.py
+++ b/src/output_data.py
@@ -49,7 +49,7 @@ def prepare_files_for_upload(years):
 
     This should only be run when releasing a new minor or major version of the repo.
     """
-    zip_data_for_zenodo()
+    # zip_data_for_zenodo()
     for year in years:
         zip_results_for_s3(year)
 
@@ -63,11 +63,17 @@ def zip_results_for_s3(year):
             for unit in ["metric_units", "us_units"]:
                 folder = f"{results_folder()}/{year}/{data_type}/{aggregation}/{unit}"
                 shutil.make_archive(
-                    f"{results_folder()}/{year}/{data_type}/{data_type}_{aggregation}_{unit}",
+                    f"{results_folder()}/{year}/{data_type}/{year}_{data_type}_{aggregation}_{unit}",
                     "zip",
                     root_dir=folder,
                     # base_dir="",
                 )
+    shutil.make_archive(
+        f"{results_folder()}/{year}/data_quality_metrics/{year}_data_quality_metrics",
+        "zip",
+        root_dir=f"{results_folder()}/{year}/data_quality_metrics",
+        # base_dir="",
+    )
 
 
 def zip_data_for_zenodo():


### PR DESCRIPTION
Advances #220 with an AZPS-SRP fix. Because AZPS-SRP has multiple different and not straightforward problems (see #220), we use SRP-AZPS as the ground truth. 

Also includes code to add data quality metrics to zipped output, change naming convention of zipped files for easier upload. 

Also includes small fix to `validate_vs_egrid` notebook (column name change from `plant_name` to `plant_name_eia`)