### PR TITLE
Validate that data does not overlap when combining

### DIFF
--- a/src/data_cleaning.py
+++ b/src/data_cleaning.py
@@ -1541,7 +1541,7 @@ def combine_plant_data(
     partial_cems_plant,
     eia_data,
     resolution,
-    validate=False,
+    validate=True,
 ):
     """
     Combines final hourly subplant data from each source into a single dataframe.

--- a/src/data_pipeline.py
+++ b/src/data_pipeline.py
@@ -297,7 +297,6 @@ def main():
         partial_cems_plant,
         monthly_eia_data_to_shape,
         "monthly",
-        True,
     )
     output_data.output_plant_data(
         monthly_plant_data, path_prefix, "monthly", args.skip_outputs


### PR DESCRIPTION
At some point, it looks like an argument was added to `data_cleaning.combine_plant_data()` to allow the user to not validate that the data being combined does not overlap. For some reason, the default argument was set to `False`, which means that the combined hourly data was not being validated for potential overlaps. This PR fixes that by changing the default argument to `True`