### PR TITLE
v0.1.2

### DIFF
--- a/data/manual/epa_eia_crosswalk_manual.csv
+++ b/data/manual/epa_eia_crosswalk_manual.csv
@@ -2,6 +2,8 @@ plant_id_epa,unitid,plant_id_eia,generator_id,notes
 389,3,389,3,CAMD_UNIT_ID matches EIA_GENERATOR_ID
 1363,7A,1363,7A,CAMD_UNIT_ID matches EIA_GENERATOR_ID
 1363,7B,1363,7B,CAMD_UNIT_ID matches EIA_GENERATOR_ID
+1393,1A,1393,1,CAMD_UNIT_ID matches boiler_id and reported fuel consumption matches
+1393,2A,1393,2,CAMD_UNIT_ID matches boiler_id and reported fuel consumption matches
 1393,3,1393,3,CAMD_GENERATOR_ID matches EIA_GENERATOR_ID
 1570,11,1570,11,CAMD_UNIT_ID matches EIA_GENERATOR_ID
 1570,9,1570,9,CAMD_UNIT_ID matches EIA_GENERATOR_ID

--- a/environment.yml
+++ b/environment.yml
@@ -28,6 +28,6 @@ dependencies:
 
   - pip:
       #- --editable ../pudl #NOTE: this is for Greg's use for development
-      - git+https://github.com/grgmiller/pudl.git@allocate_fuel#egg=catalystcoop.pudl
+      - git+https://github.com/grgmiller/pudl.git@oge#egg=catalystcoop.pudl
       # - --editable ../gridemissions # NOTE: for Gailin's development use
       - git+https://github.com/gailin-p/gridemissions#egg=gridemissions

--- a/notebooks/explore_data/explore_intermediate_outputs.ipynb
+++ b/notebooks/explore_data/explore_intermediate_outputs.ipynb
@@ -39,13 +39,11 @@
     "year = 2020\n",
     "path_prefix = f\"{year}/\"\n",
     "\n",
-    "cems = pd.read_csv(f'{outputs_folder()}{path_prefix}/cems_{year}.csv', dtype=get_dtypes(), parse_dates=['datetime_utc', 'report_date'])\n",
-    "partial_cems_scaled = pd.read_csv(f'{outputs_folder()}{path_prefix}/partial_cems_scaled_{year}.csv', dtype=get_dtypes(), parse_dates=['datetime_utc', 'report_date'])\n",
-    "eia923_allocated = pd.read_csv(f'{outputs_folder()}{path_prefix}/eia923_allocated_{year}.csv', dtype=get_dtypes(), parse_dates=['report_date'])\n",
-    "plant_attributes = pd.read_csv(f\"{outputs_folder()}{path_prefix}/plant_static_attributes_{year}.csv\")\n",
-    "primary_fuel_table = plant_attributes.drop_duplicates(subset=\"plant_id_eia\")[[\"plant_id_eia\", \"plant_primary_fuel\"]]\n",
-    "residual_profiles = pd.read_csv(f\"{outputs_folder()}{path_prefix}/residual_profiles_{year}.csv\")\n",
-    "shaped_eia_data = pd.read_csv(f\"{outputs_folder()}{path_prefix}/shaped_eia923_data_{year}.csv\")"
+    "cems = pd.read_csv(outputs_folder(f\"{path_prefix}/cems_{year}.csv\"), dtype=get_dtypes(), parse_dates=['datetime_utc', 'report_date'])\n",
+    "partial_cems_plant = pd.read_csv(outputs_folder(f\"{path_prefix}/partial_cems_plant_{year}.csv\"), dtype=get_dtypes(), parse_dates=['datetime_utc', 'report_date'])\n",
+    "partial_cems_subplant = pd.read_csv(outputs_folder(f\"{path_prefix}/partial_cems_subplant_{year}.csv\"), dtype=get_dtypes(), parse_dates=['datetime_utc', 'report_date'])\n",
+    "eia923_allocated = pd.read_csv(outputs_folder(f\"{path_prefix}/eia923_allocated_{year}.csv\"), dtype=get_dtypes(), parse_dates=['report_date'])\n",
+    "plant_attributes = pd.read_csv(outputs_folder(f\"{path_prefix}/plant_static_attributes_{year}.csv\"), dtype=get_dtypes())"
    ]
   },
   {

--- a/notebooks/explore_data/gens_not_in_cems.ipynb
+++ b/notebooks/explore_data/gens_not_in_cems.ipynb
@@ -1,0 +1,257 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# import packages\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import os\n",
+    "import plotly.express as px\n",
+    "\n",
+    "%reload_ext autoreload\n",
+    "%autoreload 2\n",
+    "\n",
+    "# # Tell python where to look for modules.\n",
+    "import sys\n",
+    "sys.path.append('../../../open-grid-emissions/src/')\n",
+    "\n",
+    "import download_data\n",
+    "import load_data\n",
+    "from column_checks import get_dtypes\n",
+    "from filepaths import *\n",
+    "import impute_hourly_profiles\n",
+    "import data_cleaning\n",
+    "import output_data\n",
+    "import emissions\n",
+    "import validation\n",
+    "import gross_to_net_generation\n",
+    "import eia930\n",
+    "\n",
+    "year = 2020\n",
+    "path_prefix = f\"{year}/\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load inputs to function\n",
+    "cems = pd.read_csv(outputs_folder(f\"{path_prefix}/cems_{year}.csv\"), dtype=get_dtypes(), parse_dates=['datetime_utc', 'report_date'])\n",
+    "partial_cems_plant = pd.read_csv(outputs_folder(f\"{path_prefix}/partial_cems_plant_{year}.csv\"), dtype=get_dtypes(), parse_dates=['datetime_utc', 'report_date'])\n",
+    "partial_cems_subplant = pd.read_csv(outputs_folder(f\"{path_prefix}/partial_cems_subplant_{year}.csv\"), dtype=get_dtypes(), parse_dates=['datetime_utc', 'report_date'])\n",
+    "eia923_allocated = pd.read_csv(outputs_folder(f\"{path_prefix}/eia923_allocated_{year}.csv\"), dtype=get_dtypes(), parse_dates=['report_date'])\n",
+    "plant_attributes = pd.read_csv(outputs_folder(f\"{path_prefix}/plant_static_attributes_{year}.csv\"), dtype=get_dtypes())\n",
+    "\n",
+    "# select eia only data \n",
+    "eia_only_data = eia923_allocated[\n",
+    "    (eia923_allocated[\"hourly_data_source\"] == \"eia\")\n",
+    "    & ~(eia923_allocated[\"fuel_consumed_mmbtu\"].isna())\n",
+    "].copy()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Why are NOx emissions from non-CEMS plants so high in CAISO?\n",
+    "According to the data source, about 70% of emitting generation is represented in CEMS, but only 4% of NOx emissions are. Do 30% of plants account for 96% of NOx emissions?\n",
+    "\n",
+    "Are we over-counting NOx from non-cems plants?\n",
+    "Is there a lot of missing nox data for CEMS plants?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# add ba codes and plant primary fuel to all of the data\n",
+    "eia_only_data = eia_only_data.merge(\n",
+    "    plant_attributes[[\"plant_id_eia\", \"ba_code\", \"plant_primary_fuel\"]],\n",
+    "    how=\"left\",\n",
+    "    on=\"plant_id_eia\",\n",
+    "    validate=\"m:1\",\n",
+    ")\n",
+    "cems = cems.merge(\n",
+    "    plant_attributes[[\"plant_id_eia\", \"ba_code\", \"plant_primary_fuel\"]],\n",
+    "    how=\"left\",\n",
+    "    on=\"plant_id_eia\",\n",
+    "    validate=\"m:1\",\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems_caiso = cems[cems[\"ba_code\"] == \"CISO\"].copy()\n",
+    "eia_caiso = eia_only_data[eia_only_data[\"ba_code\"] == \"CISO\"].copy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems_caiso[\"nox_mass_lb_for_electricity\"].sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eia_caiso[\"nox_mass_lb_for_electricity\"].sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eia_caiso[\"nox_rate\"] = eia_caiso[\"nox_mass_lb_for_electricity\"] / eia_caiso[\"net_generation_mwh\"]\n",
+    "eia_caiso[\"nox_rate\"] = eia_caiso[\"nox_rate\"].replace(np.inf, np.nan)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eia_caiso.groupby([\"prime_mover_code\",\"energy_source_code\",])[\"nox_mass_lb_for_electricity\"].sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eia_caiso.groupby([\"prime_mover_code\"])[\"nox_mass_lb_for_electricity\"].sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eia_caiso.groupby([\"energy_source_code\"])[\"nox_mass_lb_for_electricity\"].sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eia_caiso[\"nox_mass_lb_for_electricity\"].sum()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Investigate the capacity factor of plants in each dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subplant_nameplate = gross_to_net_generation.calculate_subplant_nameplate_capacity(year)\n",
+    "\n",
+    "pudl_out = load_data.initialize_pudl_out(year)\n",
+    "gen_cap = pudl_out.gens_eia860()[[\"plant_id_eia\",\"generator_id\",\"capacity_mw\"]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eia_cf = eia_only_data.merge(gen_cap, how=\"left\", on=[\"plant_id_eia\",\"generator_id\"], validate=\"m:1\")\n",
+    "eia_cf[\"capfac\"] = eia_cf.net_generation_mwh / (eia_cf.report_date.dt.days_in_month * 24 * eia_cf.capacity_mw)\n",
+    "eia_cf.loc[eia_cf[\"capfac\"] > 1.2, \"capfac\"] = np.NaN\n",
+    "eia_cf.loc[eia_cf[\"capfac\"] < 0, \"capfac\"] = np.NaN\n",
+    "eia_cf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "px.histogram(eia_cf, x=\"capfac\", nbins=15, histnorm=\"percent\", width=500).update_xaxes(dtick=0.05)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems_cf = cems.merge(subplant_nameplate, how=\"left\", on=[\"plant_id_eia\",\"subplant_id\"])\n",
+    "cems_cf = cems_cf.groupby([\"plant_id_eia\",\"subplant_id\"])[[\"net_generation_mwh\",\"capacity_mw\"]].sum()\n",
+    "cems_cf = cems_cf[cems_cf[\"capacity_mw\"] > 0]\n",
+    "cems_cf['capfac'] = cems_cf['net_generation_mwh'] / cems_cf['capacity_mw']\n",
+    "cems_cf.loc[cems_cf[\"capfac\"] > 1.2, \"capfac\"] = np.NaN\n",
+    "cems_cf.loc[cems_cf[\"capfac\"] < 0, \"capfac\"] = np.NaN\n",
+    "cems_cf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "px.histogram(cems_cf, x=\"capfac\", nbins=15, histnorm=\"percent\", width=500).update_xaxes(dtick=0.05)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.10.4 ('open_grid_emissions')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "25e36f192ecdbe5da57d9bea009812e7b11ef0e0053366a845a2802aae1b29d2"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/manual_data/identify_eia930_time_lags.ipynb
+++ b/notebooks/manual_data/identify_eia930_time_lags.ipynb
@@ -72,10 +72,11 @@
     "# Tell python where to look for modules. \n",
     "# Depending on how your jupyter handles working directories, this may not be needed.\n",
     "import sys\n",
-    "sys.path.append('../../../open-grid-emissions/')\n",
+    "sys.path.append('../../')\n",
     "\n",
     "from src.download_data import download_chalendar_files\n",
-    "from src.eia930 import fuel_code_map, reformat_chalendar, manual_930_adjust"
+    "from src.eia930 import reformat_chalendar, manual_930_adjust\n",
+    "from src.load_data import PATH_TO_LOCAL_REPO, data_folder"
    ]
   },
   {
@@ -94,9 +95,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "raw = pd.read_csv(\"../data/eia930/chalendar/EBA_raw.csv\",index_col=0, parse_dates=True)\n",
+    "raw = pd.read_csv(f\"{data_folder()}/downloads/eia930/chalendar/EBA_raw.csv\",index_col=0, parse_dates=True)\n",
     "fixed = manual_930_adjust(raw)\n",
-    "fixed.to_csv(\"../data/outputs/EBA_adjusted_raw.csv\")"
+    "fixed.to_csv(f\"{data_folder()}/outputs/EBA_adjusted_raw.csv\")"
    ]
   },
   {
@@ -107,8 +108,17 @@
    "source": [
     "# Load data\n",
     "#eia930 = pd.read_csv(\"../data/eia930/chalendar/EBA_rolling.csv\",index_col=0, parse_dates=True)\n",
-    "eia930 = pd.read_csv(\"../data/outputs/EBA_adjusted_raw.csv\",index_col=0, parse_dates=True)\n",
+    "eia930 = pd.read_csv(f\"{data_folder()}/outputs/EBA_adjusted_raw.csv\",index_col=0, parse_dates=True)\n",
     "eia930 = eia930[eia930.index>\"2018-07-01T00:00\"] # limit to after gen was reported by fuel type"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eia930_raw = reformat_chalendar(raw)"
    ]
   },
   {
@@ -136,8 +146,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "plant_meta = pd.read_csv(\"../../data/outputs/2020/plant_static_attributes_2020.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "\n",
-    "files = [\"../data/outputs/cems_2019.csv\", \"../data/outputs/cems_2020.csv\"]\n",
+    "files = [f\"{data_folder()}/outputs/2019/cems_2019.csv\", f\"{data_folder()}/outputs/2020/cems_2020.csv\"]\n",
     "\n",
     "# Load files\n",
     "# Aggregate by BA during loading to cut down on space\n",
@@ -146,8 +165,9 @@
     "    print(f\"loading {y}\")\n",
     "    c = pd.read_csv(y, index_col=0, parse_dates=['datetime_utc'])\n",
     "    c = c.rename(columns={\"datetime_utc\":\"datetime_utc\"})\n",
+    "    c = c.merge(plant_meta[['plant_id_eia', 'plant_primary_fuel', 'ba_code']], how='left', left_index=True, right_on='plant_id_eia')\n",
     "    # exclude solar power for CEMS, since we're just going to look at COL + OIL + NG in the 930 data\n",
-    "    c = c[c[\"energy_source_code\"] != \"SUN\"]\n",
+    "    c = c[c[\"plant_primary_fuel\"] != \"SUN\"]\n",
     "    print(\"Aggregating\")\n",
     "    cems_aggregated = c.groupby([\"datetime_utc\",\"ba_code\"]).sum()[\"net_generation_mwh\"].reset_index()\n",
     "    cems = pd.concat([cems, cems_aggregated])\n"
@@ -262,8 +282,17 @@
     "        eia930[(eia930.datetime_utc.dt.month>=11)|(eia930.datetime_utc.dt.month<=2)]).best.rename(\"standard time\")],\n",
     "    axis='columns')\n",
     "\n",
-    "cems_930_cors.to_csv(\"../data/outputs/cems_eia930_cor_lags.csv\")\n",
+    "#cems_930_cors.to_csv(\"../data/outputs/cems_eia930_cor_lags.csv\")\n",
     "cems_930_cors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eia930_raw"
    ]
   },
   {
@@ -274,12 +303,14 @@
    "source": [
     "ba = \"SC\"\n",
     "\n",
+    "to_plot_930 = eia930_raw[eia930_raw.BA==ba].groupby(\"datetime_utc\").sum()\n",
+    "\n",
     "print(f\"correlations for {ba}\")\n",
     "print(cems_930_cors.loc[ba])\n",
     "\n",
     "fig = go.Figure()\n",
     "fig.add_trace(go.Scatter(x=cems[cems.ba_code==ba].datetime_utc, y=cems[cems.ba_code==ba].net_generation_mwh, name=\"CEMS\"))\n",
-    "fig.add_trace(go.Scatter(x=eia930[eia930.BA==ba].datetime_utc, y=eia930[eia930.BA==ba].generation, name=\"EIA 930\"))\n",
+    "fig.add_trace(go.Scatter(x=to_plot_930.index, y=to_plot_930.generation, name=\"EIA 930 (before adjustment)\"))\n",
     "fig.update_layout(\n",
     "    title=ba,\n",
     "    xaxis_title=\"Date\",\n",
@@ -721,7 +752,7 @@
   "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
-    "hash": "4103f3cd497821eca917ea303dbe10c590d787eb7d2dc3fd4e15dec0356e7931"
+    "hash": "65c02dfd2dc2ef471c0b5088763a28c1faaa7cad28937ca42fadf51e669fd8e8"
    }
   }
  },

