### PR TITLE
Update the flag threshold in `Check_allocated_gf_matches_input_gf`

### DIFF
--- a/src/data_cleaning.py
+++ b/src/data_cleaning.py
@@ -401,7 +401,9 @@ def clean_eia923(
     )
 
     # test to make sure allocated totals match input totals
-    validation.check_allocated_gf_matches_input_gf(pudl_out, gen_fuel_allocated)
+    validation.check_allocated_gf_matches_input_gf(
+        pudl_out, gen_fuel_allocated, threshold_percent=0.01
+    )
 
     # manually update energy source code when OTH
     gen_fuel_allocated = update_energy_source_codes(gen_fuel_allocated)

--- a/src/data_cleaning.py
+++ b/src/data_cleaning.py
@@ -401,9 +401,7 @@ def clean_eia923(
     )
 
     # test to make sure allocated totals match input totals
-    validation.check_allocated_gf_matches_input_gf(
-        pudl_out, gen_fuel_allocated, threshold_percent=0.001
-    )
+    validation.check_allocated_gf_matches_input_gf(pudl_out, gen_fuel_allocated)
 
     # manually update energy source code when OTH
     gen_fuel_allocated = update_energy_source_codes(gen_fuel_allocated)

--- a/src/data_cleaning.py
+++ b/src/data_cleaning.py
@@ -402,7 +402,7 @@ def clean_eia923(
 
     # test to make sure allocated totals match input totals
     validation.check_allocated_gf_matches_input_gf(
-        pudl_out, gen_fuel_allocated, threshold_percent=0.01
+        pudl_out, gen_fuel_allocated, threshold_percent=0.001
     )
 
     # manually update energy source code when OTH

--- a/src/validation.py
+++ b/src/validation.py
@@ -57,16 +57,24 @@ def check_allocated_gf_matches_input_gf(pudl_out, gen_fuel_allocated):
             "fuel_consumed_for_electricity_mmbtu",
         ]
     ].sum()
-    # calculate the difference between the values
-    plant_total_diff = plant_total_gf - plant_total_alloc
-    # flag values where the absolute difference is greater than 10 mwh or mmbtu
+    # calculate the percentage difference between the values
+    plant_total_diff = (plant_total_alloc - plant_total_gf) / plant_total_gf
+    # flag rows where the absolute percentage difference is greater than our threshold
+    threshold_percent = 0.05
     mismatched_allocation = plant_total_diff[
-        (abs(plant_total_diff["fuel_consumed_mmbtu"]) > 10)
-        | (abs(plant_total_diff["net_generation_mwh"]) > 10)
+        (abs(plant_total_diff["fuel_consumed_mmbtu"]) > threshold_percent)
+        | (abs(plant_total_diff["net_generation_mwh"]) > threshold_percent)
     ]
     if len(mismatched_allocation) > 0:
-        print("WARNING: Allocated EIA-923 doesn't match input data for plants:")
+        print(
+            "WARNING: Allocated EIA-923 data doesn't match input data for the following plants:"
+        )
+        print("Percentage Difference:")
         print(mismatched_allocation)
+        print("Input Totals:")
+        print(plant_total_gf.loc[mismatched_allocation.index, :])
+        print("Allocated Totals:")
+        print(plant_total_alloc.loc[mismatched_allocation.index, :])
 
 
 def test_for_negative_values(df, small: bool = False):

--- a/src/validation.py
+++ b/src/validation.py
@@ -71,7 +71,7 @@ def check_allocated_gf_matches_input_gf(pudl_out, gen_fuel_allocated):
         )
         print("Percentage Difference:")
         print(mismatched_allocation)
-        print("Input Totals:")
+        print("EIA-923 Input Totals:")
         print(plant_total_gf.loc[mismatched_allocation.index, :])
         print("Allocated Totals:")
         print(plant_total_alloc.loc[mismatched_allocation.index, :])


### PR DESCRIPTION
`validation.check_allocated_gf_matches_input_gf()` checks that the allocated generation and fuel from EIA-923 matches the input totals when running `data_cleaning.clean_eia923()`. 

Changes in this PR:
- Previously, we had flagged differences that were greater than an absolute threshold arbitrarily set at 10 units. We now flag allocated totals that are more than +/- 0.1% different than the input total. This threshold is in place so that values that are off by very small amounts due to rounding errors are not flagged.
- We add more helpful warning messages that shows the percentage difference, input total, and allocated total for easy comparison

Note: this validation check should be temporary until https://github.com/catalyst-cooperative/pudl/pull/2297 and https://github.com/catalyst-cooperative/pudl/pull/2235 are merged into PUDL.

This is an example of what the output of this warning looks like for 2021:

```
WARNING: Allocated EIA-923 data doesn't match input data for the following plants:
Percentage Difference:
              net_generation_mwh  fuel_consumed_mmbtu  fuel_consumed_for_electricity_mmbtu
plant_id_eia                                                                              
1206                   -0.001076            -0.002514                            -0.002514
1316                    0.023964             0.000000                             0.000000
54967                  -1.000000            -1.000000                            -1.000000
58256                   0.411966             0.000000                             0.000000
59260                  -0.475486            -0.475496                            -0.475496
59825                  -1.000000            -1.000000                            -1.000000
63098                  -1.000000            -1.000000                            -1.000000
EIA-923 Input Totals:
              net_generation_mwh  fuel_consumed_mmbtu  fuel_consumed_for_electricity_mmbtu
plant_id_eia                                                                              
1206                    56313.00             493763.0                             493763.0
1316                     2003.00              32704.0                              32704.0
54967                       1.96                 24.0                                 24.0
58256                     585.00               7304.0                               7304.0
59260                    1760.00              28873.0                              28873.0
59825                    9539.00              84354.0                              84354.0
63098                       1.00                  6.0                                  6.0
Allocated Totals:
              net_generation_mwh  fuel_consumed_mmbtu  fuel_consumed_for_electricity_mmbtu
plant_id_eia                                                                              
1206                56252.431817        492521.524247                        492521.524247
1316                 2051.000000         32704.000000                         32704.000000
54967                   0.000000             0.000000                             0.000000
58256                 826.000000          7304.000000                          7304.000000
59260                 923.144000         15144.000000                         15144.000000
59825                   0.000000             0.000000                             0.000000
63098                   0.000000             0.000000                             0.000000
```