### PR TITLE
Fix consumed calc

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,11 +4,13 @@ channels:
   - conda-forge
 dependencies:
   - black # development: code formatting
+  - blas=*=openblas # prevent mkl implementation of blas
   - cvxopt
   - cvxpy=1.2.1 # used by gridemissions, newer version not working as of 12/12/2022
   - flake8 # development: linter
   - geopandas>=0.9,<0.13 # used for pudl
   - ipykernel
+  - nomkl # prevent mkl implementation of blas
   - notebook
   - numpy
   - openpyxl

--- a/src/consumed.py
+++ b/src/consumed.py
@@ -508,5 +508,5 @@ class HourlyConsumed:
                         self.results[r].loc[date, col] = consumed_emissions[i]
                 if total_failed > 0:
                     print(
-                        f"Warning: {total_failed} times failed to solve for consumed emissions, {pol} {adj}"
+                        f"Warning: {total_failed} hours failed to solve for consumed emissions, {pol} {adj}"
                     )

--- a/src/consumed.py
+++ b/src/consumed.py
@@ -454,14 +454,18 @@ class HourlyConsumed:
             else:
                 G[i] = self.generation.loc[date, r]
 
+        E = np.nan_to_num(E)
+        G = np.nan_to_num(G)
+        ID = np.nan_to_num(ID)
+
         # In some cases, we have zero generation but non-zero transmission
         # usually due to imputed zeros during physics-based cleaning being set to 1.0
-        # but sometimes due to ok values being set to 1.0ß
+        # but sometimes due to ok values being set to 1.0
         to_fix = (ID.sum(axis=1) > 0) & (G == 0)
         ID[:, to_fix] = 0
         ID[to_fix, :] = 0
 
-        return np.nan_to_num(E), np.nan_to_num(G), np.nan_to_num(ID)
+        return E, G, ID
 
     def run(self):
         for pol in POLLUTANTS:

--- a/src/consumed.py
+++ b/src/consumed.py
@@ -319,6 +319,12 @@ class HourlyConsumed:
                     time_dat.datetime_local.dt.year == self.year
                 ]  # keep year of local data
 
+                # if there are small gaps in the consumed data,
+                # linearly interpolate the missing values, up to a maximum of 2 consecutive missing hours
+                time_dat = time_dat.interpolate(
+                    method="linear", axis=0, limit=2, limit_area="inside"
+                )
+
                 if time_resolution == "hourly":
                     # No resampling needed; keep timestamp cols in output
                     time_cols = ["datetime_utc", "datetime_local"]

--- a/src/consumed.py
+++ b/src/consumed.py
@@ -319,15 +319,12 @@ class HourlyConsumed:
                     time_dat.datetime_local.dt.year == self.year
                 ]  # keep year of local data
 
-                # if there are small gaps in the consumed data,
-                # linearly interpolate the missing values, up to a maximum of 2 consecutive missing hours
-                time_dat.loc[:, CONSUMED_EMISSION_RATE_COLS] = time_dat.loc[
-                    :, CONSUMED_EMISSION_RATE_COLS
-                ].interpolate(method="linear", axis=0, limit=2, limit_area="inside")
-
                 if time_resolution == "hourly":
                     # No resampling needed; keep timestamp cols in output
                     time_cols = ["datetime_utc", "datetime_local"]
+                    missing_hours = time_dat[time_dat.isna().any(axis=1)]
+                    if len(missing_hours) > 0:
+                        print(f"WARNING: {len(missing_hours)} hours are missing in {ba} consumed data")
                 elif time_resolution == "monthly":
                     time_dat["month"] = time_dat.datetime_local.dt.month
                     # Aggregate to appropriate resolution
@@ -514,5 +511,5 @@ class HourlyConsumed:
                         self.results[r].loc[date, col] = consumed_emissions[i]
                 if total_failed > 0:
                     print(
-                        f"Warning: {total_failed} hours failed to solve for consumed emissions, {pol} {adj}"
+                        f"Warning: {total_failed} hours failed to solve for consumed {pol} {adj} emissions."
                     )

--- a/src/consumed.py
+++ b/src/consumed.py
@@ -25,7 +25,7 @@ which results in unreasonable profiles with many negative hours.
 BA_930_INCONSISTENCY = {
     2019: ["EEI"],
     2020: ["EEI", "SEC"],
-    2021: [],
+    2021: ["CPLW", "GCPD"],
 }
 
 # Defined in output_data, written to each BA file

--- a/src/consumed.py
+++ b/src/consumed.py
@@ -321,9 +321,9 @@ class HourlyConsumed:
 
                 # if there are small gaps in the consumed data,
                 # linearly interpolate the missing values, up to a maximum of 2 consecutive missing hours
-                time_dat = time_dat.interpolate(
-                    method="linear", axis=0, limit=2, limit_area="inside"
-                )
+                time_dat.loc[:, CONSUMED_EMISSION_RATE_COLS] = time_dat.loc[
+                    :, CONSUMED_EMISSION_RATE_COLS
+                ].interpolate(method="linear", axis=0, limit=2, limit_area="inside")
 
                 if time_resolution == "hourly":
                     # No resampling needed; keep timestamp cols in output

--- a/src/eia930.py
+++ b/src/eia930.py
@@ -283,7 +283,7 @@ def load_chalendar_for_pipeline(cleaned_data_filepath, year):
 
 def remove_imputed_ones(eia930_data):
 
-    filter = [eia930_data["net_generation_mwh_930"].abs() < 1.5]
+    filter = eia930_data["net_generation_mwh_930"].abs() < 1.5
 
     # replace all 1.0 values with zero
     print(f"  replacing {sum(filter)} imputed 1 values with 0")

--- a/src/eia930.py
+++ b/src/eia930.py
@@ -283,17 +283,11 @@ def load_chalendar_for_pipeline(cleaned_data_filepath, year):
 
 def remove_imputed_ones(eia930_data):
 
-    # round all the values to the nearest whole MWh
-    eia930_data["net_generation_mwh_930"] = eia930_data["net_generation_mwh_930"].round(
-        0
-    )
+    filter = [eia930_data["net_generation_mwh_930"].abs() < 1.5]
+
     # replace all 1.0 values with zero
-    print(
-        f"  replacing {len(eia930_data[eia930_data['net_generation_mwh_930'] == 1])} imputed 1 values with 0"
-    )
-    eia930_data["net_generation_mwh_930"] = eia930_data[
-        "net_generation_mwh_930"
-    ].replace(1, 0)
+    print(f"  replacing {sum(filter)} imputed 1 values with 0")
+    eia930_data.loc[filter, "net_generation_mwh_930"] = 0
 
     return eia930_data
 


### PR DESCRIPTION
Fix missing values by running check for non-zero export with zero generation: check now happens *after* converting nan to 0. 

Make 930 usage consistent with residual calculation by rounding values < 1.5 to 0; this gets rid of 1 values added by `gridemissions`.