### PR TITLE
Fix bug with CEMS missing CO2 data filling

### DIFF
--- a/notebooks/validation/validate_vs_egrid.ipynb
+++ b/notebooks/validation/validate_vs_egrid.ipynb
@@ -246,6 +246,36 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Evaluate Plant-level discrepencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# evaluate all plants\n",
+    "comparison_count, compared = validation.compare_plant_level_results_to_egrid(\n",
+    "    annual_plant_results, egrid_plant, PLANTS_MISSING_FROM_EGRID\n",
+    ")\n",
+    "comparison_count"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "compared[(compared[\"ba_code\"] == \"SOCO\") & (compared[\"co2_mass_lb_status\"] != \"!exact\")]"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -404,23 +434,32 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "year = 2020\n",
+    "year = 2021\n",
     "path_prefix = year\n",
     "\n",
+    "DATA_COLUMNS = [\n",
+    "    \"net_generation_mwh\",\n",
+    "    \"fuel_consumed_mmbtu\",\n",
+    "    \"fuel_consumed_for_electricity_mmbtu\",\n",
+    "    \"co2_mass_lb\",\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Load the eGRID plant table\n",
     "egrid_plant = validation.load_egrid_plant_file(year)\n",
     "\n",
     "egrid_ba = validation.load_egrid_ba_file(year)\n",
     "\n",
     "# aggregate the plant data up to the BA level\n",