--- a/notebooks/validation/hourly_validation.ipynb
+++ b/notebooks/validation/hourly_validation.ipynb
@@ -19,7 +19,9 @@
     "\n",
     "import plotly.express as px\n",
     "import plotly.io as pio\n",
+    "import plotly.graph_objects as go\n",
     "from datetime import datetime\n",
+    "from dateutil.parser import parse as parse_dt\n",
     "from datetime import timedelta\n",
     "import json\n",
     "\n",
@@ -33,9 +35,9 @@
    "outputs": [],
    "source": [
     "import sys\n",
-    "sys.path.append(\"../../\")\n",
+    "sys.path.append(\"../../src\")\n",
     "\n",
-    "import src.load_data as load_data"
+    "import filepaths"
    ]
   },
   {
@@ -54,7 +56,7 @@
    "outputs": [],
    "source": [
     "# EIA-930 data after timestamp adjustments but no cleaning\n",
-    "raw = pd.read_csv(f\"{load_data.data_folder()}/outputs/2020/eia930/eia930_raw.csv\", index_col=0, parse_dates=True)"
+    "raw = pd.read_csv(f\"{filepaths.data_folder()}/outputs/2020/eia930/eia930_raw.csv\", index_col=0, parse_dates=True)"
    ]
   },
   {
@@ -64,7 +66,7 @@
    "outputs": [],
    "source": [
     "GEN_ID = \"EBA.{}-ALL.NG.H\"\n",
-    "path = f\"{load_data.data_folder()}/results/{year}/power_sector_data/hourly/us_units/\"\n",
+    "path = f\"{filepaths.data_folder()}/results/{year}/power_sector_data/hourly/us_units/\"\n",
     "cors = {}\n",
     "percent_difs = {}\n",
     "annual_gen = {}\n",
@@ -92,9 +94,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "os.makedirs(f\"{filepaths.data_folder()}/outputs/{year}/validation_metrics/us_units\", exist_ok=True)\n",
+    "\n",
     "out = pd.DataFrame(data={\"Difference as percent of hourly-egrid\":percent_difs, \"Correlation\":cors, \"Annual BA generation\":annual_gen})\n",
     "out = out.sort_values(\"Annual BA generation\", ascending=False)\n",
-    "out.to_csv(f\"{load_data.data_folder()}/results/{year}/validation_metrics/us_units/compare_930_hourlyegrid.csv\")"
+    "out.to_csv(f\"{filepaths.data_folder()}/outputs/{year}/validation_metrics/us_units/compare_930_hourlyegrid.csv\")"
    ]
   },
   {
@@ -110,7 +114,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ba = \"BPAT\"\n",
+    "ba = \"NYIS\"\n",
     "col_name = GEN_ID.format(ba)\n",
     "dat = pd.read_csv(path+ba+\".csv\", parse_dates=[\"datetime_utc\"])\n",
     "dat = dat[dat.fuel_category==\"total\"]\n",
@@ -132,7 +136,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "eia930 = pd.read_csv(f\"../data/outputs/{year}/eia930/eia930_raw.csv\", parse_dates=True, index_col=0)"
+    "eia930 = pd.read_csv(f\"{filepaths.data_folder()}/outputs/{year}/eia930/eia930_rolling.csv\", parse_dates=True, index_col=0)"
    ]
   },
   {
@@ -167,8 +171,48 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Default factors: coal factor is missing in FPC, PACW; so need national factor \n",
+    "default_factors = {}\n",
+    "default_factors[\"adjusted\"] = {}\n",
+    "default_factors[\"unadjusted\"] = {}\n",
+    "default_factors[\"adjusted\"][\"coal\"] = 2168.237\n",
+    "default_factors[\"unadjusted\"][\"coal\"] = 2168.237"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "factors[\"adjusted\"][\"HST\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "EIA_REGIONS = {\n",
+    "    'BPAT',\n",
+    "    'CISO',\n",
+    "    'ISNE',\n",
+    "    'MISO',\n",
+    "    'NYIS',\n",
+    "    'PJM',\n",
+    "    'SWPP',\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "## For each BA, use singularity factors to calculate emission rate \n",
-    "bas_to_calc = [ba.replace(\".csv\", \"\") for ba in os.listdir(\"../data/results/2020/power_sector_data/hourly/us_units/\")]\n",
+    "bas_to_calc = [ba.replace(\".csv\", \"\") for ba in os.listdir(f\"{filepaths.results_folder()}/2020/power_sector_data/hourly/us_units/\")]\n",
     "\n",
     "fuel_categories = {\n",
     "    \"coal\":\"COL\",\n",
@@ -192,14 +236,19 @@
     "    for adjustment in [\"adjusted\", \"unadjusted\"]:\n",
     "        s_fuels = list(factors[adjustment][singularity_ba].keys())\n",
     "        s_factors = [factors[adjustment][singularity_ba][f]['value'] for f in s_fuels]\n",
+    "        # Add default factors for missing fuel types \n",
+    "        for f in default_factors[adjustment].keys():\n",
+    "            if f not in s_fuels: \n",
+    "                s_fuels.append(f)\n",
+    "                s_factors.append(default_factors[adjustment][f])\n",
     "        fuels = [fuel_categories[f] for f in s_fuels]\n",
     "        generation_labels = [f\"EBA.{ba}-ALL.NG.{f}.H\" for f in fuels]\n",
     "\n",
     "        out.loc[:,f\"{adjustment}_carbon\"] = eia930[generation_labels].mul(s_factors, axis='columns').sum(axis='columns')\n",
     "        out.loc[:,f\"{adjustment}_rate\"] = out.loc[:,f\"{adjustment}_carbon\"] / eia930.loc[:,f\"EBA.{ba}-ALL.NG.H\"]\n",
     "\n",
-    "    os.makedirs(f\"{load_data.data_folder()}/outputs/{year}/validation/real_time_rate/\", exist_ok=True)\n",
-    "    out.to_csv(f\"{load_data.data_folder()}/outputs/{year}/validation/real_time_rate/{ba}.csv\")\n"
+    "    os.makedirs(f\"{filepaths.data_folder()}/outputs/{year}/validation/real_time_rate/\", exist_ok=True)\n",
+    "    out.to_csv(f\"{filepaths.data_folder()}/outputs/{year}/validation/real_time_rate/{ba}.csv\")\n"
    ]
   },
   {
@@ -217,8 +266,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gen_path = f\"{load_data.data_folder()}/results/{year}/power_sector_data/hourly/us_units/\"\n",
-    "consumed_path = f\"{load_data.data_folder()}/results/{year}/carbon_accounting/hourly/us_units/\""
+    "gen_path = f\"{filepaths.data_folder()}/results/{year}/power_sector_data/hourly/us_units/\"\n",
+    "consumed_path = f\"{filepaths.data_folder()}/results/{year}/carbon_accounting/hourly/us_units/\""
    ]
   },
   {
@@ -237,12 +286,15 @@
    "outputs": [],
    "source": [
     "percent_difs = {}\n",
+    "abs_difs = {}\n",
+    "med_rate = {}\n",
     "cors = {}\n",
-    "for ba in os.listdir(f\"{load_data.data_folder()}/outputs/{year}/validation/real_time_rate/\"):\n",
+    "max_difs = {}\n",
+    "for ba in os.listdir(f\"{filepaths.data_folder()}/outputs/{year}/validation/real_time_rate/\"):\n",
     "    if ba == \".DS_Store\": # just some os stuff\n",
     "        continue \n",
     "    ba = ba.replace(\".csv\", \"\")\n",
-    "    singularity_dat = pd.read_csv(f\"{load_data.data_folder()}/outputs/{year}/validation/real_time_rate/{ba}.csv\", index_col=0, parse_dates=True)\n",
+    "    singularity_dat = pd.read_csv(f\"{filepaths.data_folder()}/outputs/{year}/validation/real_time_rate/{ba}.csv\", index_col=0, parse_dates=True)\n",
     "    # hourly_consumed = pd.read_csv(consumed_path+ba+\".csv\",\n",
     "    #     usecols=[\"datetime_utc\", \"consumed_co2_rate_lb_per_mwh_for_electricity\", \"consumed_co2_rate_lb_per_mwh_adjusted\"], \n",
     "    #     index_col=\"datetime_utc\", parse_dates=True)\n",
@@ -252,10 +304,25 @@
     "    hourly_generated = hourly_generated.loc[hourly_generated.fuel_category==\"total\"]\n",
     "    hourly_generated = hourly_generated.sort_index()\n",
     "    all_dat = pd.concat([singularity_dat, hourly_generated], axis='columns')\n",
+    "\n",
+    "    dat_key = \"generated_co2_rate_lb_per_mwh_for_electricity_adjusted\"\n",
+    "\n",
+    "    # Patch fix for PJM, see https://github.com/singularity-energy/open-grid-emissions/issues/230\n",
+    "    if ba==\"PJM\":\n",
+    "        all_dat.loc[all_dat[dat_key] < 100, dat_key] = np.nan\n",
+    "        all_dat = all_dat[\"2020-02-01T00:00\":]\n",
+    "\n",
+    "    # Patch fix for FPL real-time issue not caught by rolling filter \n",
+    "    if ba==\"FPL\":\n",
+    "        all_dat.loc[all_dat[\"adjusted_rate\"] > 5000, \"adjusted_rate\"] = np.nan\n",
+    "\n",
+    "\n",
     "    all_dat = all_dat.sort_index()\n",
-    "    cors[ba] = all_dat[[\"generated_co2_rate_lb_per_mwh_for_electricity_adjusted\", \"adjusted_rate\"]].corr().to_numpy()[0,1]\n",
-    "    percent_difs[ba] = ((all_dat[\"adjusted_rate\"] - all_dat[\"generated_co2_rate_lb_per_mwh_for_electricity_adjusted\"])/all_dat[\"generated_co2_rate_lb_per_mwh_for_electricity_adjusted\"]).median()\n",
-    "\n"
+    "    cors[ba] = all_dat[[dat_key, \"adjusted_rate\"]].corr().to_numpy()[0,1]\n",
+    "    percent_difs[ba] = ((all_dat[\"adjusted_rate\"] - all_dat[dat_key])/all_dat[dat_key]).median()\n",
+    "    max_difs[ba] = ((all_dat[\"adjusted_rate\"] - all_dat[dat_key])/all_dat[dat_key]).abs().replace(1.0, np.nan).max()\n",
+    "    abs_difs[ba] = ((all_dat[\"adjusted_rate\"] - all_dat[dat_key])).median()\n",
+    "    med_rate[ba] = all_dat[\"adjusted_rate\"].median()\n"
    ]
   },
   {
@@ -264,9 +331,35 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "out = pd.DataFrame(data={\"Difference as percent of OGE\":percent_difs, \"Correlation\":cors, \"Annual BA generation\":annual_gen})\n",
+    "out = pd.DataFrame(data={\n",
+    "    \"Median rate difference\":abs_difs,\n",
+    "    \"Difference as percent of OGE\":percent_difs,\n",
+    "    \"Correlation\":cors, \n",
+    "    \"Annual BA generation\":annual_gen,\n",
+    "    \"Median rate\":med_rate,\n",
+    "    })\n",
     "out = out.sort_values(\"Annual BA generation\", ascending=False)\n",
-    "out.to_csv(f\"{load_data.data_folder()}/results/{year}/validation_metrics/us_units/compare_real_time_rates.csv\")"
+    "\n",
+    "# Exclude BAs for which we couldn't calculate a real-time rate \n",
+    "todrop = [b for b in out.index if (b not in factors[\"adjusted\"].keys()) and (\"EIA.\"+b not in factors[\"adjusted\"].keys())]\n",
+    "print(f\"dropping {todrop} because they aren't included in Singularity's emission rate API\")\n",
+    "out = out.drop(labels=todrop)\n",
+    "# exclude BAs for which rate is always zero (Hydro-only BAs)\n",
+    "zero_rates = []\n",
+    "for ba in out.index: \n",
+    "    if (out.loc[ba, \"Median rate\"] == 0) and (out.loc[ba, \"Median rate difference\"] == 0):\n",
+    "        zero_rates.append(ba)\n",
+    "print(f\"Note {zero_rates} have zero rates in OGE data\")\n",
+    "#out = out.drop(labels=todrop)\n",
+    "# exclude BAs with zero net gen according to our data\n",
+    "zero_gen = []\n",
+    "for ba in out.index: \n",
+    "    if (out.loc[ba, \"Annual BA generation\"] == 0):\n",
+    "        zero_gen.append(ba)\n",
+    "print(f\"Dropping {zero_gen} because they have zero generation in OGE data\")\n",
+    "out = out.drop(labels=zero_gen)\n",
+    "\n",
+    "out.to_csv(f\"{filepaths.data_folder()}/outputs/{year}/validation_metrics/us_units/compare_real_time_rates.csv\")"
    ]
   },
   {
@@ -276,6 +369,29 @@
    "outputs": [],
    "source": [
     "out.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "out_tbl = out.copy()#.round(2)\n",
+    "out_tbl[\"Annual BA generation\"] = out_tbl[\"Annual BA generation\"]/1000000 # convert to millions\n",
+    "out_tbl[\"Difference as percent of OGE\"] = out_tbl[\"Difference as percent of OGE\"]*100 # convert to %\n",
+    "out_tbl = out_tbl.round(2)\n",
+    "for line in out_tbl.to_markdown().split(\"/n\"): \n",
+    "    print(line)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "out.loc[\"FPC\"]"
    ]
   },
   {
@@ -292,10 +408,16 @@
    "outputs": [],
    "source": [
     "# For one-off interactive plotting\n",
-    "ba_of_interest = \"DEAA\"\n",
+    "ba_of_interest = \"BPAT\"\n",
     "\n",
-    "real_time = pd.read_csv(f\"{load_data.data_folder()}/outputs/{year}/validation/real_time_rate/{ba_of_interest}.csv\", index_col=0, parse_dates=True)\n",
+    "\n",
+    "\n",
+    "real_time = pd.read_csv(f\"{filepaths.data_folder()}/outputs/{year}/validation/real_time_rate/{ba_of_interest}.csv\", index_col=0, parse_dates=True)\n",
     "real_time = real_time[\"2020-01-01T00:00\":]\n",
+    "if ba_of_interest == \"NYIS\":\n",
+    "    # NYIS has a hole in the EIA data that's not there in ISO data: fill it \n",
+    "    nyis_hole = pd.Series(data=[313, 287.79, 262.215], index=[\"2020-03-30T01:00+00\", \"2020-03-30T02:00+00\", \"2020-03-30T03:00+00\"])\n",
+    "    real_time.loc[nyis_hole.index, \"adjusted_rate\"] = nyis_hole\n",
     "\n",
     "hourly_consumed = pd.read_csv(consumed_path+ba_of_interest+\".csv\",\n",
     "    usecols=[\"datetime_utc\", \"consumed_co2_rate_lb_per_mwh_for_electricity\", \"consumed_co2_rate_lb_per_mwh_for_electricity_adjusted\"], \n",
@@ -307,15 +429,29 @@
     "all_dat = pd.concat([real_time, hourly_consumed, hourly_generated.loc[hourly_generated.fuel_category==\"total\"]], axis='columns')\n",
     "all_dat = all_dat.sort_index()\n",
     "\n",
-    "fig = px.line(all_dat, x=all_dat.index, y=[\"generated_co2_rate_lb_per_mwh_for_electricity\", \"adjusted_rate\"], \n",
-    "    title=f\"{ba_of_interest} rate comparison\",\n",
-    "    labels={\n",
-    "        \"value\":\"Adjsuted CO2 emission rate (lb/mwh)\",\n",
-    "        \"index\":\"Hour\"\n",
-    "    })\n",
+    "all_dat[\"percent_difs\"] = (all_dat[\"adjusted_rate\"] - all_dat[\"generated_co2_rate_lb_per_mwh_for_electricity_adjusted\"])/all_dat[\"generated_co2_rate_lb_per_mwh_for_electricity_adjusted\"]\n",
     "\n",
-    "newnames = {'generated_co2_rate_lb_per_mwh_for_electricity': 'Our data', 'adjusted_rate': 'Real-time data'}\n",
-    "fig.for_each_trace(lambda t: t.update(name = newnames[t.name]))"
+    "#all_dat = all_dat.loc[parse_dt(\"2020-07-19T00:00+00\"):parse_dt(\"2020-08-06T00:00+00\")]\n",
+    "#all_dat = all_dat.loc[parse_dt(\"2020-02-10T00:00+00\"):parse_dt(\"2020-02-28T00:00+00\")]\n",
+    "\n",
+    "fig = px.line(all_dat, x=all_dat.index, y=[\"generated_co2_rate_lb_per_mwh_for_electricity_adjusted\", \"adjusted_rate\"], \n",
+    "    title=f\"Real time accuracy in {ba_of_interest}\",\n",
+    "    labels={\n",
+    "        \"value\":\"CO2 emission rate (lb/mwh)\",\n",
+    "        \"index\":\"Hour (UTC)\"\n",
+    "    }, \n",
+    "    template='plotly_white',\n",
+    ")\n",
+    "\n",
+    "newnames = {\n",
+    "    'generated_co2_rate_lb_per_mwh_for_electricity_adjusted': 'Historical benchmark',\n",
+    "    'adjusted_rate': 'Real-time data'}\n",
+    "fig.for_each_trace(lambda t: t.update(name = newnames[t.name]))\n",
+    "fig.update_layout(legend_title_text='')\n",
+    "fig.show()\n",
+    "\n",
+    "os.makedirs(f\"{filepaths.data_folder()}/outputs/viz/\", exist_ok=True)\n",
+    "#pio.write_image(fig, f\"{filepaths.data_folder()}/outputs/viz/{ba_of_interest}_aug_sm.jpg\", width=1000*(2/3), height=500*(2/3), scale=3)"
    ]
   },
   {
@@ -324,9 +460,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# What's happening Jun 16? \n",
-    "to_investigate = pd.read_csv(gen_path+ba_of_interest+\".csv\", \n",
-    "    index_col=\"datetime_utc\", parse_dates=True)"
+    "factors[\"adjusted\"][\"EIA.NYIS\"]"
    ]
   },
   {
@@ -335,7 +469,273 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "to_investigate.loc[\"2020-06-16T14:00\"].to_csv(\"~/Desktop/plant_\")"
+    "### Plot natural gas emission rate: does this explain larger gap in summer? \n",
+    "\n",
+    "hourly_rate = pd.read_csv(gen_path+ba_of_interest+\".csv\", \n",
+    "    usecols=[\"datetime_utc\", \"generated_co2_rate_lb_per_mwh_for_electricity\", \"generated_co2_rate_lb_per_mwh_for_electricity_adjusted\", \"co2_mass_lb\", \"fuel_category\"], \n",
+    "    index_col=\"datetime_utc\", parse_dates=True)\n",
+    "hourly_rate = hourly_rate[hourly_rate.fuel_category == \"natural_gas\"]\n",
+    "\n",
+    "fig = go.Figure()\n",
+    "fig.add_trace(go.Scatter(x=hourly_rate.index, y=hourly_rate[\"generated_co2_rate_lb_per_mwh_for_electricity_adjusted\"], name=\"Hourly emission rate\"))\n",
+    "fig.add_trace(go.Scatter(x=[parse_dt(\"2020-01-01T00:00\"), parse_dt(\"2021-01-01T00:00\")], \n",
+    "    y=[factors[\"adjusted\"][\"EIA.\"+ba_of_interest][\"natural_gas\"][\"value\"], factors[\"adjusted\"][\"EIA.\"+ba_of_interest][\"natural_gas\"][\"value\"]], \n",
+    "    name=\"eGRID annual emission rate\", mode=\"lines\"\n",
+    "))\n",
+    "\n",
+    "fig.update_xaxes(range=(parse_dt(\"2020-01-01T00:00\"), parse_dt(\"2021-01-01T00:00\")))\n",
+    "fig.update_layout(template=\"plotly_white\", title=f\"Natural gas emission rates in {ba_of_interest}O\",\n",
+    "legend=dict(\n",
+    "    yanchor=\"top\",\n",
+    "    y=0.99,\n",
+    "    xanchor=\"left\",\n",
+    "    x=0.01\n",
+    "))\n",
+    "\n",
+    "fig.update_yaxes(title_text='Natural gas emission rate<br>(lb CO2/MWh)')\n",
+    "\n",
+    "fig.show()\n",
+    "\n",
+    "pio.write_image(fig, f\"{filepaths.data_folder()}/outputs/viz/gas_rate_{ba_of_interest}.jpg\", width=1000*(4/5), height=500*(4/5), scale=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "oge_generation = pd.read_csv(gen_path+ba_of_interest+\".csv\", \n",
+    "    usecols=[\"datetime_utc\", \"fuel_category\", \"net_generation_mwh\"], \n",
+    "    index_col=\"datetime_utc\", parse_dates=True)\n",
+    "oge_generation = oge_generation.pivot(columns=\"fuel_category\", values=\"net_generation_mwh\")\n",
+    "\n",
+    "# plot real-time and OGE per-fuel generation in FPC to identify source of neg correlation \n",
+    "eiacols = [f'EBA.{ba_of_interest}-ALL.NG.COL.H',\n",
+    " f'EBA.{ba_of_interest}-ALL.NG.NG.H',\n",
+    " f'EBA.{ba_of_interest}-ALL.NG.NUC.H',\n",
+    " f'EBA.{ba_of_interest}-ALL.NG.OIL.H',\n",
+    " f'EBA.{ba_of_interest}-ALL.NG.OTH.H',\n",
+    " f'EBA.{ba_of_interest}-ALL.NG.SUN.H',\n",
+    " f'EBA.{ba_of_interest}-ALL.NG.UNK.H',\n",
+    " f'EBA.{ba_of_interest}-ALL.NG.WAT.H',\n",
+    " f'EBA.{ba_of_interest}-ALL.NG.WND.H']\n",
+    "\n",
+    "toplot = pd.concat([eia930[eiacols], oge_generation])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "toplot.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# plot real-time and OGE per-fuel generation in FPC to identify source of neg correlation \n",
+    "plotcols = [\n",
+    " #f'EBA.{ba_of_interest}-ALL.NG.COL.H',\n",
+    " #f'EBA.{ba_of_interest}-ALL.NG.NG.H',\n",
+    " #f'EBA.{ba_of_interest}-ALL.NG.NUC.H',\n",
+    " #f'EBA.{ba_of_interest}-ALL.NG.OIL.H',\n",
+    " f'EBA.{ba_of_interest}-ALL.NG.OTH.H',\n",
+    " #f'EBA.{ba_of_interest}-ALL.NG.SUN.H',\n",
+    " f'EBA.{ba_of_interest}-ALL.NG.UNK.H',\n",
+    " f'EBA.{ba_of_interest}-ALL.NG.WAT.H',\n",
+    " #f'EBA.{ba_of_interest}-ALL.NG.WND.H',\n",
+    " #\"biomass\",\n",
+    " #\"natural_gas\",\n",
+    " #\"petroleum\",\n",
+    " #\"solar\",\n",
+    " #\"total\",\n",
+    " #\"waste\",\n",
+    " #\"geothermal\", \n",
+    " \"hydro\",\n",
+    " #\"wind\",\n",
+    " ]\n",
+    "\n",
+    "px.line(toplot[plotcols])\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# What plants "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "px.histogram(all_dat, x=\"percent_difs\", title=\"NYIS hourly difference between benchmark and real-time<br>as percent of benchmark \")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Roll up real-time to annual to compare to eGRID\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Real time aggregated over 2020, lb CO2 {all_dat['adjusted_carbon'].sum()}\")\n",
+    "print(f\"egrid is {28845962*2000}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(55539223793.10689 - 57691924000)/57691924000"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Plot differences over BAs\n",
+    "\n",
+    "Correlation, % difference, BA size, CI. \n",
+    "Goal: show that errors are concentrated in smaller BAs "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "out.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "px.scatter(out, x=\"Difference as percent of OGE\", y=\"Correlation\", size=\"Annual BA generation\", template=\"plotly_white\")#, text=out.index)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#fig = px.scatter(out, x=\"Annual BA generation\", y=\"Correlation\", template=\"plotly_white\")#, text=out.index)\n",
+    "fig = go.Figure()\n",
+    "\n",
+    "fig.add_trace(go.Scatter(y=[-3000000,805000000], x=[1,1], line={\"width\":2, \"color\":\"lightslategrey\"}, mode=\"lines\"))\n",
+    "fig.add_trace( go.Scatter(y=out[\"Annual BA generation\"], x=out[\"Correlation\"], text=out.index, mode=\"markers\", marker={\"color\":\"rgb(17, 119, 51)\"})) #, color=\"Median rate\")#, text=out.index)\n",
+    "fig.update_yaxes(range=(-3000000,805000000))\n",
+    "fig.update_layout(template=\"plotly_white\", showlegend=False)\n",
+    "\n",
+    "fig.update_xaxes(dtick=.250)\n",
+    "fig.show()\n",
+    "pio.write_image(fig, f\"{filepaths.data_folder()}/outputs/viz/cor_ba_gen.jpg\", width=800*(1/2), height=900*(1/2), scale=4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#px.scatter(out, x=\"Annual BA generation\", y=\"Difference as percent of OGE\")#, text=out.index)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = go.Figure()\n",
+    "\n",
+    "fig.add_trace(go.Scatter(y=[-3000000,805000000], x=[0,0], line={\"width\":2, \"color\":\"lightslategrey\"}, mode=\"lines\"))\n",
+    "fig.add_trace( go.Scatter(y=out[\"Annual BA generation\"], x=out[\"Median rate difference\"], text=out.index, mode=\"markers\", marker={\"color\":\"rgb(17, 119, 51)\"})) #, color=\"Median rate\")#, text=out.index)\n",
+    "fig.update_yaxes(range=(-3000000,805000000))\n",
+    "fig.update_layout(template=\"plotly_white\", showlegend=False)\n",
+    "fig.update_xaxes(dtick=500)\n",
+    "fig.show()\n",
+    "pio.write_image(fig, f\"{filepaths.data_folder()}/outputs/viz/dif_ba_gen.jpg\", width=800*(1/2), height=900*(1/2), scale=4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "px.colors.qualitative.Safe[3]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Plot natural gas emission rate as a \"future directons\" example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dat = "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Summary statistics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "good = len(out[out[\"Difference as percent of OGE\"].abs() <= .1])\n",
+    "bad = len(out[out[\"Difference as percent of OGE\"].abs() > .1])\n",
+    "print(good/(bad+good))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for col in out.columns: \n",
+    "    out = out.replace(np.inf, np.nan)\n",
+    "    out = out.replace(-1*np.inf, np.nan)\n",
+    "    non_nan_out = out.dropna(subset=col)\n",
+    "    a = np.average(non_nan_out[col].abs(), weights=non_nan_out[\"Annual BA generation\"])\n",
+    "    print(f\"{col} = {a}\")"
    ]
   },
   {
@@ -352,17 +752,14 @@
    "outputs": [],
    "source": [
     "# Plot and save all BAs \n",
-    "for ba_of_interest in os.listdir(\"{load_data.data_folder()}/outputs/2020/validation/real_time_rate/\"):\n",
+    "for ba_of_interest in os.listdir(f\"{filepaths.data_folder()}/outputs/2020/validation/real_time_rate/\"):\n",
     "    ba_of_interest = ba_of_interest.replace(\".csv\", \"\")\n",
     "    if \".DS_\" in ba_of_interest:\n",
     "        continue\n",
     "    \n",
-    "    real_time = pd.read_csv(f\"{load_data.data_folder()}/outputs/{year}/validation/real_time_rate/{ba_of_interest}.csv\", index_col=0, parse_dates=True)\n",
+    "    real_time = pd.read_csv(f\"{filepaths.data_folder()}/outputs/{year}/validation/real_time_rate/{ba_of_interest}.csv\", index_col=0, parse_dates=True)\n",
     "    real_time = real_time[\"2020-01-01T00:00\":]\n",
     "\n",
-    "    hourly_consumed = pd.read_csv(consumed_path+ba_of_interest+\".csv\",\n",
-    "        usecols=[\"datetime_utc\", \"consumed_co2_rate_lb_per_mwh_for_electricity\", \"consumed_co2_rate_lb_per_mwh_for_electricity_adjusted\"], \n",
-    "        index_col=\"datetime_utc\", parse_dates=True)\n",
     "    hourly_generated = pd.read_csv(gen_path+ba_of_interest+\".csv\", \n",
     "        usecols=[\"datetime_utc\", \"generated_co2_rate_lb_per_mwh_for_electricity\", \"generated_co2_rate_lb_per_mwh_for_electricity_adjusted\", \"co2_mass_lb\", \"fuel_category\"], \n",
     "        index_col=\"datetime_utc\", parse_dates=True)\n",
@@ -379,7 +776,7 @@
     "\n",
     "    newnames = {'generated_co2_rate_lb_per_mwh_for_electricity': 'Our data', 'adjusted_rate': 'Real-time data'}\n",
     "    fig.for_each_trace(lambda t: t.update(name = newnames[t.name]))\n",
-    "    pio.write_image(fig, f\"{load_data.data_folder()}/outputs/viz/{ba_of_interest}.jpg\", width=1000, height=400, scale=3)"
+    "    pio.write_image(fig, f\"{filepaths.data_folder()}/outputs/viz/{ba_of_interest}.jpg\", width=1000, height=400, scale=3)"
    ]
   },
   {

--- a/notebooks/visualization/map_visualization.ipynb
+++ b/notebooks/visualization/map_visualization.ipynb
@@ -595,7 +595,7 @@
    ],
    "metadata": {
       "kernelspec": {
-         "display_name": "Python 3.10.4 ('open_grid_emissions')",
+         "display_name": "Python 3.10.5 ('hourly_egrid')",
          "language": "python",
          "name": "python3"
       },
@@ -609,12 +609,12 @@
          "name": "python",
          "nbconvert_exporter": "python",
          "pygments_lexer": "ipython3",
-         "version": "3.10.4"
+         "version": "3.10.5"
       },
       "orig_nbformat": 4,
       "vscode": {
          "interpreter": {
-            "hash": "25e36f192ecdbe5da57d9bea009812e7b11ef0e0053366a845a2802aae1b29d2"
+            "hash": "65c02dfd2dc2ef471c0b5088763a28c1faaa7cad28937ca42fadf51e669fd8e8"
          }
       }
    },

