### PR TITLE
Integrate Power Sector Data Crosswalk v0.3

### DIFF
--- a/src/data_pipeline.py
+++ b/src/data_pipeline.py
@@ -119,7 +119,7 @@ def main():
     # Power Sector Data Crosswalk
     # NOTE: Check for new releases at https://github.com/USEPA/camd-eia-crosswalk
     download_data.download_epa_psdc(
-        psdc_url="https://github.com/USEPA/camd-eia-crosswalk/releases/download/v0.2.1/epa_eia_crosswalk.csv"
+        psdc_url="https://github.com/USEPA/camd-eia-crosswalk/releases/download/v0.3/epa_eia_crosswalk.csv"
     )
     # download the raw EIA-923 and EIA-860 files for use in NOx/SO2 calculations until integrated into pudl
     download_data.download_raw_eia860(year)

--- a/src/load_data.py
+++ b/src/load_data.py
@@ -470,6 +470,7 @@ def load_epa_eia_crosswalk(year):
     camd_to_eia_fuel_type = {
         "Pipeline Natural Gas": "NG",
         "Coal": "SUB",  # assume that generic coal is subbituminous to be conservative
+        "Coal Refuse": "WC",
         "Residual Oil": "RFO",
         "Other Oil": "WO",
         "Diesel Oil": "DFO",


### PR DESCRIPTION
Closes https://github.com/singularity-energy/open-grid-emissions/issues/243 by using v0.3 of the EPA's Power Sector Data Crosswalk.