-    "data_columns = [\n",
-    "    \"net_generation_mwh\",\n",
-    "    \"fuel_consumed_mmbtu\",\n",
-    "    \"fuel_consumed_for_electricity_mmbtu\",\n",
-    "    \"co2_mass_lb\",\n",
-    "    \"co2_mass_lb_for_electricity_adjusted\",\n",
-    "]\n",
-    "egrid_plant_ba_agg = egrid_plant.groupby([\"ba_code\"]).sum()[data_columns].reset_index()\n"
+    "egrid_plant_ba_agg = egrid_plant.groupby([\"ba_code\"]).sum()[DATA_COLUMNS].reset_index()\n",
+    "\n",
+    "egrid_plant_ba_agg[\"generated_co2_rate_lb_per_mwh\"] = egrid_plant_ba_agg[\"co2_mass_lb\"] / egrid_plant_ba_agg[\"net_generation_mwh\"]"
    ]
   },
   {
@@ -430,14 +469,6 @@
    "outputs": [],
    "source": [
     "# load our annual ba data\n",
-    "DATA_COLUMNS = [\n",
-    "    \"net_generation_mwh\",\n",
-    "    \"fuel_consumed_mmbtu\",\n",
-    "    \"fuel_consumed_for_electricity_mmbtu\",\n",
-    "    \"co2_mass_lb\",\n",
-    "    \"co2_mass_lb_adjusted\",\n",
-    "]\n",
-    "\n",
     "calculated_ba = []\n",
     "\n",
     "for filename in os.listdir(\n",
@@ -455,7 +486,9 @@
     "    ba_data = ba_data[[\"ba_code\"] + DATA_COLUMNS]\n",
     "    calculated_ba.append(ba_data)\n",
     "\n",
-    "calculated_ba = pd.concat(calculated_ba, axis=0)\n"
+    "calculated_ba = pd.concat(calculated_ba, axis=0)\n",
+    "\n",
+    "calculated_ba[\"generated_co2_rate_lb_per_mwh\"] = calculated_ba[\"co2_mass_lb\"] / calculated_ba[\"net_generation_mwh\"]\n"
    ]
   },
   {
@@ -479,15 +512,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "percent_diff_from_egrid.sort_values(by=\"net_generation_mwh\")\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "# divide our calculation by the BA totals from eGRID\n",
     "# if there are 0 values, replace with 0.1, so that div by zero doesn't return missing value\n",
     "ba_metric = (\n",
@@ -497,21 +521,59 @@
     "    .sort_values(by=\"co2_mass_lb\")\n",
     "    .round(3)\n",
     ")\n",
+    "ba_metric = ba_metric - 1\n",
     "\n",
     "total = pd.DataFrame(\n",
-    "    calculated_ba[data_columns]\n",
+    "    calculated_ba[DATA_COLUMNS + [\"generated_co2_rate_lb_per_mwh\"]]\n",
     "    .sum()\n",
-    "    .div(egrid_plant_ba_agg[data_columns].sum())\n",
+    "    .div(egrid_plant_ba_agg[DATA_COLUMNS + [\"generated_co2_rate_lb_per_mwh\"]].sum())\n",
     "    .rename(\"Total\")\n",
     ").T\n",
+    "total = total - 1\n",
     "\n",
     "# calculate the difference in the number of plants in each region\n",
-    "# plant_count = (plant_annual_total.groupby('ba_code', dropna=False).count()['plant_id_egrid'] - egrid_plant.groupby('ba_code', dropna=False).count()['plant_id_egrid']).rename('num_plants')\n",
-    "# ba_metric = ba_metric.merge(plant_count, how='left', left_index=True, right_index=True).drop(columns=['plant_id_egrid']).sort_index()\n",
+    "plant_count = (\n",
+    "    annual_plant_results[\n",
+    "        ~(\n",
+    "            annual_plant_results[\n",
+    "                [\n",
+    "                    \"net_generation_mwh\",\n",
+    "                    \"fuel_consumed_mmbtu\",\n",
+    "                    \"fuel_consumed_for_electricity_mmbtu\",\n",
+    "                    \"co2_mass_lb\",\n",
+    "                ]\n",
+    "            ].sum(axis=1)\n",
+    "            == 0\n",
+    "        )\n",
+    "    ]\n",
+    "    .groupby(\"ba_code\", dropna=False)[\"plant_id_eia\"]\n",
+    "    .nunique()\n",
+    "    - egrid_plant[\n",
+    "        ~(\n",
+    "            egrid_plant[\n",
+    "                [\n",
+    "                    \"net_generation_mwh\",\n",
+    "                    \"fuel_consumed_mmbtu\",\n",
+    "                    \"fuel_consumed_for_electricity_mmbtu\",\n",
+    "                    \"co2_mass_lb\",\n",
+    "                ]\n",
+    "            ].sum(axis=1)\n",
+    "            == 0\n",
+    "        )\n",
+    "    ]\n",
+    "    .groupby(\"ba_code\", dropna=False)[\"plant_id_eia\"]\n",
+    "    .nunique()\n",
+    ").rename(\"num_plants\")\n",
+    "\n",
+    "ba_metric = ba_metric.merge(\n",
+    "    plant_count, how=\"left\", left_index=True, right_index=True\n",
+    ").sort_index()\n",
+    "\n",
+    "ba_metric = ba_metric.sort_values(by=[\"generated_co2_rate_lb_per_mwh\"], ascending=True)\n",
     "\n",
     "ba_metric = pd.concat([ba_metric, total], axis=0).round(2)\n",
     "\n",
-    "ba_metric = ba_metric[data_columns]\n",
+    "ba_metric = ba_metric[DATA_COLUMNS + [\"generated_co2_rate_lb_per_mwh\", \"num_plants\"]]\n",
     "\n",
     "columns_to_check = [\n",
     "    \"net_generation_mwh\",\n",
@@ -521,19 +583,15 @@
     "]\n",
     "\n",
     "with pd.option_context(\"display.max_rows\", None, \"display.max_columns\", None):\n",
-    "    display(ba_metric[~(ba_metric[columns_to_check] == 1).all(axis=1)])\n"
+    "    display(ba_metric[~(ba_metric[columns_to_check] == 0).all(axis=1)])\n"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Explore specific plants\n",
-    "\n",
-    "### Notes\n",
-    "\n",
-    "BA Totals\n",
-    " - TEPC and SRP are off because the Gila River Generator is shared between SRP and TEPC, and eGRID reports all generation from this project belonging to TEPC\n"
+    "## Explore specific plants\n"
    ]
   },
   {

--- a/notebooks/work_in_progress/GH279_missing_cems_data.ipynb
+++ b/notebooks/work_in_progress/GH279_missing_cems_data.ipynb
@@ -1,0 +1,731 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# import packages\n",
+    "import pandas as pd\n",
+    "\n",
+    "%reload_ext autoreload\n",
+    "%autoreload 2\n",
+    "\n",
+    "# # Tell python where to look for modules.\n",
+    "import sys\n",
+    "sys.path.append('../../../open-grid-emissions/src/')\n",
+    "\n",
+    "from column_checks import get_dtypes\n",
+    "from filepaths import *\n",
+    "import load_data\n",
+    "from data_cleaning import *\n",
+    "import validation\n",
+    "import emissions\n",
+    "\n",
+    "year = 2021"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What does the cleaned CEMS data look like"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load data from csv\n",
+    "year = 2021\n",
+    "path_prefix = f\"{year}/\"\n",
+    "\n",
+    "cems = pd.read_csv(outputs_folder(f\"{path_prefix}/cems_cleaned_{year}.csv\"), dtype=get_dtypes())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems[cems[\"plant_id_eia\"] == 3].groupby([\"plant_id_eia\",\"emissions_unit_id_epa\",]).sum(numeric_only=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems[cems[\"plant_id_eia\"] == 3].sum(numeric_only=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eia923_allocated = pd.read_csv(outputs_folder(f\"{path_prefix}/eia923_allocated_{year}.csv\"), dtype=get_dtypes())\n",
+    "eia923_allocated[eia923_allocated[\"plant_id_eia\"] == 3].groupby([\"plant_id_eia\",\"subplant_id\",\"report_date\"]).sum(numeric_only=True).head(20)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Test where data is being dropped"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(\n",
+    "    eia923_allocated,\n",
+    "    primary_fuel_table,\n",
+    "    subplant_emission_factors,\n",
+    ") = clean_eia923(year, False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# does the raw cems match this?\n",
+    "cems_raw = load_data.load_cems_data(year)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems_raw[cems_raw[\"plant_id_eia\"] == 3].groupby([\"plant_id_eia\",\"emissions_unit_id_epa\",]).sum(numeric_only=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "barry.sum(numeric_only=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# remove non-grid connected plants\n",
+    "cems_raw = remove_plants(\n",
+    "    cems_raw,\n",
+    "    non_grid_connected=True,\n",
+    "    remove_states=[\"PR\"],\n",
+    "    steam_only_plants=False,\n",
+    "    distribution_connected_plants=False,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems_raw[cems_raw[\"plant_id_eia\"] == 3].groupby([\"plant_id_eia\",\"emissions_unit_id_epa\",]).sum(numeric_only=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# manually remove steam-only units\n",
+    "cems_raw = manually_remove_steam_units(cems_raw)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems_raw[cems_raw[\"plant_id_eia\"] == 3].groupby([\"plant_id_eia\",\"emissions_unit_id_epa\",]).sum(numeric_only=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# add a report date\n",
+    "cems_raw = load_data.add_report_date(cems_raw)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems_raw[cems_raw[\"plant_id_eia\"] == 3].groupby([\"plant_id_eia\",\"emissions_unit_id_epa\",]).sum(numeric_only=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# remove data for any unit-months where there are incomplete data reported\n",
+    "# this is generally when there is a single observation reported for an entire month\n",
+    "cems_raw = remove_incomplete_unit_months(cems_raw)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems_raw[cems_raw[\"plant_id_eia\"] == 3].groupby([\"plant_id_eia\",\"emissions_unit_id_epa\",]).sum(numeric_only=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# add subplant id\n",
+    "subplant_crosswalk = (\n",
+    "    pd.read_csv(\n",
+    "        outputs_folder(f\"{year}/subplant_crosswalk_{year}.csv\"),\n",
+    "        dtype=get_dtypes(),\n",
+    "    )[[\"plant_id_eia\", \"emissions_unit_id_epa\", \"subplant_id\"]]\n",
+    "    .drop_duplicates()\n",
+    "    .dropna(subset=\"emissions_unit_id_epa\")\n",
+    ")\n",
+    "cems_raw = cems_raw.merge(\n",
+    "    subplant_crosswalk,\n",
+    "    how=\"left\",\n",
+    "    on=[\"plant_id_eia\", \"emissions_unit_id_epa\"],\n",
+    "    validate=\"m:1\",\n",
+    ")\n",
+    "validation.test_for_missing_subplant_id(cems_raw)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems_raw[cems_raw[\"plant_id_eia\"] == 3].groupby([\"plant_id_eia\",\"emissions_unit_id_epa\",]).sum(numeric_only=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# add a fuel type to each observation\n",
+    "cems_raw = assign_fuel_type_to_cems(cems_raw, year, primary_fuel_table)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems_raw[cems_raw[\"plant_id_eia\"] == 3].groupby([\"plant_id_eia\",\"emissions_unit_id_epa\",]).sum(numeric_only=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# fill in missing hourly emissions data using the fuel type and heat input\n",
+    "validation.test_for_missing_energy_source_code(cems_raw)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems_raw[cems_raw[\"plant_id_eia\"] == 3].groupby([\"plant_id_eia\",\"emissions_unit_id_epa\",]).sum(numeric_only=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# save a copy of the cems data at this point to test later\n",
+    "cems_test = cems_raw.copy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems_raw = emissions.fill_cems_missing_co2(cems_test, year, subplant_emission_factors)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems_raw[cems_raw[\"plant_id_eia\"] == 3].groupby([\"plant_id_eia\",\"emissions_unit_id_epa\",]).sum(numeric_only=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems_raw = emissions.calculate_ghg_emissions_from_fuel_consumption(\n",
+    "        df=cems_raw, year=year, include_co2=False, include_ch4=True, include_n2o=True\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems_raw[cems_raw[\"plant_id_eia\"] == 3].groupby([\"plant_id_eia\",\"emissions_unit_id_epa\",]).sum(numeric_only=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems_raw = remove_cems_with_zero_monthly_data(cems_raw)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems_raw[cems_raw[\"plant_id_eia\"] == 3].groupby([\"plant_id_eia\",\"emissions_unit_id_epa\",]).sum(numeric_only=True)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Investigate emissions filling"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cems_test[cems_test[\"plant_id_eia\"] == 3].groupby([\"plant_id_eia\",\"emissions_unit_id_epa\",]).sum(numeric_only=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "barry = cems_test.copy() #[(cems_test[\"plant_id_eia\"] == 3)]\n",
+    "barry"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# add a new categorical option to the mass measurement code\n",
+    "barry[\"co2_mass_measurement_code\"] = barry[\n",
+    "    \"co2_mass_measurement_code\"\n",
+    "].cat.add_categories(\"Imputed\")\n",
+    "\n",
+    "# replace all \"missing\" CO2 values with zero\n",
+    "barry[\"co2_mass_lb\"] = barry[\"co2_mass_lb\"].fillna(0)\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# replace 0 reported CO2 values with missing values, if there was reported heat input\n",
+    "barry.loc[\n",
+    "    (barry[\"co2_mass_lb\"] == 0) & (barry[\"fuel_consumed_mmbtu\"] > 0),\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# replace 0 reported CO2 values with missing values, if there was reported heat input\n",
+    "barry.loc[\n",
+    "    (barry[\"co2_mass_lb\"] == 0) & (barry[\"fuel_consumed_mmbtu\"] > 0),\n",
+    "    \"co2_mass_lb\",\n",
+    "] = np.NaN"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create a new df with all observations with missing co2 data\n",
+    "missing_co2 = barry[barry[\"co2_mass_lb\"].isnull()]\n",
+    "missing_co2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "unit_months_missing_co2 = missing_co2[\n",
+    "        [\"plant_id_eia\", \"emissions_unit_id_epa\", \"report_date\"]\n",
+    "    ].drop_duplicates()\n",
+    "unit_months_missing_co2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get non-missing data from cems for these unit months\n",
+    "unit_months_missing_co2 = unit_months_missing_co2.merge(\n",
+    "    barry[\n",
+    "        [\n",
+    "            \"plant_id_eia\",\n",
+    "            \"emissions_unit_id_epa\",\n",
+    "            \"report_date\",\n",
+    "            \"co2_mass_lb\",\n",
+    "            \"fuel_consumed_mmbtu\",\n",
+    "        ]\n",
+    "    ],\n",
+    "    how=\"left\",\n",
+    "    on=[\"plant_id_eia\", \"emissions_unit_id_epa\", \"report_date\"],\n",
+    "    validate=\"1:m\",\n",
+    ")\n",
+    "unit_months_missing_co2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "unit_months_missing_co2 = unit_months_missing_co2[\n",
+    "        (unit_months_missing_co2[\"co2_mass_lb\"] > 0)\n",
+    "        & (unit_months_missing_co2[\"fuel_consumed_mmbtu\"] > 0)\n",
+    "    ]\n",
+    "unit_months_missing_co2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# calculate total fuel consumption and emissions by month\n",
+    "unit_month_efs = (\n",
+    "    unit_months_missing_co2.groupby(\n",
+    "        [\"plant_id_eia\", \"emissions_unit_id_epa\", \"report_date\"], dropna=False\n",
+    "    )\n",
+    "    .sum()\n",
+    "    .reset_index()\n",
+    ")\n",
+    "unit_month_efs[\"co2_lb_per_mmbtu\"] = (\n",
+    "    unit_month_efs[\"co2_mass_lb\"] / unit_month_efs[\"fuel_consumed_mmbtu\"]\n",
+    ")\n",
+    "unit_month_efs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# merge these EFs into the missing cems data\n",
+    "missing_co2 = missing_co2.merge(\n",
+    "    unit_month_efs[\n",
+    "        [\"plant_id_eia\", \"report_date\", \"emissions_unit_id_epa\", \"co2_lb_per_mmbtu\"]\n",
+    "    ],\n",
+    "    how=\"left\",\n",
+    "    on=[\"plant_id_eia\", \"report_date\", \"emissions_unit_id_epa\"],\n",
+    "    validate=\"m:1\",\n",
+    ").set_index(missing_co2.index)\n",
+    "missing_co2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# only keep observations where there is a non-missing ef\n",
+    "missing_co2 = missing_co2[~missing_co2[\"co2_lb_per_mmbtu\"].isna()]\n",
+    "\n",
+    "# calculate missing co2 data\n",
+    "missing_co2[\"co2_mass_lb\"] = (\n",
+    "    missing_co2[\"fuel_consumed_mmbtu\"] * missing_co2[\"co2_lb_per_mmbtu\"]\n",
+    ")\n",
+    "missing_co2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# update in CEMS table\n",
+    "barry.update(missing_co2[[\"co2_mass_lb\"]])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# update the co2 mass measurement code\n",
+    "barry.loc[missing_co2.index, \"co2_mass_measurement_code\"] = \"Imputed\"\n",
+    "\n",
+    "# identify all observations that are still missing co2 data\n",
+    "missing_co2 = barry[barry[\"co2_mass_lb\"].isnull()]\n",
+    "missing_co2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# merge the weighted ef into the missing data\n",
+    "missing_co2 = missing_co2.merge(\n",
+    "    subplant_emission_factors[\n",
+    "        [\"plant_id_eia\", \"report_date\", \"subplant_id\", \"co2_lb_per_mmbtu\"]\n",
+    "    ],\n",
+    "    how=\"left\",\n",
+    "    on=[\"plant_id_eia\", \"report_date\", \"subplant_id\"],\n",
+    "    validate=\"m:1\",\n",
+    ").set_index(missing_co2.index)\n",
+    "missing_co2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# only keep observations where there is a non-missing ef\n",
+    "missing_co2 = missing_co2[~missing_co2[\"co2_lb_per_mmbtu\"].isna()]\n",
+    "\n",
+    "# calculate missing co2 data\n",
+    "missing_co2[\"co2_mass_lb\"] = (\n",
+    "    missing_co2[\"fuel_consumed_mmbtu\"] * missing_co2[\"co2_lb_per_mmbtu\"]\n",
+    ")\n",
+    "missing_co2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# update in barry table\n",
+    "barry.update(missing_co2[[\"co2_mass_lb\"]])\n",
+    "\n",
+    "# update the co2 mass measurement code\n",
+    "barry.loc[missing_co2.index, \"co2_mass_measurement_code\"] = \"Imputed\"\n",
+    "\n",
+    "# identify all observations that are still missing co2 data\n",
+    "missing_co2 = barry[barry[\"co2_mass_lb\"].isnull()]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_co2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# for rows that have a successful fuel code match, move to a temporary dataframe to hold the data\n",
+    "co2_to_fill = missing_co2.copy()[~missing_co2[\"energy_source_code\"].isna()]\n",
+    "fill_index = co2_to_fill.index\n",
+    "co2_to_fill"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# calculate emissions based on fuel type\n",
+    "co2_to_fill = emissions.calculate_ghg_emissions_from_fuel_consumption(\n",
+    "    df=co2_to_fill,\n",
+    "    year=year,\n",
+    "    include_co2=True,\n",
+    "    include_ch4=False,\n",
+    "    include_n2o=False,\n",
+    ").set_index(fill_index)\n",
+    "\n",
+    "co2_to_fill"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# fill this data into the original cems data\n",
+    "barry.update(co2_to_fill[[\"co2_mass_lb\"]])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "barry[[\"plant_id_eia\",\"emissions_unit_id_epa\",\"datetime_utc\", \"co2_mass_lb\"]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_fill = cems_test.loc[cems_test[\"co2_mass_lb\"] > 0,[\"plant_id_eia\",\"emissions_unit_id_epa\",\"datetime_utc\", \"co2_mass_lb\"]]\n",
+    "test_fill = test_fill.merge(barry[[\"plant_id_eia\",\"emissions_unit_id_epa\",\"datetime_utc\", \"co2_mass_lb\"]], how=\"left\", on=[\"plant_id_eia\",\"emissions_unit_id_epa\",\"datetime_utc\"], validate=\"1:1\", suffixes=(\"_original\",\"_postfill\"))\n",
+    "test_fill[\"diff\"] = test_fill[\"co2_mass_lb_postfill\"] - test_fill[\"co2_mass_lb_original\"]\n",
+    "test_fill[test_fill[\"diff\"] != 0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "open_grid_emissions",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.9"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "25e36f192ecdbe5da57d9bea009812e7b11ef0e0053366a845a2802aae1b29d2"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/data_cleaning.py
+++ b/src/data_cleaning.py
@@ -1298,6 +1298,20 @@ def remove_cems_with_zero_monthly_data(cems):
     print(
         f"    Removing {len(cems[cems['missing_data_flag'] == 'remove'])} observations from cems for unit-months where no data reported"
     )
+    check_that_data_is_zero = cems[
+        cems["missing_data_flag"] == "remove",
+        [
+            "gross_generation_mwh",
+            "steam_load_1000_lb",
+            "fuel_consumed_mmbtu",
+            "co2_mass_lb",
+            "nox_mass_lb",
+            "so2_mass_lb",
+        ],
+    ].sum(numeric_only=True)
+    if check_that_data_is_zero.sum() > 0:
+        print("WARNING: Some data being removed has non-zero data associated with it:")
+        print(check_that_data_is_zero)
     cems = cems[cems["missing_data_flag"] != "remove"]
     # drop the missing data flag column
     cems = cems.drop(columns="missing_data_flag")

--- a/src/emissions.py
+++ b/src/emissions.py
@@ -1753,7 +1753,7 @@ def fill_cems_missing_co2(cems, year, subplant_emission_factors):
         how="left",
         on=["plant_id_eia", "report_date", "emissions_unit_id_epa"],
         validate="m:1",
-    )
+    ).set_index(missing_co2.index)
 
     # only keep observations where there is a non-missing ef
     missing_co2 = missing_co2[~missing_co2["co2_lb_per_mmbtu"].isna()]
@@ -1783,7 +1783,7 @@ def fill_cems_missing_co2(cems, year, subplant_emission_factors):
         how="left",
         on=["plant_id_eia", "report_date", "subplant_id"],
         validate="m:1",
-    )
+    ).set_index(missing_co2.index)
 
     # only keep observations where there is a non-missing ef
     missing_co2 = missing_co2[~missing_co2["co2_lb_per_mmbtu"].isna()]
@@ -1830,5 +1830,8 @@ def fill_cems_missing_co2(cems, year, subplant_emission_factors):
         raise UserWarning(
             "There are still misssing CO2 values remaining after filling missing CO2 values in CEMS"
         )
+
+    # check that no non-missing co2 values were modified during filling
+    validation.check_non_missing_cems_co2_values_unchanged(cems, year)
 
     return cems


### PR DESCRIPTION
This PR closes https://github.com/singularity-energy/open-grid-emissions/issues/279. 

Updates:
- Fixes issue where the index of a dataframe that was being used to update the cems dataframe was being reset, causing the wrong data to be overwritten, and leading to incorrect CEMS output data.
- Adds validation check to ensure that non-missing CEMS CO2 data is not being modified by `emissions.fill_cems_missing_co2()`
- Adds a validation check to ensure that none of the data being removed from CEMS by `data_cleaning.remove_cems_with_zero_monthly_data()` actually has non-zero data associated with it.
- Updates the eGRID validation notebook to more helpfully format the BA-total comparison table