### PR TITLE
Gailinpease/snakemake proof of concept

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ notebooks/*/.ipynb_checkpoints
 
 # VS Code
 .vscode/
+
+# Snakemake 
+.snakemake/

--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,7 @@ name: open_grid_emissions
 channels:
   - defaults
   - conda-forge
+  - bioconda
 dependencies:
   - black # development: code formatting
   - blas=*=openblas # prevent mkl implementation of blas
@@ -27,6 +28,7 @@ dependencies:
   - sqlalchemy
   - sqlite # used for pudl
   - statsmodels
+  - snakemake-minimal # minimal version of snakemake is PC-compatible
 
   - pip:
       # --editable ../pudl #NOTE: this is for development use

--- a/src/data_pipeline.py
+++ b/src/data_pipeline.py
@@ -523,19 +523,6 @@ def main():
     # Output final data: per-ba hourly generation and rate
     output_data.write_power_sector_results(ba_fuel_data, path_prefix, args.skip_outputs)
 
-    # 18. Calculate consumption-based emissions and write carbon accounting results
-    ####################################################################################
-    print("18. Calculating and exporting consumption-based results")
-    hourly_consumed_calc = consumed.HourlyConsumed(
-        clean_930_file,
-        path_prefix,
-        year,
-        small=args.small,
-        skip_outputs=args.skip_outputs,
-    )
-    hourly_consumed_calc.run()
-    hourly_consumed_calc.output_results()
-
 
 if __name__ == "__main__":
     main()

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -1,0 +1,25 @@
+
+configfile: "workflow/config/config.yaml"
+
+wildcard_constraints:
+    year="[0-9]+",
+    run_type="[a-z]+" # "small", "base", or "flat"
+
+def calculate_consumed_inputs(wildcards):
+    if wildcards.run_type=="small":
+        return {"clean_930_file":"data/downloads/eia930/chalendar/EBA_elec.csv"}
+    elif wildcards.run_type=="base":
+        return {"clean_930_file":"data/outputs/{run_type}/{year}/eia930/eia930_elec.csv"}
+    else:
+        raise Exception("unknown run type")
+
+rule calculate_consumed:
+    input:
+        unpack(calculate_consumed_inputs),
+        "data/results/{run_type}/{year}/power_sector_data/hourly/us_units/",
+        "data/outputs/{run_type}/{year}/annual_generation_averages_by_fuel_{year}.csv",
+        "data/manual/ba_reference.csv",
+    output:
+        directory("data/results/{run_type}/{year}/carbon_accounting/"),
+    script:
+        "scripts/calculate_consumed.py"

--- a/workflow/config/config.yaml
+++ b/workflow/config/config.yaml
@@ -1,0 +1,2 @@
+data_pipeline: 
+  skip_outputs: False

--- a/workflow/scripts/calculate_consumed.py
+++ b/workflow/scripts/calculate_consumed.py
@@ -1,0 +1,38 @@
+import os
+import argparse
+import sys
+
+sys.path.append("src")
+
+
+import consumed as consumed
+
+
+def main(args):
+    year = int(snakemake.wildcards.year)
+    path_prefix = f"{snakemake.wildcards.run_type}/{year}/"
+
+    print("18. Calculating and exporting consumption-based results")
+    hourly_consumed_calc = consumed.HourlyConsumed(
+        snakemake.input[0],
+        path_prefix,
+        year=year,
+        small=args.small,
+        skip_outputs=snakemake.config["data_pipeline"]["skip_outputs"],
+    )
+    hourly_consumed_calc.run()
+    hourly_consumed_calc.output_results()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--small",
+        type=bool,
+        default=False,
+    )
+
+    args = parser.parse_args()
+
+    main(args)


### PR DESCRIPTION
This PR demonstrates how we might use Snakemake as a workflow manager by implementing a snakemake rule for the final step in the pipeline (calculating consumed emissions). 

## Why snakemake? 
* In active development + active user community 
* Open source and free to use (so any OGE user can use it)
* Supports running both locally and in cloud using the same rules (though configuring to run on AWS would require some work) 
* By default, decides which jobs need to be run based on file change timestamps (both source code and data). This means that as we make changes to the pipeline, Snakemake will detect which parts of the pipeline need to be re-run, and we can avoid re-computing expensive but rarely-changed tasks (eg, 930 cleaning) without having to hardcode that logic.

## How does it work? 

1. Define rules that describe which inputs a step takes, what outputs it produces, and what to run to produce the outputs (in this PR, I use a python script, but the job can also be a command line script, a jupyter notebook (including with a custom conda env), or in-line python). 
2. On the command line, ask snakemake to produce a result file: `snakemake -n data/results/base/2019/carbon_accounting` (-n signals dry run, so snakemake won't actually produce anything)
3. Snakemake tells you what rules it's running and why. Currently there's only one rule, but with more rules, snakemake will detect dependencies between input and output files and decide which jobs to run based on updates to input data or code. 
![Screen Shot 2023-02-20 at 5 15 47 PM](https://user-images.githubusercontent.com/12755256/220206146-7f68e89b-9dea-40f3-8e18-dbf0b5886280.png)

If we instead ask for `data/results/small/2019/carbon_accounting`, snakemake will detect based on the `input` for the rule that we need to use the downloaded 930 file instead of the outputs 930 file, replicating the logic currently in data_pipeline.py: 
![Screen Shot 2023-02-20 at 5 27 27 PM](https://user-images.githubusercontent.com/12755256/220207263-8e30c5d8-cfb8-4b34-b5c0-3abea2b6b9ee.png)

## Advantages of snakemake over data_pipeline.py 

* New rules can be added (for example, for validation tasks) without adding computational time to the main pipeline, since Snakemake will detect that they're not necessary for computing `results/2019`, for example
* Parts of the pipeline can be run separately without manually copying code into a jupyter notebook 
* Files for intermediate outputs between jobs are captured as `input` and `output` files (this could also eventually support validation and/or manual inspection of intermediate output files)
* Dependencies between steps are captured 
* The workflow is captured in the `workflow` folder, which will eventually support separately packaging `src`  

## Disadvantages 

* Snakemake will likely not be able to detect code changes affecting individual jobs since most jobs depend on code in data_pipeline.py. You can tell snakemake to only consider the timestamps of input and output files using `--rerun-trigger mtime` 
* Because of how snakemake wildcards work, we'll need to put results and outputs in "results/base/{year}" if we also want to use the rules to generate "results/small/{year}"
* Snakemake will not play nicely with `skip_outputs` (implemented in this PR as a config option, see config.yaml), since it deletes the output files for a job before running it. I think `skip_outputs` should be less necessary though if snakemake helps us avoid running the entire pipeline 
 