### PR TITLE
Fix missing NOx and SO2 identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # Open Grid Emissions Initiative
+[![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7062460.svg)](https://doi.org/10.5281/zenodo.7062460)
+
 The Open Grid Emissions Initiative seeks to fill a critical need for high-quality, publicly-accessible, hourly grid emissions data that can be used for GHG accounting, policymaking, academic research, and energy attribute certificate markets. The initiative includes this repository of open-source grid emissions data processing tools that use peer-reviewed, well-documented, and validated methodologies to create the accompanying public dataset of hourly, monthly, and annual U.S. electric grid generation, GHG, and air pollution data.
 
 Please check out [our documentation](https://docs.singularity.energy/docs/open-grid-emissions-docs) for more details about the Open Grid Emissions methodology.

--- a/notebooks/explore_data/explore_intermediate_outputs.ipynb
+++ b/notebooks/explore_data/explore_intermediate_outputs.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -18,6 +18,7 @@
     "\n",
     "from column_checks import get_dtypes\n",
     "from filepaths import *\n",
+    "import data_cleaning\n",
     "\n",
     "year = 2020"
    ]
@@ -47,6 +48,40 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load data from csv\n",
+    "year = 2020\n",
+    "path_prefix = f\"{year}/\"\n",
+    "\n",
+    "eia923_allocated, primary_fuel_table = data_cleaning.clean_eia923(year, False)\n",
+    "cems = data_cleaning.clean_cems(year, False, primary_fuel_table)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = cems[cems[\"plant_id_eia\"] == 673]\n",
+    "\n",
+    "data.groupby([\"plant_id_eia\",\"unitid\",\"report_date\"]).sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eia923_allocated[eia923_allocated[\"plant_id_eia\"] == 50949].to_csv(\"test.csv\")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -72,6 +107,25 @@
     "all_data = pd.concat(all_data, axis=0)\n",
     "\n",
     "all_data[all_data[\"fuel_category\"] == \"total\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Explore the difference between adjusted and unadjusted (for biomass) factors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "all_data[\"pctdiff\"] = (all_data.generated_co2_rate_lb_per_mwh_for_electricity_adjusted - all_data.generated_co2_rate_lb_per_mwh_for_electricity) / all_data.generated_co2_rate_lb_per_mwh_for_electricity\n",
+    "\n",
+    "\n",
+    "all_data.loc[all_data[\"fuel_category\"] == \"total\", [\"ba_code\",\"pctdiff\",\"generated_co2_rate_lb_per_mwh_for_electricity_adjusted\",\"generated_co2_rate_lb_per_mwh_for_electricity\"]].sort_values(by=\"pctdiff\").head(25)"
    ]
   }
  ],

--- a/src/column_checks.py
+++ b/src/column_checks.py
@@ -412,7 +412,7 @@ def get_dtypes():
         "pm_control_id": "str",
         "so2_control_id": "str",
         "nox_control_id": "str",
-        "mercury_control_id": "str",
+        "hg_control_id": "str",
         "operational_status": "str",
         "hours_in_service": "float64",
         "annual_nox_emission_rate_lb_per_mmbtu": "float64",

--- a/src/load_data.py
+++ b/src/load_data.py
@@ -673,7 +673,7 @@ def load_emissions_controls_eia923(year: int):
         "pm_control_id",
         "so2_control_id",
         "nox_control_id",
-        "mercury_control_id",
+        "hg_control_id",
         "operational_status",
         "hours_in_service",
         "annual_nox_emission_rate_lb_per_mmbtu",
@@ -752,29 +752,39 @@ def load_emissions_controls_eia923(year: int):
     return emissions_controls_eia923
 
 