--- a/notebooks/work_in_progress/GH240_eia930_physics_reconciliation.ipynb
+++ b/notebooks/work_in_progress/GH240_eia930_physics_reconciliation.ipynb
@@ -1,0 +1,148 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook is meant to start exploring issue 240 (https://github.com/singularity-energy/open-grid-emissions/issues/240).\n",
+    "\n",
+    "We want to investigate how much the physics-based reconciliation is modifying the original net generation profiles, especially in ways that seem inconsistent with the original data (e.g. modifying a flat nuclear profile to be load following).  \n",
+    "\n",
+    "To do this, we are loading the raw EIA-930 data and the reconciled data and comparing them side by side.  \n",
+    "\n",
+    "We first calculate the correlation between each timeseries in each month to identify particularly eggregious examples where the shape of the modified profile does not resemble the shape of the raw profile (e.g. correlation near zero or negative)\n",
+    "\n",
+    "We then visualize these individual timeseries to see what's going on. In some cases, these low correlations are resulting from spikes being cleaned, but in others, the reconciliation process is just modifying the profile in an unacceptable way.\n",
+    "\n",
+    "The next step is to think about if we can adjust the reconciliation parameters to prevent this issue."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# import packages\n",
+    "import pandas as pd\n",
+    "import os\n",
+    "import plotly.express as px\n",
+    "\n",
+    "%reload_ext autoreload\n",
+    "%autoreload 2\n",
+    "\n",
+    "# # Tell python where to look for modules.\n",
+    "import sys\n",
+    "sys.path.append('../../../open-grid-emissions/src/')\n",
+    "\n",
+    "import download_data\n",
+    "import load_data\n",
+    "from column_checks import get_dtypes\n",
+    "from filepaths import *\n",
+    "import impute_hourly_profiles\n",
+    "import data_cleaning\n",
+    "import output_data\n",
+    "import emissions\n",
+    "import validation\n",
+    "import gross_to_net_generation\n",
+    "import eia930\n",
+    "\n",
+    "year = 2020\n",
+    "path_prefix = f\"{year}/\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load the raw and cleaned eia930 data to compare\n",
+    "raw_930_file = outputs_folder(f\"{path_prefix}/eia930/eia930_raw.csv\")\n",
+    "clean_930_file = outputs_folder(f\"{path_prefix}/eia930/eia930_elec.csv\")\n",
+    "\n",
+    "eia930_raw = eia930.load_chalendar_for_pipeline(raw_930_file, year=year)\n",
+    "eia930_data = eia930.load_chalendar_for_pipeline(clean_930_file, year=year)\n",
+    "\n",
+    "eia930_merged = eia930_raw.merge(eia930_data, how=\"left\", on=[\"ba_code\",\"fuel_category_eia930\",\"datetime_utc\",\"datetime_local\",\"report_date\"], suffixes=(\"_raw\",\"_cleaned\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# calculate how well correlated the raw and cleaned data is\n",
+    "correlations = eia930_merged.groupby([\"ba_code\",\"fuel_category_eia930\",\"report_date\"], dropna=False)[[\"net_generation_mwh_930_raw\",\"net_generation_mwh_930_cleaned\"]].corr().reset_index()\n",
+    "correlations = correlations[correlations[\"level_3\"] == \"net_generation_mwh_930_raw\"]\n",
+    "correlations = correlations.drop(columns=[\"level_3\",\"net_generation_mwh_930_raw\"])\n",
+    "correlations = correlations.rename(columns={\"net_generation_mwh_930_cleaned\":\"correlation_with_raw\"})\n",
+    "correlations = correlations[correlations[\"report_date\"].dt.year == 2020]\n",
+    "correlations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ba = \"PJM\"\n",
+    "fuel = \"coal\"\n",
+    "\n",
+    "correlations[(correlations[\"ba_code\"] == ba) & (correlations[\"fuel_category_eia930\"] == fuel)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "correlations[correlations[\"correlation_with_raw\"] < 0.1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ba = \"BPAT\"\n",
+    "fuel = \"nuclear\"\n",
+    "\n",
+    "data_to_plot = eia930_merged[(eia930_merged[\"ba_code\"] == ba) & (eia930_merged[\"fuel_category_eia930\"] == fuel)]\n",
+    "\n",
+    "px.line(data_to_plot, x=\"datetime_local\", y=[\"net_generation_mwh_930_raw\",\"net_generation_mwh_930_cleaned\"])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.10.4 ('open_grid_emissions')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "25e36f192ecdbe5da57d9bea009812e7b11ef0e0053366a845a2802aae1b29d2"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/work_in_progress/clean_cems_outliers.ipynb
+++ b/notebooks/work_in_progress/clean_cems_outliers.ipynb
@@ -1,0 +1,377 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Clean cems\n",
+    "\n",
+    "Temporary notebook for cleaning cems using 860 net capacity \n",
+    "\n",
+    "Notes: \n",
+    "* CEMS data is per smokestack/EPA unit: https://catalystcoop-pudl.readthedocs.io/en/latest/data_sources/epacems.html, while 860 capacity is per generator. So need to use crosswalk to sum generators to EPA units before checking against CEMS \n",
+    "* Some CEMS spikes will be short enough to interpolate, while some won't. What's the cutoff? And when we don't interpolate, do we want to trash the whole month and use the residual, or just fill in the residual during missing times? "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import plotly.express as px"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%reload_ext autoreload\n",
+    "%autoreload 2\n",
+    "\n",
+    "# # Tell python where to look for modules.\n",
+    "import sys\n",
+    "\n",
+    "sys.path.append(\"../../src/\")\n",
+    "\n",
+    "# import local modules\n",
+    "import src.load_data as load_data\n",
+    "from src.filepaths import outputs_folder\n",
+    "from src.column_checks import get_dtypes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "year = 2020"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems = pd.read_csv(f\"{outputs_folder()}/{year}/cems_{year}.csv\", dtype=get_dtypes())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# example CEMS data \n",
+    "px.line(cems[cems.plant_id_eia==3], x=\"datetime_utc\", y=\"net_generation_mwh\", color=\"subplant_id\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Simple cleaning \n",
+    "At the subplant level, filter data where hourly CEMS generation exceeds 890 capacity. \n",
+    "\n",
+    "Active questions: \n",
+    "* Do we need to build in a buffer for generation that slightly exceeds capacity but is still possible? In some cases, capacity is estimated; and we know that it's variable (eg, summer capacity < winter capacity; both summer and winter capacity often exceed nameplate capacity)\n",
+    "* Do we need to aggregate to the plant level to do this check? This would allow data to pass through the filter even if it's potentially labeled with the incorrect subplant. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pudl_dat = load_data.initialize_pudl_out(year=year)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gens_pudl = pudl_dat.gens_eia860()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Table is unique by plant ID, generator ID. \n",
+    "# For each plant and generator, find the maximum of the three capacity values (summer, winter, nameplate)\n",
+    "gens = gens_pudl.copy(deep=True)\n",
+    "gens[\"net_capacity_mw\"] = gens.winter_capacity_mw.combine(gens.summer_capacity_mw, max)\n",
+    "gens[\"net_capacity_mw\"] = gens.net_capacity_mw.combine(gens.capacity_mw, max)\n",
+    "gens = gens.loc[:,[\"plant_id_eia\",\"generator_id\",\"net_capacity_mw\"]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Subplants are defined on \"plant_id_eia\", largest of (\"unitid\", \"generator_id\")\n",
+    "subplant_crosswalk = pd.read_csv(f\"{outputs_folder()}/{year}/subplant_crosswalk.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gens_unit = gens.merge(subplant_crosswalk, how='left', on=['plant_id_eia','generator_id'])\n",
+    "print(f\"Setting {sum(gens_unit.subplant_id.isna())} NaN subplants to 1 in 860 data\")\n",
+    "gens_unit.loc[gens_unit.subplant_id.isna()] = 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Group gens by subplant \n",
+    "gens_per_sub = gens_unit.groupby([\"plant_id_eia\", \"subplant_id\"]).sum().reset_index()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems.subplant_id.dtype"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Setting {sum(cems.subplant_id.isna())} NaN subplants to 1 in CEMS data\")\n",
+    "cems.loc[cems.subplant_id.isna(), \"subplant_id\"] = 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Now that nans are gone, we can switch from the weird pandas int dtype to numpy dtype, which is required for merge \n",
+    "cems = cems.astype(dtype={\"subplant_id\":np.int32})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems_cap = cems.merge(gens_per_sub[[\"plant_id_eia\", \"subplant_id\", \"net_capacity_mw\"]], how='left', on=[\"plant_id_eia\", \"subplant_id\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: here we're assuming that all columns are bad if net gen is bad, and that all bad rows have bad net gen. \n",
+    "dat_cols = ['gross_generation_mwh', 'steam_load_1000_lb', 'fuel_consumed_mmbtu', 'co2_mass_lb', 'nox_mass_lb', 'so2_mass_lb', 'plant_id_epa', 'co2_mass_measurement_code', 'nox_mass_measurement_code', 'so2_mass_measurement_code', 'report_date', 'energy_source_code', 'ch4_mass_lb', 'n2o_mass_lb', 'fuel_consumed_for_electricity_mmbtu', 'co2_mass_lb_for_electricity', 'ch4_mass_lb_for_electricity', 'n2o_mass_lb_for_electricity', 'nox_mass_lb_for_electricity', 'so2_mass_lb_for_electricity', 'co2_mass_lb_adjusted', 'ch4_mass_lb_adjusted', 'n2o_mass_lb_adjusted', 'nox_mass_lb_adjusted', 'so2_mass_lb_adjusted','net_generation_mwh']\n",
+    "bad = cems_cap.net_generation_mwh > cems_cap.net_capacity_mw\n",
+    "cems_cap.loc[bad,dat_cols] = np.nan"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems_cap[bad]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## What proportion of CEMS data was ID'ed as bad using capacity filter? \n",
+    "sum(bad)/len(cems)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plant = 2410\n",
+    "\n",
+    "print(gens_unit.loc[gens_unit.plant_id_eia==plant,[\"plant_id_eia\", \"subplant_id\", \"generator_id\",\"net_capacity_mw\"]])\n",
+    "\n",
+    "px.line(cems_cap[cems_cap.plant_id_eia==plant], x=\"datetime_utc\", y=\"net_generation_mwh\", color=\"subplant_id\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(gens_unit.loc[gens_unit.plant_id_eia==plant,[\"plant_id_eia\", \"subplant_id\", \"generator_id\",\"net_capacity_mw\"]])\n",
+    "\n",
+    "px.line(cems[cems.plant_id_eia==plant], x=\"datetime_utc\", y=\"net_generation_mwh\", color=\"subplant_id\", title=f\"plant id = {plant}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Median/IQR cleaning \n",
+    "\n",
+    "### Advantages over capacity cleaning: \n",
+    "Works consistantly for all data types, and isn't sensitive to plants occasionally producing over capacity"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get per-plant, per-variable median and IQR \n",
+    "numeric_cols = ['gross_generation_mwh', 'steam_load_1000_lb', 'fuel_consumed_mmbtu', 'co2_mass_lb', 'ch4_mass_lb', 'n2o_mass_lb', 'nox_mass_lb', 'so2_mass_lb', 'co2_mass_lb_adjusted', 'ch4_mass_lb_adjusted', 'n2o_mass_lb_adjusted', 'nox_mass_lb_adjusted', 'so2_mass_lb_adjusted', 'net_generation_mwh', 'fuel_consumed_for_electricity_mmbtu', 'co2_mass_lb_for_electricity', 'co2_mass_lb_for_electricity_adjusted', 'ch4_mass_lb_for_electricity', 'ch4_mass_lb_for_electricity_adjusted', 'n2o_mass_lb_for_electricity', 'n2o_mass_lb_for_electricity_adjusted', 'nox_mass_lb_for_electricity', 'nox_mass_lb_for_electricity_adjusted', 'so2_mass_lb_for_electricity', 'so2_mass_lb_for_electricity_adjusted', 'co2e_mass_lb', 'co2e_mass_lb_adjusted', 'co2e_mass_lb_for_electricity', 'co2e_mass_lb_for_electricity_adjusted']\n",
+    "iqr = cems.groupby([\"plant_id_eia\", \"subplant_id\"])[numeric_cols].quantile(.75) - cems.groupby([\"plant_id_eia\",\"subplant_id\"])[numeric_cols].quantile(.25)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "median = cems.groupby([\"plant_id_eia\",\"subplant_id\"]).median()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lower_bound = median + (iqr * -3)\n",
+    "upper_bound = median + (iqr * 3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems_filtered = cems.copy()\n",
+    "#for plant in cems_filtered.plant_id_eia.unique():\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems_filtered = cems_filtered.set_index([\"plant_id_eia\",\"subplant_id\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems_filtered.loc[(3,1)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "checked = (cems_filtered.loc[(3,1), lower_bound.columns] < lower_bound.loc[(3,1)]) | (cems_filtered.loc[(3,1), lower_bound.columns] > upper_bound.loc[(3, 1)])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "checked.sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "toplot = cems_filtered.loc[(3,1)]\n",
+    "px.scatter(toplot, x=\"datetime_utc\", y=\"fuel_consumed_mmbtu\", color=checked[\"fuel_consumed_mmbtu\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "median.loc[(3,1)]"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.9.13 ('hourly_egrid')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.5"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "65c02dfd2dc2ef471c0b5088763a28c1faaa7cad28937ca42fadf51e669fd8e8"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/work_in_progress/issue230_spikes.ipynb
+++ b/notebooks/work_in_progress/issue230_spikes.ipynb
@@ -1,0 +1,187 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# issue 230: spikes in PJM caused by broken filter \n",
+    "\n",
+    "process: \n",
+    "\n",
+    "* verify that shaped_profiles shows bug \n",
+    "\n",
+    "It does not! profile_method correctly selects 930_profile during the issue, and `profile` does not show the dips. So the issue seems to be with the application of the profiles. \n",
+    "Shaped 923 data also does not show issue (though it does show variable nuclear profile, which is still wrong -- that's an issue introduced by `gridemissions`)\n",
+    "\n",
+    "* replicate running `impute_hourly_profiles.calculate_hourly_profiles` to reproduce bug \n",
+    "* fix bug \n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd \n",
+    "import plotly.express as px"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%reload_ext autoreload\n",
+    "%autoreload 2\n",
+    "\n",
+    "# # Tell python where to look for modules.\n",
+    "import sys\n",
+    "sys.path.append('../../src/')\n",
+    "\n",
+    "import impute_hourly_profiles\n",
+    "from filepaths import outputs_folder, results_folder\n",
+    "from column_checks import get_dtypes\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "problem_profiles = pd.read_csv(f\"{outputs_folder()}/2020/hourly_profiles_2020.csv\", dtype=get_dtypes())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "problem_profiles = problem_profiles[(problem_profiles.ba_code==\"PJM\") & (problem_profiles.fuel_category==\"nuclear\")]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "problem_profiles.head()\n",
+    "\n",
+    "px.line(problem_profiles, x=\"datetime_utc\", y=[\"residual_profile\",\"scaled_residual_profile\",\"shifted_residual_profile\",\"profile\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "problem_profiles.profile_method.unique()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "problem_profiles[(problem_profiles.datetime_utc > \"2020-04-15\") & (problem_profiles.datetime_utc < \"2020-04-16\")]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "### Look for the issue in the next output \n",
+    "shaped = pd.read_csv(f\"{outputs_folder()}/2020/shaped_eia923_data_2020.csv\", dtype=get_dtypes())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "shaped = shaped[(shaped.ba_code==\"PJM\")]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "px.line(shaped, x=\"datetime_utc\", y=\"net_generation_mwh\", line_group=\"fuel_category\", color=\"fuel_category\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#### Ok, issue is not in 923 shaped data, so it must just be in CEMS data \n",
+    "plant_level = pd.read_csv(f\"{results_folder()}/2020/plant_data/hourly/us_units/individual_plant_data.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "problem_plant = plant_level[plant_level.plant_id_eia == 2410]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "px.line(problem_plant, x=\"datetime_utc\", y=\"net_generation_mwh\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.10.5 ('hourly_egrid')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.5"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "65c02dfd2dc2ef471c0b5088763a28c1faaa7cad28937ca42fadf51e669fd8e8"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/work_in_progress/sandbox.ipynb
+++ b/notebooks/work_in_progress/sandbox.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebooks/work_in_progress/sandbox.ipynb
+++ b/notebooks/work_in_progress/sandbox.ipynb
@@ -1,13 +1,6 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "This notebook is set up to test code as needed."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -15,7 +8,9 @@
    "source": [
     "# import packages\n",
     "import pandas as pd\n",
+    "import numpy as np\n",
     "import os\n",
+    "import plotly.express as px\n",
     "\n",
     "%reload_ext autoreload\n",
     "%autoreload 2\n",

--- a/notebooks/work_in_progress/test_eia923_allocation.ipynb
+++ b/notebooks/work_in_progress/test_eia923_allocation.ipynb
@@ -12,15 +12,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "%reload_ext autoreload\n",
     "%autoreload 2\n",
-    "\n",
-    "import sys\n",
-    "sys.path.append('../../../open-grid-emissions/')\n",
     "\n",
     "# Useful high-level external modules.\n",
     "import numpy as np\n",
@@ -31,35 +28,13 @@
     "\n",
     "import pudl\n",
     "\n",
-    "import src.data_cleaning as data_cleaning\n",
-    "import src.load_data as load_data\n",
+    "# # Tell python where to look for modules.\n",
+    "import sys\n",
+    "sys.path.append('../../../open-grid-emissions/src/')\n",
+    "\n",
+    "import data_cleaning\n",
+    "import load_data\n",
     "import pudl.analysis.allocate_net_gen as allocate_gen_fuel\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "year = 2020\n",
-    "\n",
-    "pudl_db = 'sqlite:///../data/downloads/pudl/pudl_data/sqlite/pudl.sqlite'\n",
-    "pudl_engine = sa.create_engine(pudl_db)\n",
-    "\n",
-    "pudl_out = pudl.output.pudltabl.PudlTabl(\n",
-    "    pudl_engine,\n",
-    "    freq='MS',\n",
-    "    start_date=f'{year}-01-01',\n",
-    "    end_date=f'{year}-12-31'\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Load EIA data"
    ]
   },
   {
@@ -68,12 +43,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# extract all of the tables from pudl_out early in the process and select\n",
-    "# only the columns we need. this is for speed and clarity.\n",
-    "\n",
-    "remove_this = pudl.analysis.allocate_net_gen\n",
-    "drop_interim_cols = False\n",
-    "\n",
+    "year = 2020\n",
+    "pudl_out = load_data.initialize_pudl_out(year)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "IDX_GENS = [\"report_date\", \"plant_id_eia\", \"generator_id\"]\n",
     "\"\"\"Id columns for generators.\"\"\"\n",
     "\n",
@@ -99,8 +78,15 @@
     "\n",
     "IDX_ESC = [\"report_date\", \"plant_id_eia\", \"energy_source_code\"]\n",
     "\n",
-    "IDX_U_ESC = [\"report_date\", \"plant_id_eia\", \"energy_source_code\", \"unit_id_pudl\"]\n",
-    "\n",
+    "IDX_U_ESC = [\"report_date\", \"plant_id_eia\", \"energy_source_code\", \"unit_id_pudl\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# extract all of the tables from pudl_out early in the process and select\n",
     "# only the columns we need. this is for speed and clarity.\n",
     "gens = pudl_out.gens_eia860().loc[\n",
@@ -128,7 +114,7 @@
     "            \"fuel_consumed_for_electricity_mmbtu\",\n",
     "        ],\n",
     "    ]\n",
-    "    .pipe(remove_this.manually_fix_energy_source_codes)\n",
+    "    .pipe(allocate_gen_fuel.manually_fix_energy_source_codes)\n",
     ")\n",
     "bf = (\n",
     "    pudl_out.bf_eia923()\n",
@@ -139,16 +125,28 @@
     "    )\n",
     "    .loc[:, IDX_B_PM_ESC + [\"fuel_consumed_mmbtu\"]]\n",
     ").pipe(\n",
-    "    remove_this.distribute_annually_reported_data_to_months,\n",
+    "    allocate_gen_fuel.distribute_annually_reported_data_to_months,\n",
     "    key_columns=[\"plant_id_eia\", \"boiler_id\", \"energy_source_code\"],\n",
     "    data_column_name=\"fuel_consumed_mmbtu\",\n",
     ")\n",
+    "# load boiler generator associations\n",
+    "bga = pudl_out.bga_eia860().loc[\n",
+    "    :,\n",
+    "    [\n",
+    "        \"plant_id_eia\",\n",
+    "        \"boiler_id\",\n",
+    "        \"generator_id\",\n",
+    "        \"report_date\",\n",
+    "    ],\n",
+    "]\n",
     "# allocate the boiler fuel data to generators\n",
-    "bf = remove_this.allocate_bf_data_to_gens(bf, gens, pudl_out)\n",
+    "bf = allocate_gen_fuel.allocate_bf_data_to_gens(bf, gens, bga)\n",
     "\n",
     "# add any startup energy source codes to the list of energy source codes\n",
     "# fix MSW codes\n",
-    "gens = remove_this.adjust_energy_source_codes(gens, gf, bf)\n",
+    "gens = allocate_gen_fuel.adjust_energy_source_codes(gens, gf, bf)\n",
+    "\n",
+    "\n",
     "# fix prime mover codes in gens so that they match the codes in the gf table\n",
     "missing_pm = gens[gens[\"prime_mover_code\"].isna()]\n",
     "if not missing_pm.empty:\n",
@@ -157,14 +155,17 @@
     "        \"This will result in incorrect allocation.\"\n",
     "    )\n",
     "# duplicate each entry in the gens table 12 times to create an entry for each month of the year\n",
-    "gens = remove_this.create_monthly_gens_records(gens)\n",
+    "if pudl_out.freq == \"MS\":\n",
+    "    gens = pudl.helpers.expand_timeseries(\n",
+    "        df=gens, key_cols=[\"plant_id_eia\", \"generator_id\"], freq=\"MS\"\n",
+    "    )\n",
     "\n",
     "gen = (\n",
     "    pudl_out.gen_original_eia923().loc[:, IDX_GENS + [\"net_generation_mwh\"]]\n",
     "    # removes 4 records with NaN generator_id as of pudl v0.5\n",
     "    .dropna(subset=IDX_GENS)\n",
     ").pipe(\n",
-    "    remove_this.distribute_annually_reported_data_to_months,\n",
+    "    allocate_gen_fuel.distribute_annually_reported_data_to_months,\n",
     "    key_columns=[\"plant_id_eia\", \"generator_id\"],\n",
     "    data_column_name=\"net_generation_mwh\",\n",
     ")\n",
@@ -176,147 +177,11 @@
     "    on=[\"plant_id_eia\", \"generator_id\", \"report_date\"],\n",
     ")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# do the association!\n",
-    "gen_assoc = remove_this.associate_generator_tables(\n",
-    "    gf=gf, gen=gen, gens=gens, bf=bf, pudl_out=pudl_out\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "gen_assoc[(gen_assoc[[\"fuel_consumed_mmbtu_gf_tbl\",\"fuel_consumed_for_electricity_mmbtu_gf_tbl\",\"fuel_consumed_mmbtu_bf_tbl\",\"fuel_consumed_mmbtu_gf_tbl_fuel\",\"fuel_consumed_for_electricity_mmbtu_gf_tbl_fuel\"]] < 0).any(axis=1)]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Generate a fraction to use to allocate net generation and fuel consumption by.\n",
-    "# These two methods create a column called `frac`, which will be a fraction\n",
-    "# to allocate net generation from the gf table for each `IDX_PM_ESC` group\n",
-    "gen_pm_fuel = remove_this.prep_alloction_fraction(gen_assoc)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "gen_pm_fuel"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "gen_pm_fuel[(gen_pm_fuel[[\"fuel_consumed_mmbtu_gf_tbl\",\"fuel_consumed_for_electricity_mmbtu_gf_tbl\",\"fuel_consumed_mmbtu_bf_tbl\",\"fuel_consumed_mmbtu_gf_tbl_fuel\",\"fuel_consumed_for_electricity_mmbtu_gf_tbl_fuel\",\"fuel_consumed_mmbtu_bf_tbl_pm_fuel\",\"fuel_consumed_mmbtu_bf_tbl_unit_fuel\"]] < 0).any(axis=1)]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# fuel allocation\n",
-    "fuel_alloc = remove_this.allocate_fuel_by_gen_esc(gen_pm_fuel)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plant_id_to_investigate = 3399"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "gen_assoc[gen_assoc['plant_id_eia'] == plant_id_to_investigate]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "gens[gens['plant_id_eia'] == plant_id_to_investigate]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "gens.loc[gens['prime_mover_code'].isna(), ['plant_id_eia','generator_id']].drop_duplicates()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "gens[gens['generator_id'].str.contains('ST')]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "gen[gen['plant_id_eia'] == plant_id_to_investigate]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "gf[gf['plant_id_eia'] == plant_id_to_investigate]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "bf[(bf['plant_id_eia'] == plant_id_to_investigate) & (bf[\"report_date\"] == \"2020-01-01\")]"
-   ]
   }
  ],
  "metadata": {
-  "interpreter": {
-   "hash": "4103f3cd497821eca917ea303dbe10c590d787eb7d2dc3fd4e15dec0356e7931"
-  },
   "kernelspec": {
-   "display_name": "Python 3.9.12 ('hourly_egrid')",
+   "display_name": "Python 3.10.4 ('open_grid_emissions')",
    "language": "python",
    "name": "python3"
   },
@@ -330,9 +195,14 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
+   "version": "3.10.4"
   },
-  "orig_nbformat": 4
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "25e36f192ecdbe5da57d9bea009812e7b11ef0e0053366a845a2802aae1b29d2"
+   }
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/src/column_checks.py
+++ b/src/column_checks.py
@@ -302,8 +302,10 @@ COLUMNS = {
         "monthly_plant_ratio",
         "subplant_regression_ratio",
         "subplant_regression_shift_mw",
+        "subplant_regression_rsq_adj",
         "plant_regression_ratio",
         "plant_regression_shift_mw",
+        "plant_regression_rsq_adj",
     },
     "shaped_aggregated_plants": {
         "plant_id_eia",

--- a/src/column_checks.py
+++ b/src/column_checks.py
@@ -185,6 +185,7 @@ COLUMNS = {
         "data_source",
         "hourly_profile_source",
         "net_generation_method",
+        "shaped_plant_id",
     },
     "hourly_profiles": {
         "ba_code",

--- a/src/data_cleaning.py
+++ b/src/data_cleaning.py
@@ -1230,13 +1230,23 @@ def adjust_cems_for_chp(cems, eia923_allocated):
 def identify_hourly_data_source(eia923_allocated, cems, year):
     """Identifies whether there is hourly CEMS data available for each subplant-month.
     Possible categories:
-        1. `cems`: For subplant-months for which we have hourly CEMS data for all CEMS units that make up that subplant,
-            we will use the hourly values reported in CEMS. (Add a validation check for the net generation and fuel consumption totals)
-        2. `partial_cems`: For subplant-months for which we have hourly CEMS data
+        1. `cems`: For subplant-months for which we have hourly CEMS data for all CEMS
+            units that make up that subplant, we will use the hourly values reported in
+            CEMS.
+        2. `partial_cems_subplant`: For subplant-months for which we have hourly CEMS data
             for only some of the CEMS units that make up a subplant, we will use the reported
-            EIA-923 values to scale the partial hourly CEMS data from the other units to match the total value for the entire subplant. This will also calculate a partial subplant scaling factor for each data column (e.g. net generation, fuel consumption) by comparing the total monthly CEMS data to the monthly EIA-923 data.
-        3. `eia`: for subplant-months for which no hourly data is reported in CEMS,
-            we will attempt to use EIA-930 data to assign an hourly profile to the monthly EIA-923 data
+            EIA-923 values to scale the partial hourly CEMS data from the other units to
+            match the total value for the entire subplant. We will also calculate a partial
+            subplant scaling factor for each data column (e.g. net generation, fuel
+            consumption) by comparing the total monthly CEMS data to the monthly EIA-923 data.
+        3. `partial_cems_plant`: when some subplants in a plant have CEMS data, use the shape
+            from those subplants to shape the remaining generation from that plant.
+            NOTE: This method only applies if the subplants missing CEMS data have a primary
+            fuel that would report to CEMS (ie no clean generators). This prevents a diesel
+            backup generator that reports to CEMS from being used to shape the generation of
+            a nuclear plant (for example) that does not report to CEMS.
+        4. `eia`: for subplant-months for which no hourly data is reported in CEMS, we will
+            attempt to use EIA-930 data to assign an hourly profile to the monthly EIA-923 data
     Inputs:
         eia923_allocated:
         cems:
@@ -1457,15 +1467,56 @@ def identify_partial_cems_plants(all_data):
         validate="m:1",
     )
 
-    # for plants where the data source is eia only, and it exists in partial plant, change the source to partial_cems_plant
+    # Plants with these primary fuel types shouldn't be shaped using CEMS data --
+    # any cems data is likely to be a backup generator and therefore not representative of overall generation.
+    non_cems_fuels = CLEAN_FUELS + ["GEO"]
+
+    # for plants where the data source is eia only, and it exists in partial plant,
+    # change the source to partial_cems_plant
+    # but only if the fuel type is consistent with CEMS fuel types
     all_data.loc[
         (all_data["hourly_data_source"] == "eia")
-        & (all_data["partial_plant"] == "both"),
+        & (all_data["partial_plant"] == "both")
+        & (
+            ~all_data["energy_source_code"].isin(non_cems_fuels)
+        ),  # CEMS data should only be used to shape if plant is primarilly fossil
         "hourly_data_source",
     ] = "partial_cems_plant"
 
+    # It is possible to have generators within a subplant assigned different hourly methods
+    # due to the source code check above if subplant_id is mixing fuel types.
+    # This was an issue before PR #239; this check will catch it if it reoccurs
+    mixed_method_subplants = (
+        all_data.groupby(
+            [
+                "plant_id_eia",
+                "subplant_id",
+                "report_date",
+            ],
+            dropna=False,
+        )
+        .nunique()
+        .reset_index()
+    )
+    mixed_method_subplants = mixed_method_subplants[
+        mixed_method_subplants.hourly_data_source > 1
+    ]
+    if len(mixed_method_subplants) > 0:
+        # Check for subplants with mixed hourly data sources,
+        # likely resulting from mixed fuel types.
+        # If subplant_id assignment is working, there shouldn't be any
+        raise Exception(
+            f"    ERROR: {len(mixed_method_subplants)} subplant-months have multiple hourly methods assigned."
+        )
+
     # remove the intermediate indicator column
-    all_data = all_data.drop(columns=["partial_plant", "eia_data", "cems_data"])
+    all_data = all_data.drop(
+        columns=[
+            "partial_plant",
+            "eia_data",
+            "cems_data",
+        ],
+    )
 
     return all_data
 

--- a/src/data_cleaning.py
+++ b/src/data_cleaning.py
@@ -1541,7 +1541,7 @@ def combine_plant_data(
     partial_cems_plant,
     eia_data,
     resolution,
-    validate=False,
+    validate=True,
 ):
     """
     Combines final hourly subplant data from each source into a single dataframe.

--- a/src/data_pipeline.py
+++ b/src/data_pipeline.py
@@ -11,6 +11,7 @@ Optional arguments for development are --small, --flat, and --skip_outputs
 # import packages
 import argparse
 import os
+import shutil
 
 # import local modules
 # import local modules
@@ -74,7 +75,12 @@ def main():
     os.makedirs(downloads_folder(), exist_ok=True)
     os.makedirs(outputs_folder(f"{path_prefix}"), exist_ok=True)
     os.makedirs(outputs_folder(f"{path_prefix}/eia930"), exist_ok=True)
-    os.makedirs(results_folder(f"{path_prefix}"), exist_ok=True)
+    # If we are outputing, wipe results dir so we can be confident there are no old result files (eg because of a file name change)
+    if not args.skip_outputs:
+        shutil.rmtree(results_folder(f"{path_prefix}"))
+        os.makedirs(results_folder(f"{path_prefix}"), exist_ok=False)
+    else: # still make sure results dir exists, but exist is ok and we won't be writing to it 
+        os.makedirs(results_folder(f"{path_prefix}"), exist_ok=True)
     os.makedirs(
         results_folder(f"{path_prefix}data_quality_metrics"),
         exist_ok=True,

--- a/src/data_pipeline.py
+++ b/src/data_pipeline.py
@@ -79,7 +79,7 @@ def main():
     if not args.skip_outputs:
         shutil.rmtree(results_folder(f"{path_prefix}"))
         os.makedirs(results_folder(f"{path_prefix}"), exist_ok=False)
-    else: # still make sure results dir exists, but exist is ok and we won't be writing to it 
+    else:  # still make sure results dir exists, but exist is ok and we won't be writing to it
         os.makedirs(results_folder(f"{path_prefix}"), exist_ok=True)
     os.makedirs(
         results_folder(f"{path_prefix}data_quality_metrics"),
@@ -128,13 +128,8 @@ def main():
     # 2. Identify subplants
     ####################################################################################
     print("2. Identifying subplant IDs")
-    # GTN ratios are saved for reloading, as this is computationally intensive
-    if not os.path.exists(outputs_folder(f"{year}/subplant_crosswalk.csv")):
-        print("    Generating subplant IDs")
-        number_of_years = args.gtn_years
-        data_cleaning.identify_subplants(year, number_of_years)
-    else:
-        print("    Subplant IDs already created")
+    number_of_years = args.gtn_years
+    data_cleaning.identify_subplants(year, number_of_years)
 
     # 3. Clean EIA-923 Generation and Fuel Data at the Monthly Level
     ####################################################################################

--- a/src/data_pipeline.py
+++ b/src/data_pipeline.py
@@ -297,7 +297,6 @@ def main():
         partial_cems_plant,
         monthly_eia_data_to_shape,
         "monthly",
-        True,
     )
     output_data.output_plant_data(
         monthly_plant_data, path_prefix, "monthly", args.skip_outputs

--- a/src/download_data.py
+++ b/src/download_data.py
@@ -138,7 +138,7 @@ def download_pudl(zenodo_url, pudl_version):
 
 def download_updated_pudl_database(download=True):
     """
-    Downloaded the updated `pudl.sqlite` file from datasette.
+    Downloaded the updated `pudl.sqlite` file from datasette, currently archived on our zenodo.
 
     This is temporary until a new version of the data is published on zenodo.
     """
@@ -147,10 +147,16 @@ def download_updated_pudl_database(download=True):
         # remove the existing file from zenodo
         os.remove(downloads_folder("pudl/pudl_data/sqlite/pudl.sqlite"))
 
-        r = requests.get("https://data.catalyst.coop/pudl.db", stream=True)
-        with open(downloads_folder("pudl/pudl_data/sqlite/pudl.sqlite"), "wb") as fd:
-            for chunk in r.iter_content(chunk_size=1024 * 1024):
-                fd.write(chunk)
+
+        url = "https://zenodo.org/record/7063072/files/pudl_data.zip?download=1"
+        download_filepath = downloads_folder("pudl/pudl_data/sqlite/pudl_data.zip")
+        output_filepath = downloads_folder("pudl/pudl_data/sqlite/pudl")
+        download_data.download_helper(
+            url, download_filepath, output_filepath, requires_unzip=True, should_clean=True
+        )
+        shutil.move(downloads_folder("pudl/pudl_data/sqlite/pudl/pudl.sqlite"), downloads_folder("pudl/pudl_data/sqlite/pudl.sqlite"))
+        os.rmdir(downloads_folder("pudl/pudl_data/sqlite/pudl/"))
+
 
 
 def download_chalendar_files():

--- a/src/gross_to_net_generation.py
+++ b/src/gross_to_net_generation.py
@@ -335,10 +335,11 @@ def calculate_gross_to_net_conversion_factors(
         columns={
             "slope": "subplant_regression_ratio",
             "intercept": "subplant_regression_shift_mw",
+            "rsquared_adj": "subplant_regression_rsq_adj",
         }
     )
     gtn_regression_subplant = gtn_regression_subplant.drop(
-        columns=["rsquared", "rsquared_adj", "observations"]
+        columns=["rsquared", "observations"]
     )
 
     gtn_regression_plant = gross_to_net_regression(combined_gen_data, "plant")
@@ -349,10 +350,11 @@ def calculate_gross_to_net_conversion_factors(
         columns={
             "slope": "plant_regression_ratio",
             "intercept": "plant_regression_shift_mw",
+            "rsquared_adj": "plant_regression_rsq_adj",
         }
     )
     gtn_regression_plant = gtn_regression_plant.drop(
-        columns=["rsquared", "rsquared_adj", "observations"]
+        columns=["rsquared", "observations"]
     )
 
     gtn_conversions = gtn_conversions.merge(
@@ -376,7 +378,7 @@ def calculate_subplant_nameplate_capacity(year):
     ]
 
     subplant_crosswalk = pd.read_csv(
-        outputs_folder(f"{year}/subplant_crosswalk.csv"),
+        outputs_folder(f"{year}/subplant_crosswalk_{year}.csv"),
         dtype=get_dtypes(),
     )[["plant_id_eia", "generator_id", "subplant_id"]].drop_duplicates()
     gen_capacity = gen_capacity.merge(
@@ -748,9 +750,9 @@ def gross_to_net_ratio(gross_gen_data, net_gen_data, agg_level, year):
 
     # load the activation and retirement dates into the data
     subplant_crosswalk = pd.read_csv(
-        outputs_folder(f"{year}/subplant_crosswalk.csv"),
+        outputs_folder(f"{year}/subplant_crosswalk_{year}.csv"),
         dtype=get_dtypes(),
-    )
+    ).dropna(subset="unitid")
     incomplete_data = incomplete_data.merge(
         subplant_crosswalk,
         how="left",

--- a/src/output_data.py
+++ b/src/output_data.py
@@ -278,22 +278,22 @@ def write_plant_metadata(
 
     if not skip_outputs:
         # From monthly EIA data, we want only the EIA-only subplants -- these are the ones that got shaped
-        monthly_eia_to_shape = eia923_allocated[
+        eia_only_subplants = eia923_allocated[
             (eia923_allocated["hourly_data_source"] == "eia")
             & ~(eia923_allocated["fuel_consumed_mmbtu"].isna())
-        ]
+        ].copy()
 
         # identify the source
         cems["data_source"] = "CEMS"
         partial_cems_subplant["data_source"] = "EIA"
         partial_cems_plant["data_source"] = "EIA"
         shaped_eia_data["data_source"] = "EIA"
-        monthly_eia_to_shape["data_source"] = "EIA"
+        eia_only_subplants["data_source"] = "EIA"
 
         # identify net generation method
         cems = cems.rename(columns={"gtn_method": "net_generation_method"})
         shaped_eia_data["net_generation_method"] = shaped_eia_data["profile_method"]
-        monthly_eia_to_shape["net_generation_method"] = "<See shaped plant ID>"
+        eia_only_subplants["net_generation_method"] = "<See shaped plant ID>"
         partial_cems_subplant["net_generation_method"] = "scaled_partial_cems_subplant"
         partial_cems_plant["net_generation_method"] = "shaped_from_partial_cems_plant"
 
@@ -304,7 +304,7 @@ def write_plant_metadata(
         shaped_eia_data = shaped_eia_data.rename(
             columns={"profile_method": "hourly_profile_source"}
         )
-        monthly_eia_to_shape["hourly_profile_source"] = "<See shaped plant ID>"
+        eia_only_subplants["hourly_profile_source"] = "<See shaped plant ID>"
 
         # only keep one metadata row per plant/subplant-month
         cems_meta = cems.copy()[KEY_COLUMNS + METADATA_COLUMNS].drop_duplicates(
@@ -319,7 +319,7 @@ def write_plant_metadata(
         shaped_eia_data_meta = shaped_eia_data.copy()[
             ["plant_id_eia", "report_date"] + METADATA_COLUMNS
         ].drop_duplicates(subset=["plant_id_eia", "report_date"])
-        monthly_eia_meta = monthly_eia_to_shape.copy()[
+        monthly_eia_meta = eia_only_subplants.copy()[
             ["plant_id_eia", "report_date"] + METADATA_COLUMNS
         ].drop_duplicates(subset=["plant_id_eia", "report_date"])
 

--- a/src/validation.py
+++ b/src/validation.py
@@ -466,7 +466,7 @@ def validate_unique_datetimes(df, df_name, keys):
 
 
 def hourly_profile_source_metric(
-    cems, partial_cems_subplant, partial_cems_plant, shaped_eia_data
+    cems, partial_cems_subplant, partial_cems_plant, shaped_eia_data, plant_attributes
 ):
     """Calculates the percentage of data whose hourly profile was determined by method"""
     data_metrics = [
@@ -479,24 +479,52 @@ def hourly_profile_source_metric(
         "so2_mass_lb_for_electricity",
     ]
 
+    # add ba codes and fuel categories to all of the data
+    cems = cems.merge(
+        plant_attributes[["plant_id_eia", "ba_code"]],
+        how="left",
+        on="plant_id_eia",
+        validate="m:1",
+    )
+    partial_cems_subplant = partial_cems_subplant.merge(
+        plant_attributes[["plant_id_eia", "ba_code"]],
+        how="left",
+        on="plant_id_eia",
+        validate="m:1",
+    )
+    partial_cems_plant = partial_cems_plant.merge(
+        plant_attributes[["plant_id_eia", "ba_code"]],
+        how="left",
+        on="plant_id_eia",
+        validate="m:1",
+    )
+
     # determine the source of the hourly profile
-    profile_from_cems = pd.DataFrame(cems[data_metrics].sum(axis=0)).T
+    profile_from_cems = (
+        cems.groupby(["ba_code"], dropna=False)[data_metrics].sum().reset_index()
+    )
     profile_from_cems["profile_method"] = "cems_reported"
 
-    profile_from_partial_cems_subplant = pd.DataFrame(
-        partial_cems_subplant[data_metrics].sum(axis=0)
-    ).T
+    profile_from_partial_cems_subplant = (
+        partial_cems_subplant.groupby(["ba_code"], dropna=False)[data_metrics]
+        .sum()
+        .reset_index()
+    )
     profile_from_partial_cems_subplant[
         "profile_method"
     ] = "eia_scaled_partial_cems_subplant"
 
-    profile_from_partial_cems_plant = pd.DataFrame(
-        partial_cems_plant[data_metrics].sum(axis=0)
-    ).T
+    profile_from_partial_cems_plant = (
+        partial_cems_plant.groupby(["ba_code"], dropna=False)[data_metrics]
+        .sum()
+        .reset_index()
+    )
     profile_from_partial_cems_plant["profile_method"] = "eia_shaped_partial_cems_plant"
 
     profile_from_eia = (
-        shaped_eia_data.groupby("profile_method", dropna=False)[data_metrics]
+        shaped_eia_data.groupby(["ba_code", "profile_method"], dropna=False)[
+            data_metrics
+        ]
         .sum()
         .reset_index()
     )
@@ -512,36 +540,59 @@ def hourly_profile_source_metric(
             profile_from_eia,
         ]
     )
-    profile_source = profile_source.set_index("profile_method")
-    profile_source = (profile_source / profile_source.sum(axis=0)).round(4)
 
-    # re-order values from best quality to lowest quality
-    profile_source = profile_source.reindex(
-        [
-            "cems_reported",
-            "eia_scaled_partial_cems_subplant",
-            "eia_shaped_partial_cems_plant",
-            "eia_shaped_residual_profile",
-            "eia_shaped_shifted_residual_profile",
-            "eia_shaped_eia930_profile",
-            "eia_shaped_cems_profile",
-            "eia_shaped_DIBA_average",
-            "eia_shaped_national_average",
-            "eia_shaped_assumed_flat",
-        ]
+    # groupby and calculate percentages for the entire country
+    national_source = profile_source.groupby("profile_method").sum()
+    national_source = (national_source / national_source.sum(axis=0)).reset_index()
+    national_source["ba_code"] = "US Total"
+
+    profile_source = profile_source.set_index(["ba_code", "profile_method"])
+    # calculate percentages by ba
+    profile_source = (
+        (profile_source / profile_source.groupby(["ba_code"]).sum())
+        .round(4)
+        .reset_index()
     )
-    profile_source = profile_source.reset_index()
+
+    method_order = {
+        "cems_reported": "0_cems_reported",
+        "eia_scaled_partial_cems_subplant": "1_eia_scaled_partial_cems_subplant",
+        "eia_shaped_partial_cems_plant": "2_eia_shaped_partial_cems_plant",
+        "eia_shaped_residual_profile": "3_eia_shaped_residual_profile",
+        "eia_shaped_shifted_residual_profile": "4_eia_shaped_shifted_residual_profile",
+        "eia_shaped_eia930_profile": "5_eia_shaped_eia930_profile",
+        "eia_shaped_cems_profile": "6_eia_shaped_cems_profile",
+        "eia_shaped_DIBA_average": "7_eia_shaped_DIBA_average",
+        "eia_shaped_national_average": "8_eia_shaped_national_average",
+        "eia_shaped_assumed_flat": "9_eia_shaped_assumed_flat",
+    }
+    profile_source["profile_method"] = profile_source["profile_method"].replace(
+        method_order
+    )
+
+    profile_source = profile_source.sort_values(by=["ba_code", "profile_method"])
+
+    profile_source["profile_method"] = profile_source["profile_method"].str[2:]
+
+    # concat the national data to the ba data
+    profile_source = pd.concat([profile_source, national_source], axis=0)
 
     return profile_source
 
 
 def identify_percent_of_data_by_input_source(
-    cems, partial_cems_subplant, partial_cems_plant, eia_only_data, year
+    cems,
+    partial_cems_subplant,
+    partial_cems_plant,
+    eia_only_data,
+    year,
+    plant_attributes,
 ):
     """Identifies what percent of output data comes from each input source (CEMS or EIA)."""
 
     columns_to_use = [
         "net_generation_mwh",
+        "emitting_net_generation_mwh",
         "co2_mass_lb",
         "co2_mass_lb_for_electricity",
         "co2e_mass_lb",
@@ -557,6 +608,56 @@ def identify_percent_of_data_by_input_source(
     partial_cems_subplant = identify_reporting_frequency(partial_cems_subplant, year)
     partial_cems_plant = identify_reporting_frequency(partial_cems_plant, year)
 
+    # add ba codes and plant primary fuel to all of the data
+    eia_only_data = eia_only_data.merge(
+        plant_attributes[["plant_id_eia", "ba_code", "plant_primary_fuel"]],
+        how="left",
+        on="plant_id_eia",
+        validate="m:1",
+    )
+    cems = cems.merge(
+        plant_attributes[["plant_id_eia", "ba_code", "plant_primary_fuel"]],
+        how="left",
+        on="plant_id_eia",
+        validate="m:1",
+    )
+    partial_cems_subplant = partial_cems_subplant.merge(
+        plant_attributes[["plant_id_eia", "ba_code", "plant_primary_fuel"]],
+        how="left",
+        on="plant_id_eia",
+        validate="m:1",
+    )
+    partial_cems_plant = partial_cems_plant.merge(
+        plant_attributes[["plant_id_eia", "ba_code", "plant_primary_fuel"]],
+        how="left",
+        on="plant_id_eia",
+        validate="m:1",
+    )
+
+    # add a column for fossil-based generation
+    # this copies the net generation data if the associated fuel is not clean or geothermal, and otherwise adds a zero
+    # use the generator-specific energy source code for the eia data, otherwise use the pliant primary fuel
+    eia_only_data = eia_only_data.assign(
+        emitting_net_generation_mwh=lambda x: np.where(
+            ~x.energy_source_code.isin(CLEAN_FUELS + ["GEO"]), x.net_generation_mwh, 0
+        )
+    )
+    cems = cems.assign(
+        emitting_net_generation_mwh=lambda x: np.where(
+            ~x.plant_primary_fuel.isin(CLEAN_FUELS + ["GEO"]), x.net_generation_mwh, 0
+        )
+    )
+    partial_cems_subplant = partial_cems_subplant.assign(
+        emitting_net_generation_mwh=lambda x: np.where(
+            ~x.plant_primary_fuel.isin(CLEAN_FUELS + ["GEO"]), x.net_generation_mwh, 0
+        )
+    )
+    partial_cems_plant = partial_cems_plant.assign(
+        emitting_net_generation_mwh=lambda x: np.where(
+            ~x.plant_primary_fuel.isin(CLEAN_FUELS + ["GEO"]), x.net_generation_mwh, 0
+        )
+    )
+
     # associate each dataframe with a data source label
     data_sources = {
         "cems": cems,
@@ -564,8 +665,7 @@ def identify_percent_of_data_by_input_source(
         "partial_cems_plant": partial_cems_plant,
         "eia": eia_only_data,
     }
-    ## get a count of the number of observations (subplant-hours) from each source
-
+    # get a count of the number of observations (subplant-hours) from each source
     source_of_input_data = []
     for name, df in data_sources.items():
         if len(df) == 0:  # Empty df. May occur when running `small`
@@ -573,7 +673,8 @@ def identify_percent_of_data_by_input_source(
             continue
         if name == "eia":
             subplant_data = df.groupby(
-                ["plant_id_eia", "subplant_id", "eia_data_resolution"], dropna=False
+                ["ba_code", "plant_id_eia", "subplant_id", "eia_data_resolution"],
+                dropna=False,
             ).sum()[columns_to_use]
             # because EIA data is not hourly, we have to multiply the number of subplants by the number of hours in a year
             if year % 4 == 0:
@@ -584,7 +685,7 @@ def identify_percent_of_data_by_input_source(
             # group the data by resolution
             subplant_data = (
                 subplant_data.reset_index()
-                .groupby("eia_data_resolution", dropna=False)
+                .groupby(["ba_code", "eia_data_resolution"], dropna=False)
                 .sum()[["subplant_hours"] + columns_to_use]
                 .reset_index()
             )
@@ -592,20 +693,30 @@ def identify_percent_of_data_by_input_source(
                 columns={"eia_data_resolution": "source"}
             )
             subplant_data["source"] = subplant_data["source"].replace(
-                {"annual": "eia_annual", "monthly": "eia_monthly"}
+                {
+                    "annual": "eia_annual",
+                    "monthly": "eia_monthly",
+                    "multiple": "eia_multiple",
+                }
             )
             source_of_input_data.append(subplant_data)
         # for the partial cems data
         elif (name == "partial_cems_subplant") | (name == "partial_cems_plant"):
             subplant_data = df.groupby(
-                ["plant_id_eia", "subplant_id", "datetime_utc", "eia_data_resolution"],
+                [
+                    "ba_code",
+                    "plant_id_eia",
+                    "subplant_id",
+                    "datetime_utc",
+                    "eia_data_resolution",
+                ],
                 dropna=False,
             ).sum()[columns_to_use]
             subplant_data["subplant_hours"] = 1
             # group the data by resolution
             subplant_data = (
                 subplant_data.reset_index()
-                .groupby("eia_data_resolution", dropna=False)
+                .groupby(["ba_code", "eia_data_resolution"], dropna=False)
                 .sum()[["subplant_hours"] + columns_to_use]
                 .reset_index()
             )
@@ -613,20 +724,24 @@ def identify_percent_of_data_by_input_source(
                 columns={"eia_data_resolution": "source"}
             )
             subplant_data["source"] = subplant_data["source"].replace(
-                {"annual": "eia_annual", "monthly": "eia_monthly"}
+                {
+                    "annual": "eia_annual",
+                    "monthly": "eia_monthly",
+                    "multiple": "eia_multiple",
+                }
             )
             source_of_input_data.append(subplant_data)
         # for the cems data
         else:
             subplant_data = df.groupby(
-                ["plant_id_eia", "subplant_id", "datetime_utc"], dropna=False
+                ["ba_code", "plant_id_eia", "subplant_id", "datetime_utc"], dropna=False
             ).sum()[columns_to_use]
             subplant_data["subplant_hours"] = 1
             subplant_data["source"] = "cems_hourly"
             # group the data by resolution
             subplant_data = (
                 subplant_data.reset_index()
-                .groupby("source", dropna=False)
+                .groupby(["ba_code", "source"], dropna=False)
                 .sum()[["subplant_hours"] + columns_to_use]
                 .reset_index()
             )
@@ -635,11 +750,18 @@ def identify_percent_of_data_by_input_source(
     # concat the dataframes together
     source_of_input_data = pd.concat(source_of_input_data, axis=0)
 
-    # groupby and calculate percentages
-    source_of_input_data = source_of_input_data.groupby("source").sum()
-    source_of_input_data = source_of_input_data / source_of_input_data.sum(axis=0)
+    # groupby and calculate percentages for the entire country
+    national_source = source_of_input_data.groupby("source").sum()
+    national_source = (national_source / national_source.sum(axis=0)).reset_index()
+    national_source["ba_code"] = "US Total"
 
-    source_of_input_data = source_of_input_data.reset_index()
+    # calculate percentages by ba
+    source_of_input_data = (
+        source_of_input_data.groupby(["ba_code", "source"]).sum()
+        / source_of_input_data.groupby(["ba_code"]).sum()
+    ).reset_index()
+    # concat the national data to the ba data
+    source_of_input_data = pd.concat([source_of_input_data, national_source], axis=0)
 
     return source_of_input_data
 
@@ -652,7 +774,10 @@ def identify_reporting_frequency(eia923_allocated, year):
     pudl_out = load_data.initialize_pudl_out(year)
     plant_frequency = pudl_out.plants_eia860()[
         ["plant_id_eia", "reporting_frequency_code"]
-    ]
+    ].copy()
+    plant_frequency["reporting_frequency_code"] = plant_frequency[
+        "reporting_frequency_code"
+    ].fillna("multiple")
     # rename the column and recode the values
     plant_frequency = plant_frequency.rename(
         columns={"reporting_frequency_code": "eia_data_resolution"}
@@ -832,7 +957,7 @@ def summarize_cems_measurement_quality(cems):
     # drop NA values
     cems_quality_summary = cems_quality_summary.loc[["Measured", "Imputed"], :]
     cems_quality_summary = cems_quality_summary.reset_index()
-    
+
     return cems_quality_summary
 
 

--- a/src/validation.py
+++ b/src/validation.py
@@ -3,6 +3,7 @@ import numpy as np
 
 import load_data
 import impute_hourly_profiles
+from emissions import CLEAN_FUELS
 from column_checks import get_dtypes
 from filepaths import downloads_folder, manual_folder
 
@@ -1264,20 +1265,19 @@ def load_egrid_plant_file(year):
     )
 
     # if egrid has a missing value for co2 for a clean plant, replace with zero
-    clean_fuels = ["SUN", "MWH", "WND", "WAT", "WH", "PUR", "NUC"]
     egrid_plant.loc[
-        egrid_plant["plant_primary_fuel"].isin(clean_fuels),
+        egrid_plant["plant_primary_fuel"].isin(CLEAN_FUELS),
         "co2_mass_lb_for_electricity_adjusted",
     ] = egrid_plant.loc[
-        egrid_plant["plant_primary_fuel"].isin(clean_fuels),
+        egrid_plant["plant_primary_fuel"].isin(CLEAN_FUELS),
         "co2_mass_lb_for_electricity_adjusted",
     ].fillna(
         0
     )
     egrid_plant.loc[
-        egrid_plant["plant_primary_fuel"].isin(clean_fuels), "co2_mass_lb"
+        egrid_plant["plant_primary_fuel"].isin(CLEAN_FUELS), "co2_mass_lb"
     ] = egrid_plant.loc[
-        egrid_plant["plant_primary_fuel"].isin(clean_fuels), "co2_mass_lb"
+        egrid_plant["plant_primary_fuel"].isin(CLEAN_FUELS), "co2_mass_lb"
     ].fillna(
         0
     )


### PR DESCRIPTION
Merges v0.1.2 patch updates into main.

**Fixes issue with assignment of subplant IDs**
Fixes an issue that was causing some generators/units to be assigned missing or incorrect [subplant IDs](https://singularity-docs.stoplight.io/docs/open-grid-emissions-docs/subplant_aggregation-background-on-power-plant-configuration-and-data-crosswalking). This issue caused several downstream issues including inaccurate hourly shapes being assigned to certain subplants, or inaccurate conversion of gross to net generation in the CEMS data. This patch ensures that every `generator_id` and `unitid` is associated with a non-missing subplant ID, and that these subplant assignments account for boiler-generator associations from EIA-860 ([full details](https://github.com/singularity-energy/open-grid-emissions/pull/239)). 

**Fixes anomalous spikes in emission rate data**
Several grid regions were exhibiting [anomalous dips](https://github.com/singularity-energy/open-grid-emissions/issues/230) in their regional emission intensity values due to an issue with the [methodology](https://singularity-docs.stoplight.io/docs/open-grid-emissions-docs/partial_cems_plant-shaping-eia-subplants-with-partial-cems-plant-data) used to shape data from plants with partial CEMS data. Specifically, the generation from certain non-emitting plants (e.g. nuclear, solar, etc) that had a fossil-fuel backup generator onsite were being assigned the intermittent hourly profile of the backup generator if that generator reported to CEMS. This resulted in data quality issues in both the generated and consumed emission rates for some regions. This patch fixes that issue by excluding all non-emitting generators and plants with subplants of mixed fuel types from using the partial CEMS methodology. ([full details](https://github.com/singularity-energy/open-grid-emissions/pull/238)).

**Other updates**
- Fixes an issue that was resulting in an infeasible conda environment by [updating our dependency](https://github.com/singularity-energy/open-grid-emissions/pull/235) on the Public Utility Data Liberation Project to a stable branch of the project. 
- Improves the speed of running the part of the data pipeline that identifies subplant IDs.
- Updates the `plant_metadata.csv` file to help users more easily identify the methodologies used for each plant.
- Adds adjusted R2 values to the gross to net generation regression outputs available in the `data/outputs/gross_to_net_conversions.csv` file.
- Renames the `data/outputs/subplant_crosswalk.csv` file to `subplant_crosswalk_[YEAR].csv` to clarify that subplant IDs are only valid for a specific year.