### PR TITLE
add eGRID2021 data

### DIFF
--- a/data/manual/plants_not_connected_to_grid.csv
+++ b/data/manual/plants_not_connected_to_grid.csv
@@ -3,6 +3,7 @@ Plant ID,State,Plant Name
 1594,MA,Blackstone
 2440,SC,AbiBow US Inc. - Catawba Operations
 2549,NY,Huntley Power
+2837,OH,Eastlake
 10071,VA,Virginia Renewable Power-Portsmouth LLC
 10111,MI,DTE Pontiac North LLC
 10381,NC,Coastal Carolina Clean Power LLC

--- a/notebooks/validation/validate_vs_egrid.ipynb
+++ b/notebooks/validation/validate_vs_egrid.ipynb
@@ -41,7 +41,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "year = 2020"
+    "year = 2021"
    ]
   },
   {
@@ -587,7 +587,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.5 ('hourly_egrid')",
+   "display_name": "open_grid_emissions",
    "language": "python",
    "name": "python3"
   },
@@ -601,11 +601,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
+   "version": "3.10.9"
   },
   "vscode": {
    "interpreter": {
-    "hash": "65c02dfd2dc2ef471c0b5088763a28c1faaa7cad28937ca42fadf51e669fd8e8"
+    "hash": "25e36f192ecdbe5da57d9bea009812e7b11ef0e0053366a845a2802aae1b29d2"
    }
   }
  },

--- a/src/data_cleaning.py
+++ b/src/data_cleaning.py
@@ -1996,6 +1996,15 @@ def create_plant_ba_table(year):
         "balancing_authority_code_eia"
     ].fillna(value=np.NaN)
 
+    # load the ba name reference
+    ba_name_to_ba_code = pd.read_csv(manual_folder("ba_reference.csv"))
+    ba_name_to_ba_code = dict(
+        zip(
+            ba_name_to_ba_code["ba_name"],
+            ba_name_to_ba_code["ba_code"],
+        )
+    )
+
     # specify a ba code for certain utilities
     utility_as_ba_code = pd.read_csv(manual_folder("utility_name_ba_code_map.csv"))
     utility_as_ba_code = dict(
@@ -2006,6 +2015,9 @@ def create_plant_ba_table(year):
     )
 
     # fill missing BA codes first based on the BA name, then utility name, then on the transmisison owner name
+    plant_ba["balancing_authority_code_eia"] = plant_ba[
+        "balancing_authority_code_eia"
+    ].fillna(plant_ba["balancing_authority_name_eia"].map(ba_name_to_ba_code))
     plant_ba["balancing_authority_code_eia"] = plant_ba[
         "balancing_authority_code_eia"
     ].fillna(plant_ba["balancing_authority_name_eia"].map(utility_as_ba_code))

--- a/src/data_pipeline.py
+++ b/src/data_pipeline.py
@@ -110,6 +110,7 @@ def main():
         "https://www.epa.gov/sites/default/files/2020-03/egrid2018_data_v2.xlsx",
         "https://www.epa.gov/sites/default/files/2021-02/egrid2019_data.xlsx",
         "https://www.epa.gov/system/files/documents/2022-01/egrid2020_data.xlsx",
+        "https://www.epa.gov/system/files/documents/2023-01/eGRID2021_data.xlsx",
     ]
     download_data.download_egrid_files(egrid_files_to_download)
     # EIA-930

--- a/src/load_data.py
+++ b/src/load_data.py
@@ -909,7 +909,7 @@ def load_default_gtn_ratios():
     default_gtn = pd.read_csv(
         manual_folder("default_gross_to_net_ratios.csv"),
         dtype=get_dtypes(),
-    )
+    )[["prime_mover_code", "default_gtn_ratio"]]
 
     return default_gtn
 

--- a/test/test_download_data.py
+++ b/test/test_download_data.py
@@ -28,6 +28,7 @@ def test_download_egrid(download_data):
         "https://www.epa.gov/sites/default/files/2020-03/egrid2018_data_v2.xlsx",
         "https://www.epa.gov/sites/default/files/2021-02/egrid2019_data.xlsx",
         "https://www.epa.gov/system/files/documents/2022-01/egrid2020_data.xlsx",
+        "https://www.epa.gov/system/files/documents/2023-01/eGRID2021_data.xlsx",
     ]
     download_data.download_egrid_files(egrid_files_to_download)
     print("DONE")


### PR DESCRIPTION
- Adds eGRID 2021 data to our list of downloads
- Updates the list of non-grid connected plants based on additions to the list in eGRID 2021.
- Fixes an issue where a plant with no reported ba_code was getting filled with the incorrect code based on the ba_name. 

In comparing our 2021 data to the eGRID 2021 data, I found that there are some plants that EIA-860 identifies as being in ISNE that are getting assigned to NYIS by pudl, and thus are categorized in a different BA than they are in eGRID. All of these plants seem to be physically located in the state of New York, but are listed with an ISNE BA code. Also, all of these plants are pretty small. See: https://github.com/catalyst-cooperative/pudl/issues/2255. For now, I was going to leave this in place until this is resolved on the pudl side. 