-def load_boiler_nox_association_eia860(year):
-    boiler_nox_association_eia860_names = [
+def load_boiler_control_id_association_eia860(year, pollutant):
+    """Generic function for loading the EIA-860 tables that associate boiler_id with a pollutant-specific control id.
+
+    the `pollutant` parameter could be any of the following: ['pm','so2','nox','hg']
+    """
+    pollutant_abbreviation_to_name = {
+        "pm": "Particulate Matter",
+        "so2": "SO2",
+        "nox": "NOx",
+        "hg": "Mercury",
+    }
+    boiler_association_eia860_names = [
         "utility_id_eia",
         "utility_name_eia",
         "plant_id_eia",
         "plant_name_eia",
         "boiler_id",
-        "nox_control_id",
+        f"{pollutant}_control_id",
         "steam_plant_type",
     ]
 
     if year <= 2013:
         # This column isn't included in 2013 and earlier.
-        boiler_nox_association_eia860_names.remove("steam_plant_type")
+        boiler_association_eia860_names.remove("steam_plant_type")
 
     # NOTE: Pre-2013, the EIA-860 file format changes, so this load function will not work
     # The environmental association data is available pre-2013, but would require additional work to format
     if year >= 2013:
-        boiler_nox_association_eia860 = pd.read_excel(
+        boiler_control_id_association_eia860 = pd.read_excel(
             io=downloads_folder(f"eia860/eia860{year}/6_1_EnviroAssoc_Y{year}.xlsx"),
-            sheet_name="Boiler NOx",
+            sheet_name=f"Boiler {pollutant_abbreviation_to_name[pollutant]}",
             header=1,
-            names=boiler_nox_association_eia860_names,
+            names=boiler_association_eia860_names,
             dtype=get_dtypes(),
             na_values=".",
             skipfooter=1,
@@ -784,52 +794,12 @@ def load_boiler_nox_association_eia860(year):
         print(
             "WARNING: Environmental association data prior to 2013 have not been integrated into the data pipeline."
         )
-        print("This may result in less accurate NOx and SO2 emissions calculations.")
-        boiler_nox_association_eia860 = pd.DataFrame(
-            columns=boiler_nox_association_eia860_names
+        print("This may result in less accurate pollutant emissions calculations.")
+        boiler_control_id_association_eia860 = pd.DataFrame(
+            columns=boiler_association_eia860_names
         )
 
-    return boiler_nox_association_eia860
-
-
-def load_boiler_so2_association_eia860(year):
-    boiler_so2_association_eia860_names = [
-        "utility_id_eia",
-        "utility_name_eia",
-        "plant_id_eia",
-        "plant_name_eia",
-        "boiler_id",
-        "so2_control_id",
-        "steam_plant_type",
-    ]
-
-    if year <= 2013:
-        # This column isn't included in 2013 and earlier.
-        boiler_so2_association_eia860_names.remove("steam_plant_type")
-
-    # NOTE: Pre-2013, the EIA-860 file format changes, so this load function will not work
-    # The environmental association data is available pre-2013, but would require additional work to format
-    if year >= 2013:
-        boiler_so2_association_eia860 = pd.read_excel(
-            io=downloads_folder(f"eia860/eia860{year}/6_1_EnviroAssoc_Y{year}.xlsx"),
-            sheet_name="Boiler SO2",
-            header=1,
-            names=boiler_so2_association_eia860_names,
-            dtype=get_dtypes(),
-            na_values=".",
-            skipfooter=1,
-        )
-    # return a blank dataframe if the data is not available
-    else:
-        print(
-            "WARNING: Environmental association data prior to 2013 have not been integrated into the data pipeline."
-        )
-        print("This may result in less accurate NOx and SO2 emissions calculations.")
-        boiler_so2_association_eia860 = pd.DataFrame(
-            columns=boiler_so2_association_eia860_names
-        )
-
-    return boiler_so2_association_eia860
+    return boiler_control_id_association_eia860
 
 
 def load_boiler_design_parameters_eia860(year):

--- a/test/test_load_data.py
+++ b/test/test_load_data.py
@@ -25,7 +25,7 @@ def load_emissions_controls_helper(years, load_data, expect_empty=False):
 def load_boiler_nox_association_eia860_helper(years, load_data, expect_empty=False):
     for year in years:
         print(f'-- Loading boiler NOx information from EIA-923 for {year}')
-        df_boiler_nox = load_data.load_boiler_nox_association_eia860(year)
+        df_boiler_nox = load_data.load_boiler_control_id_association_eia860(year, "nox")
         print('Columns:\n', df_boiler_nox.columns)
         if expect_empty:
             assert(len(df_boiler_nox) == 0)
@@ -37,7 +37,7 @@ def load_boiler_nox_association_eia860_helper(years, load_data, expect_empty=Fal
 def load_boiler_so2_association_eia860_helper(years, load_data, expect_empty=False):
     for year in years:
         print(f'-- Loading boiler SO2 information from EIA-923 for {year}')
-        df_boiler_nox = load_data.load_boiler_so2_association_eia860(year)
+        df_boiler_nox = load_data.load_boiler_control_id_association_eia860(year, "so2")
         print('Columns:\n', df_boiler_nox.columns)
         if expect_empty:
             assert(len(df_boiler_nox) == 0)


### PR DESCRIPTION
This PR is meant to address https://github.com/singularity-energy/open-grid-emissions/issues/255.

To get around the fact that some NOx and SO2 control data doesn't have an associated nox or so2 control id, we now load all four control ids (nox, so2, pm, hg) and use these to map the data to a boiler if the nox or so2 id is missing. 

Previously we had dropped all rows from the air emissions control table that had a missing pollutant-specific control id, but now we only drop rows that don't have any pollutant-specific data (ie if we're calculating nox, we drop any rows that don't have any nox control data.

I've set this up as an iterative process where the user specifies which id they want to use as primary, and then the code cycles through each additional id, filling missing boiler associations until all data is associated with boilers (or there are no remaining ids to use). I did it this way instead of loading all control-boiler associations because many control ids are associated with many boilers, so this led to duplicate boiler matches. This is all coordinated by `emissions.associate_control_ids_with_boiler_id()`

Because we now need to load four different control id to boiler association tables, I replaced the nox- and so2-specific functions to load these tables with a more generic function `load_boiler_control_id_association_eia860()` in which the user can specify which pollutant table they want to load (eg nox, so2, hg, pm). This is possible because all four of these tables are in the same format.