### PR TITLE
Make PUDL logging show up, and set up logging in OGE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,13 +3,14 @@ data/*
 
 example/.ipynb_checkpoints/
 test/__pycache__/
+test/*.txt
 src/__pycache__/
 
 CHANGELOG.md
 
 notebooks/visualization/outputs/*
 
-# Python 
+# Python
 notebooks/.ipynb_checkpoints
 notebooks/*/.ipynb_checkpoints
 .hypothesis/

--- a/environment.yml
+++ b/environment.yml
@@ -27,6 +27,7 @@ dependencies:
   - sqlalchemy
   - sqlite # used for pudl
   - statsmodels
+  - coloredlogs # used for prettier logging
 
   - pip:
       # --editable ../pudl #NOTE: this is for development use

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,5 @@
+# Set up the OGE logging configuration once.
+import logging
+from .logging_util import configure_root_logger
+from .filepaths import outputs_folder
+configure_root_logger(outputs_folder("logfile.txt"), logging.INFO)

--- a/src/column_checks.py
+++ b/src/column_checks.py
@@ -17,6 +17,9 @@ those files or uses, then remove it here.
 After any change, re-run data_pipeline to regenerate all files and re-run these
 checks.
 """
+from logging_util import get_logger
+logger = get_logger(__name__)
+
 
 COLUMNS = {
     "eia923_allocated": {
@@ -348,8 +351,8 @@ def check_columns(df, file_name):
     # Check for extra columns. Warning not exception
     extras = cols - expected_cols
     if len(extras) > 0:
-        print(
-            f"WARNING: columns {extras} in {file_name} are not guaranteed by column_checks.py"
+        logger.warning(
+            f"columns {extras} in {file_name} are not guaranteed by column_checks.py"
         )
 
     # Raise exception for missing columns
@@ -464,8 +467,8 @@ def apply_dtypes(df):
         if (col not in dtypes) and (col not in datetime_columns)
     ]
     if len(cols_missing_dtypes) > 0:
-        print(
-            "WARNING: The following columns do not have dtypes assigned in `column_checks.get_dtypes()`"
+        logger.warning(
+            "The following columns do not have dtypes assigned in `column_checks.get_dtypes()`"
         )
-        print(cols_missing_dtypes)
+        logger.warning(cols_missing_dtypes)
     return df.astype({col: dtypes[col] for col in df.columns if col in dtypes})

--- a/src/consumed.py
+++ b/src/consumed.py
@@ -517,5 +517,5 @@ class HourlyConsumed:
                         self.results[r].loc[date, col] = consumed_emissions[i]
                 if total_failed > 0:
                     logger.warning(
-                        f"Warning: {total_failed} hours failed to solve for consumed {pol} {adj} emissions."
+                        f"{total_failed} hours failed to solve for consumed {pol} {adj} emissions."
                     )

--- a/src/data_cleaning.py
+++ b/src/data_cleaning.py
@@ -545,14 +545,12 @@ def update_energy_source_codes(df):
         (df["energy_source_code"] == "OTH") & (df["fuel_consumed_mmbtu"] > 0)
     ]
     if len(plants_with_other_fuel) > 0:
-        logger.warning(
-            "After cleaning energy source codes, some fuel consumption is still associated with an 'OTH' fuel type."
+        logger.warning(f"""
+            After cleaning energy source codes, some fuel consumption is still associated with an 'OTH' fuel type.
+            This will lead to incorrect emissions calculations.
+            Check the following plants: {list(plants_with_other_fuel.plant_id_eia.unique())}
+            Assign a fuel type in `data_cleaning.update_energy_source_codes`"""
         )
-        logger.warning("This will lead to incorrect emissions calculations.")
-        logger.warning(
-            f"Check the following plants: {list(plants_with_other_fuel.plant_id_eia.unique())}"
-        )
-        logger.warning("Assign a fuel type in `data_cleaning.update_energy_source_codes`")
 
     return df
 

--- a/src/data_cleaning.py
+++ b/src/data_cleaning.py
@@ -1962,7 +1962,7 @@ def assign_ba_code_to_plant(df, year):
 
     if len(df[df["ba_code"].isna()]) > 0:
         logger.warning("    the following plants are missing ba_code:")
-        logger.warning(df[df["ba_code"].isna()])
+        logger.warning("\n" + df[df["ba_code"].isna()].tostring())
 
     # replace missing ba codes with NA
     df["ba_code"] = df["ba_code"].fillna("NA")

--- a/src/data_cleaning.py
+++ b/src/data_cleaning.py
@@ -13,7 +13,9 @@ import emissions
 from emissions import CLEAN_FUELS
 from column_checks import get_dtypes, apply_dtypes
 from filepaths import manual_folder, outputs_folder, downloads_folder
+from logging_util import get_logger
 
+logger = get_logger(__name__)
 
 DATA_COLUMNS = [
     "net_generation_mwh",
@@ -52,11 +54,11 @@ def identify_subplants(year, number_of_years=5):
     end_year = year
 
     # load 5 years of monthly data from CEMS
-    print("    loading CEMS ids")
+    logger.info("    loading CEMS ids")
     cems_ids = load_data.load_cems_ids(start_year, end_year)
 
     # add subplant ids to the data
-    print("    identifying unique subplants")
+    logger.info("    identifying unique subplants")
     generate_subplant_ids(start_year, end_year, cems_ids)
 
 
@@ -543,14 +545,14 @@ def update_energy_source_codes(df):
         (df["energy_source_code"] == "OTH") & (df["fuel_consumed_mmbtu"] > 0)
     ]
     if len(plants_with_other_fuel) > 0:
-        print(
-            "WARNING: After cleaning energy source codes, some fuel consumption is still associated with an 'OTH' fuel type."
+        logger.warning(
+            "After cleaning energy source codes, some fuel consumption is still associated with an 'OTH' fuel type."
         )
-        print("This will lead to incorrect emissions calculations.")
-        print(
+        logger.warning("This will lead to incorrect emissions calculations.")
+        logger.warning(
             f"Check the following plants: {list(plants_with_other_fuel.plant_id_eia.unique())}"
         )
-        print("Assign a fuel type in `data_cleaning.update_energy_source_codes`")
+        logger.warning("Assign a fuel type in `data_cleaning.update_energy_source_codes`")
 
     return df
 
@@ -735,7 +737,7 @@ def calculate_aggregated_primary_fuel(
         plants_with_no_primary_fuel = agg_primary_fuel[
             agg_primary_fuel[f"{level}_primary_fuel"].isna()
         ]
-        print(
+        logger.warning(
             f"Check the following plants: {list(plants_with_no_primary_fuel.plant_id_eia.unique())}"
         )
         raise UserWarning(
@@ -882,7 +884,7 @@ def remove_plants(
                 plant_states["state"].isin(remove_states)
             ].plant_id_eia.unique()
         )
-        print(
+        logger.info(
             f"    Removing {len(plants_in_states_to_remove)} plants located in the following states: {remove_states}"
         )
         df = df[~df["plant_id_eia"].isin(plants_in_states_to_remove)]
@@ -918,7 +920,7 @@ def remove_non_grid_connected_plants(df):
             "plant_id_eia"
         ].unique()
     )
-    print(f"    Removing {num_plants} plants that are not grid-connected")
+    logger.info(f"    Removing {num_plants} plants that are not grid-connected")
 
     df = df[~df["plant_id_eia"].isin(ngc_plants)]
 
@@ -1005,7 +1007,7 @@ def clean_cems(year: int, small: bool, primary_fuel_table, subplant_emission_fac
 
 
 def smallerize_test_data(df, random_seed=None):
-    print("    Randomly selecting 5% of plants for faster test run.")
+    logger.info("    Randomly selecting 5% of plants for faster test run.")
     # Select 5% of plants
     selected_plants = df.plant_id_eia.unique()
     if random_seed is not None:
@@ -1030,7 +1032,7 @@ def manually_remove_steam_units(df):
         dtype=get_dtypes(),
     )[["plant_id_eia", "emissions_unit_id_epa"]]
 
-    print(
+    logger.info(
         f"    Removing {len(units_to_remove)} units that only produce steam and do not report to EIA"
     )
 
@@ -1062,7 +1064,7 @@ def remove_incomplete_unit_months(cems):
         unit_hours_in_month["datetime_utc"] < 600
     ].drop(columns="datetime_utc")
 
-    print(
+    logger.info(
         f"    Removing {len(unit_months_to_remove)} unit-months with incomplete hourly data"
     )
 
@@ -1295,7 +1297,7 @@ def remove_cems_with_zero_monthly_data(cems):
         validate="m:1",
     )
     # remove any observations with the missing data flag
-    print(
+    logger.info(
         f"    Removing {len(cems[cems['missing_data_flag'] == 'remove'])} observations from cems for unit-months where no data reported"
     )
     cems = cems[cems["missing_data_flag"] != "remove"]
@@ -1959,8 +1961,8 @@ def assign_ba_code_to_plant(df, year):
     df = df.merge(plant_ba, how="left", on="plant_id_eia", validate="m:1")
 
     if len(df[df["ba_code"].isna()]) > 0:
-        print("    WARNING: the following plants are missing ba_code:")
-        print(df[df["ba_code"].isna()])
+        logger.warning("    the following plants are missing ba_code:")
+        logger.warning(df[df["ba_code"].isna()])
 
     # replace missing ba codes with NA
     df["ba_code"] = df["ba_code"].fillna("NA")

--- a/src/data_pipeline.py
+++ b/src/data_pipeline.py
@@ -6,16 +6,11 @@ Run from `src` as `python data_pipeline.py` after installing conda environment
 Optional arguments are --year (default 2021), --shape_individual_plants (default True)
 Optional arguments for development are --small, --flat, and --skip_outputs
 """
-
-
-# import packages
 import argparse
 import os
 import shutil
 
 # import local modules
-# import local modules
-# # # Tell python where to look for modules.
 import download_data
 import data_cleaning
 import emissions
@@ -26,11 +21,17 @@ import validation
 import output_data
 import consumed
 from filepaths import downloads_folder, outputs_folder, results_folder
+from logging_util import get_logger, configure_root_logger
 
 
-def get_args():
-    """
-    Specify arguments here.
+# Log the print statements to a file for debugging.
+configure_root_logger(logfile=outputs_folder("data_pipeline.log"))
+logger = get_logger("data_pipeline")
+
+
+def get_args() -> argparse.Namespace:
+    """Specify arguments here.
+
     Returns dictionary of {arg_name: arg_value}
     """
     parser = argparse.ArgumentParser()
@@ -63,8 +64,10 @@ def get_args():
 
 
 def main():
+    """Runs the OGE data pipeline."""
     args = get_args()
     year = args.year
+    logger.info(f'Running data pipeline for year {year}')
 
     validation.validate_year(year)
 
@@ -99,7 +102,7 @@ def main():
 
     # 1. Download data
     ####################################################################################
-    print("1. Downloading data")
+    logger.info("1. Downloading data")
     # PUDL
     download_data.download_pudl_data(
         zenodo_url="https://zenodo.org/record/7472137/files/pudl-v2022.11.30.tgz"
@@ -131,12 +134,12 @@ def main():
 
     # 2. Identify subplants
     ####################################################################################
-    print("2. Identifying subplant IDs")
+    logger.info("2. Identifying subplant IDs")
     data_cleaning.identify_subplants(year)
 
     # 3. Clean EIA-923 Generation and Fuel Data at the Monthly Level
     ####################################################################################
-    print("3. Cleaning EIA-923 data")
+    logger.info("3. Cleaning EIA-923 data")
     (
         eia923_allocated,
         primary_fuel_table,
@@ -152,7 +155,7 @@ def main():
 
     # 4. Clean Hourly Data from CEMS
     ####################################################################################
-    print("4. Cleaning CEMS data")
+    logger.info("4. Cleaning CEMS data")
     cems = data_cleaning.clean_cems(
         year, args.small, primary_fuel_table, subplant_emission_factors
     )
@@ -178,14 +181,14 @@ def main():
 
     # 5. Assign static characteristics to CEMS and EIA data to aid in aggregation
     ####################################################################################
-    print("5. Loading plant static attributes")
+    logger.info("5. Loading plant static attributes")
     plant_attributes = data_cleaning.create_plant_attributes_table(
         cems, eia923_allocated, year, primary_fuel_table
     )
 
     # 6. Crosswalk CEMS and EIA data
     ####################################################################################
-    print("6. Identifying source for hourly data")
+    logger.info("6. Identifying source for hourly data")
     eia923_allocated = data_cleaning.identify_hourly_data_source(
         eia923_allocated, cems, year
     )
@@ -207,13 +210,13 @@ def main():
 
     # 7. Aggregating CEMS data to subplant
     ####################################################################################
-    print("7. Aggregating CEMS data from unit to subplant")
+    logger.info("7. Aggregating CEMS data from unit to subplant")
     # aggregate cems data to subplant level
     cems = data_cleaning.aggregate_cems_to_subplant(cems)
 
     # 8. Calculate hourly data for partial_cems plants
     ####################################################################################
-    print("8. Shaping partial CEMS data")
+    logger.info("8. Shaping partial CEMS data")
     # shape partial CEMS plant data
     partial_cems_plant = impute_hourly_profiles.shape_partial_cems_plants(
         cems, eia923_allocated
@@ -251,7 +254,7 @@ def main():
 
     # 9. Convert CEMS Hourly Gross Generation to Hourly Net Generation
     ####################################################################################
-    print("9. Converting CEMS gross generation to net generation")
+    logger.info("9. Converting CEMS gross generation to net generation")
     cems, gtn_conversions = gross_to_net_generation.convert_gross_to_net_generation(
         cems, eia923_allocated, plant_attributes, year
     )
@@ -273,7 +276,7 @@ def main():
 
     # 10. Adjust CEMS emission data for CHP
     ####################################################################################
-    print("10. Adjusting CEMS emissions for CHP")
+    logger.info("10. Adjusting CEMS emissions for CHP")
     cems = data_cleaning.adjust_cems_for_chp(cems, eia923_allocated)
     cems = emissions.calculate_co2e_mass(
         cems, year, gwp_horizon=100, ar5_climate_carbon_feedback=True
@@ -290,7 +293,7 @@ def main():
 
     # 11. Export monthly and annual plant-level results
     ####################################################################################
-    print("11. Exporting monthly and annual plant-level results")
+    logger.info("11. Exporting monthly and annual plant-level results")
     # create a separate dataframe containing only the EIA data that is missing from cems
     monthly_eia_data_to_shape = eia923_allocated[
         (eia923_allocated["hourly_data_source"] == "eia")
@@ -327,14 +330,14 @@ def main():
 
     # 12. Clean and Reconcile EIA-930 data
     ####################################################################################
-    print("12. Cleaning EIA-930 data")
+    logger.info("12. Cleaning EIA-930 data")
     # Scrapes and cleans data in data/downloads, outputs cleaned file at EBA_elec.csv
     if args.flat:
-        print("    Not running 930 cleaning because we'll be using a flat profile.")
+        logger.info("    Not running 930 cleaning because we'll be using a flat profile.")
     elif not (os.path.exists(outputs_folder(f"{path_prefix}/eia930/eia930_elec.csv"))):
         eia930.clean_930(year, small=args.small, path_prefix=path_prefix)
     else:
-        print(
+        logger.info(
             f"    Not re-running 930 cleaning. If you'd like to re-run, please delete data/outputs/{path_prefix}/eia930/"
         )
 
@@ -351,7 +354,7 @@ def main():
 
     # 13. Calculate hourly profiles for monthly EIA data
     ####################################################################################
-    print("13. Estimating hourly profiles for EIA data")
+    logger.info("13. Estimating hourly profiles for EIA data")
     hourly_profiles = impute_hourly_profiles.calculate_hourly_profiles(
         cems,
         partial_cems_subplant,
@@ -384,7 +387,7 @@ def main():
 
     # 14. Export hourly plant-level data
     ####################################################################################
-    print("14. Exporting Hourly Plant-level data for each BA")
+    logger.info("14. Exporting Hourly Plant-level data for each BA")
     if args.shape_individual_plants and not args.small:
         impute_hourly_profiles.combine_and_export_hourly_plant_data(
             cems,
@@ -398,16 +401,16 @@ def main():
             region_to_group="ba_code",
         )
     else:
-        print(
+        logger.info(
             "    Not shaping and exporting individual plant data since `shape_individual_plants` is False."
         )
-        print(
+        logger.info(
             "    Plants that only report to EIA will be aggregated to the fleet level before shaping."
         )
 
     # 15. Shape fleet-level data
     ####################################################################################
-    print("15. Assigning hourly profiles to monthly EIA-923 data")
+    logger.info("15. Assigning hourly profiles to monthly EIA-923 data")
     hourly_profiles = impute_hourly_profiles.convert_profile_to_percent(
         hourly_profiles,
         group_keys=["ba_code", "fuel_category", "profile_method"],
@@ -465,7 +468,7 @@ def main():
 
     # 16. Combine plant-level data from all sources
     ####################################################################################
-    print("16. Combining plant-level hourly data")
+    logger.info("16. Combining plant-level hourly data")
     # write metadata outputs
     output_data.write_plant_metadata(
         plant_attributes,
@@ -511,7 +514,7 @@ def main():
 
     # 17. Aggregate CEMS data to BA-fuel and write power sector results
     ####################################################################################
-    print("17. Creating and exporting BA-level power sector results")
+    logger.info("17. Creating and exporting BA-level power sector results")
     ba_fuel_data = data_cleaning.aggregate_plant_data_to_ba_fuel(
         combined_plant_data, plant_attributes
     )
@@ -525,7 +528,7 @@ def main():
 
     # 18. Calculate consumption-based emissions and write carbon accounting results
     ####################################################################################
-    print("18. Calculating and exporting consumption-based results")
+    logger.info("18. Calculating and exporting consumption-based results")
     hourly_consumed_calc = consumed.HourlyConsumed(
         clean_930_file,
         path_prefix,

--- a/src/download_data.py
+++ b/src/download_data.py
@@ -7,6 +7,9 @@ import tarfile
 import zipfile
 
 from filepaths import downloads_folder, data_folder
+from logging_util import get_logger
+
+logger = get_logger(__name__)
 
 
 def download_helper(
@@ -38,11 +41,11 @@ def download_helper(
     # If the file already exists, do not re-download it.
     final_destination = output_path if output_path is not None else download_path
     if os.path.exists(final_destination):
-        print(f"    {final_destination.split('/')[-1]} already downloaded, skipping.")
+        logger.info(f"    {final_destination.split('/')[-1]} already downloaded, skipping.")
         return False
 
     # Otherwise, download to the file in chunks.
-    print(f"    Downloading {final_destination.split('/')[-1]}")
+    logger.info(f"    Downloading {final_destination.split('/')[-1]}")
     r = requests.get(input_url, stream=True)
     with open(download_path, "wb") as fd:
         for chunk in r.iter_content(chunk_size=chunk_size):
@@ -94,10 +97,10 @@ def download_pudl_data(zenodo_url: str):
         with open(pudl_version_file, "r") as f:
             existing_version = f.readlines()[0].replace("\n", "")
         if pudl_version == existing_version:
-            print("    PUDL version already downloaded")
+            logger.info("    PUDL version already downloaded")
             return
         else:
-            print("    Downloading new version of pudl")
+            logger.info("    Downloading new version of pudl")
             shutil.rmtree(downloads_folder("pudl"))
 
     download_pudl(zenodo_url, pudl_version)
@@ -117,10 +120,10 @@ def download_pudl(zenodo_url, pudl_version):
             )
             fd.write(chunk)
             downloaded += block_size
-    print("    Downloading PUDL. Progress: 100.0%")
+    logger.info("    Downloading PUDL. Progress: 100.0%")
 
     # extract the tgz file
-    print("    Extracting PUDL data...")
+    logger.info("    Extracting PUDL data...")
     with tarfile.open(downloads_folder("pudl.tgz")) as tar:
         tar.extractall(data_folder())
 
@@ -268,7 +271,7 @@ def download_raw_eia860(year):
     Downloads raw EIA-860 data (zip files), and unzips them to the downloads folder.
     """
     if year < 2005:
-        raise NotImplementedError(f"WARNING: We haven't tested EIA-860 for '{year}'.")
+        raise NotImplementedError(f"We haven't tested EIA-860 for '{year}'.")
     os.makedirs(downloads_folder("eia860"), exist_ok=True)
     url = f"https://www.eia.gov/electricity/data/eia860/xls/eia860{year}.zip"
     archive_url = (

--- a/src/eia930.py
+++ b/src/eia930.py
@@ -7,11 +7,14 @@ from os.path import join
 import load_data
 from column_checks import get_dtypes
 from filepaths import top_folder, downloads_folder, outputs_folder, manual_folder
+from logging_util import get_logger
 
 # Tell gridemissions where to find config before we load gridemissions
 os.environ["GRIDEMISSIONS_CONFIG_FILE_PATH"] = top_folder("config/gridemissions.json")
 
 from gridemissions.workflows import make_dataset
+
+logger = get_logger(__name__)
 
 
 def convert_balance_file_to_gridemissions_format(year: int, small: bool = False):
@@ -142,14 +145,14 @@ def clean_930(year: int, small: bool = False, path_prefix: str = ""):
         df = df.loc[start:end]  # Don't worry about processing everything
 
     # Adjust
-    print("    Adjusting EIA-930 time stamps")
+    logger.info("    Adjusting EIA-930 time stamps")
     df = manual_930_adjust(df)
     df.to_csv(
         join(data_folder, "eia930_raw.csv")
     )  # Will be read by gridemissions workflow
 
     # Run cleaning
-    print("    Running physics-based data cleaning")
+    logger.info("    Running physics-based data cleaning")
     make_dataset(
         start,
         end,
@@ -171,17 +174,17 @@ def reformat_chalendar(raw):
     """
     # where we have variable (NG = net generation) and fuel type
     target_cols = [c for c in raw.columns if len(c.split(".")) == 5]
-    print("Filtering")
+    logger.info("Filtering")
     cleaned = (
         raw.loc[:, target_cols]
         .melt(ignore_index=False, value_name="generation", var_name="variable")
         .reset_index()
     )
-    print("Expanding cols")
+    logger.info("Expanding cols")
     cleaned[["dtype", "BA", "other BA", "var", "fuel", "interval"]] = cleaned[
         "variable"
     ].str.split(r"[.-]", expand=True, regex=True)
-    print("Dropping and renaming")
+    logger.info("Dropping and renaming")
     cleaned = cleaned.drop(columns=["dtype", "var", "interval", "other BA"])
     cleaned = cleaned.rename(columns={"index": "datetime_utc"})
     return cleaned
@@ -286,7 +289,7 @@ def remove_imputed_ones(eia930_data):
     filter = eia930_data["net_generation_mwh_930"].abs() < 1.5
 
     # replace all 1.0 values with zero
-    print(f"  replacing {sum(filter)} imputed 1 values with 0")
+    logger.info(f"  replacing {sum(filter)} imputed 1 values with 0")
     eia930_data.loc[filter, "net_generation_mwh_930"] = 0
 
     return eia930_data

--- a/src/emissions.py
+++ b/src/emissions.py
@@ -481,7 +481,7 @@ def calculate_nox_from_fuel_consumption(
     if len(missing_ef) > 0:
         logger.warning("NOx emission factors are missing for the following records")
         logger.warning("Missing factors for FC prime movers are currently expected")
-        logger.warning(
+        logger.warning("\n" +
             missing_ef[
                 [
                     "report_date",
@@ -490,7 +490,7 @@ def calculate_nox_from_fuel_consumption(
                     "prime_mover_code",
                     "generator_id",
                 ]
-            ].drop_duplicates()
+            ].drop_duplicates().to_string()
         )
     gen_fuel_allocated["nox_mass_lb"] = (
         gen_fuel_allocated["fuel_consumed_mmbtu"]
@@ -661,7 +661,7 @@ def calculate_generator_nox_ef_per_unit_from_boiler_type(
             "NOx emission factors are missing for the following boiler types. A prime mover-fuel level factor will be used if available."
         )
         logger.warning("Missing factors for FC prime movers are currently expected")
-        logger.warning(missing_nox_efs)
+        logger.warning("\n" + missing_nox_efs.to_string())
         logger.warning(" ")
     gen_nox_factors = fill_missing_factors_based_on_pm_fuel(
         nox_emission_factors, gen_nox_factors
@@ -694,7 +694,7 @@ def calculate_generator_nox_ef_per_unit_from_boiler_type(
             "After filling with PM-fuel factors, NOx emission factors are still missing for the following boiler types. An emission factor of zero will be used for these boilers."
         )
         logger.warning("Missing factors for FC prime movers are currently expected")
-        logger.warning(missing_nox_efs)
+        logger.warning("\n" + missing_nox_efs)
         logger.warning(" ")
     gen_nox_factors["emission_factor"] = gen_nox_factors["emission_factor"].fillna(0)
 
@@ -1216,7 +1216,7 @@ def calculate_so2_from_fuel_consumption(gen_fuel_allocated, pudl_out, year):
     if len(missing_ef) > 0:
         logger.warning("SO2 emission factors are missing for the above records")
         logger.warning("Missing factors for FC prime movers are currently expected")
-        logger.warning(
+        logger.warning("\n" +
             missing_ef[
                 [
                     "report_date",
@@ -1225,7 +1225,7 @@ def calculate_so2_from_fuel_consumption(gen_fuel_allocated, pudl_out, year):
                     "prime_mover_code",
                     "generator_id",
                 ]
-            ].drop_duplicates()
+            ].drop_duplicates().to_string()
         )
     gen_fuel_allocated["so2_mass_lb"] = (
         gen_fuel_allocated["fuel_consumed_mmbtu"]
@@ -1382,7 +1382,7 @@ def calculate_generator_so2_ef_per_unit_from_boiler_type(
             "SO2 emission factors are missing for the following boiler types. A prime mover-fuel level factor will be used if available."
         )
         logger.warning("Missing factors for FC prime movers are currently expected")
-        logger.warning(missing_so2_efs)
+        logger.warning("\n" + missing_so2_efs.to_string())
         logger.warning(" ")
     gen_so2_factors = fill_missing_factors_based_on_pm_fuel(
         so2_emission_factors, gen_so2_factors
@@ -1413,7 +1413,7 @@ def calculate_generator_so2_ef_per_unit_from_boiler_type(
             "SO2 emission factors are missing for the following boiler types. An emission factor of zero will be used for these boilers."
         )
         logger.warning("Missing factors for FC prime movers are currently expected")
-        logger.warning(missing_so2_efs)
+        logger.warning("\n" + missing_so2_efs.to_string())
         logger.warning(" ")
     gen_so2_factors["emission_factor"] = gen_so2_factors["emission_factor"].fillna(0)
     gen_so2_factors["multiply_by_sulfur_content"] = gen_so2_factors[
@@ -1567,7 +1567,7 @@ def adjust_so2_efs_for_fuel_sulfur_content(uncontrolled_so2_factors, pudl_out):
     ]
     if len(missing_sulfur_content) > 0:
         logger.warning("Sulfur content data is missing in EIA-923 for the above units.")
-        logger.warning(
+        logger.warning("\n" +
             missing_sulfur_content[
                 [
                     "plant_id_eia",
@@ -1575,7 +1575,7 @@ def adjust_so2_efs_for_fuel_sulfur_content(uncontrolled_so2_factors, pudl_out):
                     "prime_mover_code",
                     "energy_source_code",
                 ]
-            ].drop_duplicates()
+            ].drop_duplicates().to_string()
         )
     uncontrolled_so2_factors.loc[
         uncontrolled_so2_factors["sulfur_content_pct"].isna()

--- a/src/emissions.py
+++ b/src/emissions.py
@@ -689,13 +689,13 @@ def calculate_generator_nox_ef_per_unit_from_boiler_type(
         )
     )
     if len(missing_nox_efs) > 0:
-        logger.warning(" ")
-        logger.warning(
-            "After filling with PM-fuel factors, NOx emission factors are still missing for the following boiler types. An emission factor of zero will be used for these boilers."
+        logger.warning("""
+            After filling with PM-fuel factors, NOx emission factors are still missing for the following boiler types.
+            An emission factor of zero will be used for these boilers.
+            Missing factors for FC prime movers are currently expected."""
         )
-        logger.warning("Missing factors for FC prime movers are currently expected")
-        logger.warning("\n" + missing_nox_efs)
-        logger.warning(" ")
+        logger.warning("\n" + missing_nox_efs.to_string())
+
     gen_nox_factors["emission_factor"] = gen_nox_factors["emission_factor"].fillna(0)
 
     # average the emission factors for all boilers associated with each generator

--- a/src/emissions.py
+++ b/src/emissions.py
@@ -656,13 +656,11 @@ def calculate_generator_nox_ef_per_unit_from_boiler_type(
         )
     )
     if len(missing_nox_efs) > 0:
-        logger.warning(" ")
         logger.warning(
             "NOx emission factors are missing for the following boiler types. A prime mover-fuel level factor will be used if available."
         )
         logger.warning("Missing factors for FC prime movers are currently expected")
         logger.warning("\n" + missing_nox_efs.to_string())
-        logger.warning(" ")
     gen_nox_factors = fill_missing_factors_based_on_pm_fuel(
         nox_emission_factors, gen_nox_factors
     )
@@ -1377,13 +1375,11 @@ def calculate_generator_so2_ef_per_unit_from_boiler_type(
         )
     )
     if len(missing_so2_efs) > 0:
-        logger.warning(" ")
         logger.warning(
             "SO2 emission factors are missing for the following boiler types. A prime mover-fuel level factor will be used if available."
         )
         logger.warning("Missing factors for FC prime movers are currently expected")
         logger.warning("\n" + missing_so2_efs.to_string())
-        logger.warning(" ")
     gen_so2_factors = fill_missing_factors_based_on_pm_fuel(
         so2_emission_factors, gen_so2_factors
     )
@@ -1408,13 +1404,11 @@ def calculate_generator_so2_ef_per_unit_from_boiler_type(
         )
     )
     if len(missing_so2_efs) > 0:
-        logger.warning(" ")
         logger.warning(
             "SO2 emission factors are missing for the following boiler types. An emission factor of zero will be used for these boilers."
         )
         logger.warning("Missing factors for FC prime movers are currently expected")
         logger.warning("\n" + missing_so2_efs.to_string())
-        logger.warning(" ")
     gen_so2_factors["emission_factor"] = gen_so2_factors["emission_factor"].fillna(0)
     gen_so2_factors["multiply_by_sulfur_content"] = gen_so2_factors[
         "multiply_by_sulfur_content"

--- a/src/emissions.py
+++ b/src/emissions.py
@@ -1,17 +1,19 @@
 import pandas as pd
 import numpy as np
 
-
 import load_data
 import validation
 from column_checks import get_dtypes
 from filepaths import manual_folder
+from logging_util import get_logger
 
 from pudl.analysis.allocate_net_gen import (
     distribute_annually_reported_data_to_months_if_annual,
 )
 
 CLEAN_FUELS = ["SUN", "MWH", "WND", "WAT", "WH", "PUR", "NUC"]
+
+logger = get_logger(__name__)
 
 
 def calculate_ghg_emissions_from_fuel_consumption(
@@ -477,9 +479,9 @@ def calculate_nox_from_fuel_consumption(
         & ~gen_fuel_allocated["energy_source_code"].isin(CLEAN_FUELS)
     ]
     if len(missing_ef) > 0:
-        print("WARNING: NOx emission factors are missing for the following records")
-        print("Missing factors for FC prime movers are currently expected")
-        print(
+        logger.warning("NOx emission factors are missing for the following records")
+        logger.warning("Missing factors for FC prime movers are currently expected")
+        logger.warning(
             missing_ef[
                 [
                     "report_date",
@@ -654,13 +656,13 @@ def calculate_generator_nox_ef_per_unit_from_boiler_type(
         )
     )
     if len(missing_nox_efs) > 0:
-        print(" ")
-        print(
-            "WARNING: NOx emission factors are missing for the following boiler types. A prime mover-fuel level factor will be used if available."
+        logger.warning(" ")
+        logger.warning(
+            "NOx emission factors are missing for the following boiler types. A prime mover-fuel level factor will be used if available."
         )
-        print("Missing factors for FC prime movers are currently expected")
-        print(missing_nox_efs)
-        print(" ")
+        logger.warning("Missing factors for FC prime movers are currently expected")
+        logger.warning(missing_nox_efs)
+        logger.warning(" ")
     gen_nox_factors = fill_missing_factors_based_on_pm_fuel(
         nox_emission_factors, gen_nox_factors
     )
@@ -687,13 +689,13 @@ def calculate_generator_nox_ef_per_unit_from_boiler_type(
         )
     )
     if len(missing_nox_efs) > 0:
-        print(" ")
-        print(
-            "WARNING: After filling with PM-fuel factors, NOx emission factors are still missing for the following boiler types. An emission factor of zero will be used for these boilers."
+        logger.warning(" ")
+        logger.warning(
+            "After filling with PM-fuel factors, NOx emission factors are still missing for the following boiler types. An emission factor of zero will be used for these boilers."
         )
-        print("Missing factors for FC prime movers are currently expected")
-        print(missing_nox_efs)
-        print(" ")
+        logger.warning("Missing factors for FC prime movers are currently expected")
+        logger.warning(missing_nox_efs)
+        logger.warning(" ")
     gen_nox_factors["emission_factor"] = gen_nox_factors["emission_factor"].fillna(0)
 
     # average the emission factors for all boilers associated with each generator
@@ -848,8 +850,8 @@ def convert_ef_to_lb_per_mmbtu(gen_emission_factors, pudl_out, pollutant):
         & (gen_emission_factors["emission_factor_denominator"] != "mmbtu")
     ]
     if len(missing_fuel_content) > 0:
-        print(
-            f"WARNING: The heat content for the following fuels is missing and NOx emissions will not be calculated for these fuel:{list(missing_fuel_content.energy_source_code.unique())}"
+        logger.warning(
+            f"The heat content for the following fuels is missing and NOx emissions will not be calculated for these fuel:{list(missing_fuel_content.energy_source_code.unique())}"
         )
 
     # convert emission factors from lb per unit to lb per mmbtu if the factor is not already in units of lb/mmbtu
@@ -1212,9 +1214,9 @@ def calculate_so2_from_fuel_consumption(gen_fuel_allocated, pudl_out, year):
         & ~gen_fuel_allocated["energy_source_code"].isin(CLEAN_FUELS)
     ]
     if len(missing_ef) > 0:
-        print("WARNING: SO2 emission factors are missing for the above records")
-        print("Missing factors for FC prime movers are currently expected")
-        print(
+        logger.warning("SO2 emission factors are missing for the above records")
+        logger.warning("Missing factors for FC prime movers are currently expected")
+        logger.warning(
             missing_ef[
                 [
                     "report_date",
@@ -1375,13 +1377,13 @@ def calculate_generator_so2_ef_per_unit_from_boiler_type(
         )
     )
     if len(missing_so2_efs) > 0:
-        print(" ")
-        print(
-            "WARNING: SO2 emission factors are missing for the following boiler types. A prime mover-fuel level factor will be used if available."
+        logger.warning(" ")
+        logger.warning(
+            "SO2 emission factors are missing for the following boiler types. A prime mover-fuel level factor will be used if available."
         )
-        print("Missing factors for FC prime movers are currently expected")
-        print(missing_so2_efs)
-        print(" ")
+        logger.warning("Missing factors for FC prime movers are currently expected")
+        logger.warning(missing_so2_efs)
+        logger.warning(" ")
     gen_so2_factors = fill_missing_factors_based_on_pm_fuel(
         so2_emission_factors, gen_so2_factors
     )
@@ -1406,13 +1408,13 @@ def calculate_generator_so2_ef_per_unit_from_boiler_type(
         )
     )
     if len(missing_so2_efs) > 0:
-        print(" ")
-        print(
-            "WARNING: SO2 emission factors are missing for the following boiler types. An emission factor of zero will be used for these boilers."
+        logger.warning(" ")
+        logger.warning(
+            "SO2 emission factors are missing for the following boiler types. An emission factor of zero will be used for these boilers."
         )
-        print("Missing factors for FC prime movers are currently expected")
-        print(missing_so2_efs)
-        print(" ")
+        logger.warning("Missing factors for FC prime movers are currently expected")
+        logger.warning(missing_so2_efs)
+        logger.warning(" ")
     gen_so2_factors["emission_factor"] = gen_so2_factors["emission_factor"].fillna(0)
     gen_so2_factors["multiply_by_sulfur_content"] = gen_so2_factors[
         "multiply_by_sulfur_content"
@@ -1564,8 +1566,8 @@ def adjust_so2_efs_for_fuel_sulfur_content(uncontrolled_so2_factors, pudl_out):
         & (uncontrolled_so2_factors["multiply_by_sulfur_content"] == 1)
     ]
     if len(missing_sulfur_content) > 0:
-        print("WARNING: Sulfur content data is missing in EIA-923 for the above units.")
-        print(
+        logger.warning("Sulfur content data is missing in EIA-923 for the above units.")
+        logger.warning(
             missing_sulfur_content[
                 [
                     "plant_id_eia",
@@ -1637,7 +1639,7 @@ def load_so2_control_efficiencies(year):
     ]
     if len(bad_efficiencies) > 0:
         raise UserWarning(
-            "WARNING: certain loaded SO2 removal efficiencies are either negative or > 100%"
+            "certain loaded SO2 removal efficiencies are either negative or > 100%"
         )
 
     return so2_efficiency

--- a/src/filepaths.py
+++ b/src/filepaths.py
@@ -1,6 +1,5 @@
+"""Convenience functions for paths."""
 import os
-
-# Convenience functions for paths.
 
 
 def top_folder(rel=""):

--- a/src/gross_to_net_generation.py
+++ b/src/gross_to_net_generation.py
@@ -15,6 +15,9 @@ import data_cleaning
 import validation
 from column_checks import get_dtypes
 from filepaths import outputs_folder
+from logging_util import get_logger
+
+logger = get_logger(__name__)
 
 
 def convert_gross_to_net_generation(cems, eia923_allocated, plant_attributes, year):
@@ -89,10 +92,10 @@ def convert_gross_to_net_generation(cems, eia923_allocated, plant_attributes, ye
         & (cems["default_gtn_ratio"].isna())
     ]
     if len(missing_defaults) > 0:
-        print(
-            "WARNING: The following subplants are missing default GTN ratios. Using a default value of 0.97"
+        logger.warning(
+            "The following subplants are missing default GTN ratios. Using a default value of 0.97"
         )
-        print(missing_defaults[["plant_id_eia", "subplant_id"]].drop_duplicates())
+        logger.warning(missing_defaults[["plant_id_eia", "subplant_id"]].drop_duplicates())
     # if there is a missing default gtn ratio, fill with 0.97
     cems["default_gtn_ratio"] = cems["default_gtn_ratio"].fillna(0.97)
     cems["net_generation_mwh"] = cems["net_generation_mwh"].fillna(
@@ -721,12 +724,12 @@ def calculate_multiyear_gtn_factors(year, number_of_years):
     )
 
     # add subplant ids to the data
-    print("Creating subplant IDs")
+    logger.info("Creating subplant IDs")
     cems_monthly, gen_fuel_allocated = data_cleaning.generate_subplant_ids(
         start_year, end_year, cems_monthly, gen_fuel_allocated
     )
 
-    print("Calculating Gross to Net regressions and ratios")
+    logger.info("Calculating Gross to Net regressions and ratios")
     # perform regression at subplant level
     gross_to_net_regression(
         gross_gen_data=cems_monthly,
@@ -772,7 +775,7 @@ def load_monthly_gross_and_net_generation(start_year, end_year):
     )
 
     # allocate net generation and heat input to each generator-fuel grouping
-    print("    Allocating EIA-923 generation data")
+    logger.info("    Allocating EIA-923 generation data")
     gen_fuel_allocated = allocate_gen_fuel.allocate_gen_fuel_by_generator_energy_source(
         pudl_out, drop_interim_cols=True
     )

--- a/src/gross_to_net_generation.py
+++ b/src/gross_to_net_generation.py
@@ -95,7 +95,7 @@ def convert_gross_to_net_generation(cems, eia923_allocated, plant_attributes, ye
         logger.warning(
             "The following subplants are missing default GTN ratios. Using a default value of 0.97"
         )
-        logger.warning(missing_defaults[["plant_id_eia", "subplant_id"]].drop_duplicates())
+        logger.warning("\n" + missing_defaults[["plant_id_eia", "subplant_id"]].drop_duplicates().to_string())
     # if there is a missing default gtn ratio, fill with 0.97
     cems["default_gtn_ratio"] = cems["default_gtn_ratio"].fillna(0.97)
     cems["net_generation_mwh"] = cems["net_generation_mwh"].fillna(

--- a/src/impute_hourly_profiles.py
+++ b/src/impute_hourly_profiles.py
@@ -148,7 +148,7 @@ def calculate_hourly_profiles(
         :,
         profile_methods,
     ]
-    logger.info(summary_table)
+    logger.info("\n" + summary_table.to_string())
 
     return hourly_profiles
 
@@ -297,7 +297,7 @@ def aggregate_for_residual(
         logger.warning(
             "The following cems subplants are missing fuel categories and will lead to incorrect residual calculations:"
         )
-        logger.warning(missing_fuel_category[["plant_id_eia", "subplant_id"]].drop_duplicates())
+        logger.warning("\n" + missing_fuel_category[["plant_id_eia", "subplant_id"]].drop_duplicates().to_string())
         raise UserWarning(
             "The missing fuel categories must be fixed before proceeding."
         )

--- a/src/impute_hourly_profiles.py
+++ b/src/impute_hourly_profiles.py
@@ -7,6 +7,10 @@ import load_data
 from filepaths import manual_folder
 import validation
 import output_data
+from logging_util import get_logger
+
+logger = get_logger(__name__)
+
 
 # specify the ba numbers with leading zeros
 FUEL_NUMBERS = {
@@ -112,7 +116,7 @@ def calculate_hourly_profiles(
         hourly_profiles["profile"] = hourly_profiles["flat_profile"]
         hourly_profiles["profile_method"] = "flat_profile"
 
-    print(
+    logger.info(
         "Summary of methods used to estimate missing hourly profiles (count of ba-months):"
     )
     summary_table = (
@@ -144,7 +148,7 @@ def calculate_hourly_profiles(
         :,
         profile_methods,
     ]
-    print(summary_table)
+    logger.info(summary_table)
 
     return hourly_profiles
 
@@ -290,10 +294,10 @@ def aggregate_for_residual(
         (cems["fuel_category_eia930"].isna()) & (cems["net_generation_mwh"] != 0)
     ]
     if len(missing_fuel_category) > 0:
-        print(
-            "WARNING: The following cems subplants are missing fuel categories and will lead to incorrect residual calculations:"
+        logger.warning(
+            "The following cems subplants are missing fuel categories and will lead to incorrect residual calculations:"
         )
-        print(missing_fuel_category[["plant_id_eia", "subplant_id"]].drop_duplicates())
+        logger.warning(missing_fuel_category[["plant_id_eia", "subplant_id"]].drop_duplicates())
         raise UserWarning(
             "The missing fuel categories must be fixed before proceeding."
         )
@@ -706,7 +710,7 @@ def average_diba_wind_solar_profiles(
     ]
     if len(df_temporary) == 0 and not validation_run:
         # if this error is raised, we might have to implement an approach that uses average values for the wider region
-        print(f"    There is no {fuel} data in the DIBAs for {ba}: {ba_dibas}")
+        logger.warning(f"    There is no {fuel} data in the DIBAs for {ba}: {ba_dibas}")
         df_temporary = average_national_wind_solar_profiles(
             residual_profiles, ba, fuel, report_date
         )
@@ -1318,8 +1322,8 @@ def shape_partial_cems_plants(cems, eia923_allocated):
             | shaped_partial_plants["fuel_profile"].isna()
         ]
         if len(missing_profiles) > 0:
-            print(
-                "WARNING: Certain partial CEMS plants are missing hourly profile data. This will result in inaccurate results"
+            logger.warning(
+                "Certain partial CEMS plants are missing hourly profile data. This will result in inaccurate results"
             )
         # check that all profiles add to 1 for each month
         incorrect_profiles = (
@@ -1334,8 +1338,8 @@ def shape_partial_cems_plants(cems, eia923_allocated):
             | (~np.isclose(incorrect_profiles["fuel_profile"], 1))
         ]
         if len(incorrect_profiles) > 0:
-            print(
-                "WARNING: Certain partial CEMS profiles do not add to 100%. This will result in inaccurate results"
+            logger.warning(
+                "Certain partial CEMS profiles do not add to 100%. This will result in inaccurate results"
             )
 
         # shape the profiles

--- a/src/load_data.py
+++ b/src/load_data.py
@@ -9,6 +9,9 @@ import pudl.output.pudltabl
 
 from column_checks import get_dtypes
 from filepaths import downloads_folder, manual_folder, outputs_folder
+from logging_util import get_logger
+
+logger = get_logger(__name__)
 
 
 def correct_epa_eia_plant_id_mapping(df):
@@ -153,7 +156,7 @@ def load_cems_gross_generation(start_year, end_year):
     cems_all = []
 
     for year in range(start_year, end_year + 1):
-        print(f"    loading {year} CEMS data")
+        logger.info(f"    loading {year} CEMS data")
         # specify the path to the CEMS data
         cems_path = downloads_folder(
             "pudl/pudl_data/parquet/epacems/hourly_emissions_epacems/"
@@ -774,10 +777,10 @@ def load_emissions_controls_eia923(year: int):
             parse_dates=["report_date", "pm_test_date", "so2_test_date"],
         )
     else:
-        print(
-            "WARNING: Emissions control data prior to 2014 has not been integrated into the data pipeline."
+        logger.warning(
+            "Emissions control data prior to 2014 has not been integrated into the data pipeline."
         )
-        print(
+        logger.warning(
             "This may overestimate SO2 and NOx emissions calculated from EIA-923 data."
         )
         emissions_controls_eia923 = pd.DataFrame(
@@ -826,10 +829,10 @@ def load_boiler_control_id_association_eia860(year, pollutant):
         )
     # return a blank dataframe if the data is not available
     else:
-        print(
-            "WARNING: Environmental association data prior to 2013 have not been integrated into the data pipeline."
+        logger.warning(
+            "Environmental association data prior to 2013 have not been integrated into the data pipeline."
         )
-        print("This may result in less accurate pollutant emissions calculations.")
+        logger.warning("This may result in less accurate pollutant emissions calculations.")
         boiler_control_id_association_eia860 = pd.DataFrame(
             columns=boiler_association_eia860_names
         )
@@ -875,10 +878,10 @@ def load_boiler_design_parameters_eia860(year):
         )
     # return a blank dataframe if the data is not available
     else:
-        print(
-            "WARNING: Boiler Design data prior to 2013 have not been integrated into the data pipeline."
+        logger.warning(
+            "Boiler Design data prior to 2013 have not been integrated into the data pipeline."
         )
-        print("This may result in less accurate NOx and SO2 emissions calculations.")
+        logger.warning("This may result in less accurate NOx and SO2 emissions calculations.")
         boiler_design_parameters_eia860 = pd.DataFrame(
             columns=list(boiler_design_parameters_eia860_names.values())
         )

--- a/src/logging_util.py
+++ b/src/logging_util.py
@@ -1,4 +1,4 @@
-"""Configure logging for the OGE package."""
+"""Configure logging for the OGE codebase."""
 import logging
 import coloredlogs
 

--- a/src/logging_util.py
+++ b/src/logging_util.py
@@ -1,0 +1,49 @@
+"""Configure logging for the OGE package."""
+import logging
+import coloredlogs
+
+
+def get_logger(name: str) -> logging.Logger:
+  """Helper function to append `oge` to the logger name and return a logger.
+
+  As a result, all returned loggers a children of the top-level `oge` logger.
+  """
+  return logging.getLogger(f"oge.{name}")
+
+
+def configure_logger(logfile: str | None = None, level: str = "INFO"):
+  """Configure the OGE logger to print to the console, and optionally to a file.
+
+  This function is safe to call multiple times, since it will check if logging
+  handlers have already been installed and skip them if so.
+
+  Logging is printed with the same format as PUDL:
+  ```
+  2023-02-21 16:10:44 [    INFO] oge.test:21 This is an example
+  ```
+  """
+  root_logger = logging.getLogger()
+
+  # Unfortunately, the `gridemissions` package adds a handler to the root logger
+  # which means that the output of other loggers propagates up and is printed
+  # twice. Remove the root handlers to avoid this.
+  for handler in root_logger.handlers:
+    root_logger.removeHandler(handler)
+
+  oge_logger = logging.getLogger("oge")
+  log_format = "%(asctime)s [%(levelname)8s] %(name)s:%(lineno)s %(message)s"
+
+  # Direct the output of the OGE logger to the terminal (and color it). Make
+  # sure this hasn't been done already to avoid adding duplicate handlers.
+  if len(oge_logger.handlers) == 0:
+    coloredlogs.install(fmt=log_format, level=level, logger=oge_logger)
+    oge_logger.addHandler(logging.NullHandler())
+
+  # Send everything to the log file by adding a file handler to the root logger.
+  if logfile is not None:
+    file_logger = logging.FileHandler(logfile, mode='w')
+    file_logger.setFormatter(logging.Formatter(log_format))
+
+    if file_logger not in root_logger.handlers:
+      root_logger.addHandler(file_logger)
+

--- a/src/logging_util.py
+++ b/src/logging_util.py
@@ -11,7 +11,7 @@ def get_logger(name: str) -> logging.Logger:
   return logging.getLogger(f"oge.{name}")
 
 
-def configure_logger(logfile: str | None = None, level: str = "INFO"):
+def configure_root_logger(logfile: str | None = None, level: str = "INFO"):
   """Configure the OGE logger to print to the console, and optionally to a file.
 
   This function is safe to call multiple times, since it will check if logging
@@ -19,7 +19,7 @@ def configure_logger(logfile: str | None = None, level: str = "INFO"):
 
   Logging is printed with the same format as PUDL:
   ```
-  2023-02-21 16:10:44 [    INFO] oge.test:21 This is an example
+  2023-02-21 16:10:44 [INFO] oge.test:21 This is an example
   ```
   """
   root_logger = logging.getLogger()
@@ -31,7 +31,7 @@ def configure_logger(logfile: str | None = None, level: str = "INFO"):
     root_logger.removeHandler(handler)
 
   oge_logger = logging.getLogger("oge")
-  log_format = "%(asctime)s [%(levelname)8s] %(name)s:%(lineno)s %(message)s"
+  log_format = "%(asctime)s [%(levelname)4s] %(name)s:%(lineno)s %(message)s"
 
   # Direct the output of the OGE logger to the terminal (and color it). Make
   # sure this hasn't been done already to avoid adding duplicate handlers.

--- a/src/validation.py
+++ b/src/validation.py
@@ -69,7 +69,7 @@ def check_allocated_gf_matches_input_gf(pudl_out, gen_fuel_allocated):
     ]
     if len(mismatched_allocation) > 0:
         logger.warning("Allocated EIA-923 doesn't match input data for plants:")
-        logger.warning(mismatched_allocation)
+        logger.warning("\n" + mismatched_allocation.to_string())
 
 
 def test_for_negative_values(df, small: bool = False):
@@ -325,7 +325,7 @@ def validate_gross_to_net_conversion(cems, eia923_allocated):
         logger.warning(
             f"There are {len(cems_net_not_equal_to_eia)} plants where calculated annual net generation does not match EIA annual net generation."
         )
-        logger.warning(cems_net_not_equal_to_eia)
+        logger.warning("\n" + cems_net_not_equal_to_eia.to_string())
     else:
         logger.info("OK")
 
@@ -528,11 +528,11 @@ def validate_shaped_totals(shaped_eia_data, monthly_eia_data_to_shape, group_key
 
     if compare.sum().sum() > 0:
         logger.warning(" ")
-        logger.warning(
+        logger.warning("\n" +
             compare[
                 (compare["net_generation_mwh"] != 0)
                 | (compare["fuel_consumed_mmbtu"] != 0)
-            ]
+            ].to_string()
         )
         raise UserWarning(
             "The data shaping process is changing the monthly total values compared to reported EIA values. This process should only shape the data, not alter it."
@@ -555,7 +555,7 @@ def validate_unique_datetimes(df, df_name, keys):
                 df.duplicated(subset=(keys + [datetime_column]), keep=False)
             ]
             if len(duplicate_dt) > 0:
-                logger.warning(duplicate_dt)
+                logger.warning("\n" + duplicate_dt.to_string())
                 raise UserWarning(
                     f"The dataframe {df_name} contains duplicate {datetime_column} values within each group of {keys}. See above output"
                 )
@@ -1310,7 +1310,7 @@ def check_for_anomalous_co2_factors(
             validate="m:1",
         )
         logger.warning("Potentially anomalous co2 factors detected for the following plants:")
-        logger.warning(
+        logger.warning("\n" +
             factor_anomaly[
                 [
                     "plant_id_eia",
@@ -1320,7 +1320,7 @@ def check_for_anomalous_co2_factors(
                     f"{pollutant}_mass_lb_for_electricity",
                     factor,
                 ]
-            ].sort_values(by=factor)
+            ].sort_values(by=factor).to_string()
         )
 
 

--- a/src/validation.py
+++ b/src/validation.py
@@ -74,7 +74,7 @@ def check_allocated_gf_matches_input_gf(pudl_out, gen_fuel_allocated):
 
 def test_for_negative_values(df, small: bool = False):
     """Checks that there are no unexpected negative values in the data."""
-    logger.info("    Checking that fuel and emissions values are positive...  ")
+    logger.info("Checking that fuel and emissions values are positive...  ")
     columns_that_should_be_positive = [
         "fuel_consumed_mmbtu",
         "fuel_consumed_for_electricity_mmbtu",
@@ -156,7 +156,7 @@ def test_for_negative_values(df, small: bool = False):
 
 def test_for_missing_values(df, small: bool = False):
     """Checks that there are no unexpected missing values in the output data."""
-    logger.info("    Checking that no values are missing...  ")
+    logger.info("Checking that no values are missing...  ")
     columns_that_should_be_complete = [
         "plant_id_eia",
         "fuel_category",
@@ -231,7 +231,7 @@ def test_for_missing_values(df, small: bool = False):
 
 def test_chp_allocation(df):
     """Checks that the CHP allocation didn't create any anomalous values."""
-    logger.info("    Checking that total fuel consumed >= fuel consumed for electricity...  ")
+    logger.info("Checking that total fuel consumed >= fuel consumed for electricity...  ")
     chp_allocation_test = df[
         df["fuel_consumed_for_electricity_mmbtu"] > df["fuel_consumed_mmbtu"]
     ]
@@ -248,7 +248,7 @@ def test_chp_allocation(df):
 def test_for_missing_energy_source_code(df):
     """Checks that there are no missing energy source codes associated with non-zero fuel consumption."""
     logger.info(
-        "    Checking that there are no missing energy source codes associated with non-zero fuel consumption...  ")
+        "Checking that there are no missing energy source codes associated with non-zero fuel consumption...  ")
     missing_esc_test = df[
         (df["energy_source_code"].isna()) & (df["fuel_consumed_mmbtu"] > 0)
     ]
@@ -265,7 +265,7 @@ def test_for_missing_energy_source_code(df):
 
 def test_for_missing_subplant_id(df):
     """Checks if any records are missing a `subplant_id`."""
-    logger.info("    Checking that all data has an associated `subplant_id`...  ")
+    logger.info("Checking that all data has an associated `subplant_id`...  ")
     missing_subplant_test = df[df["subplant_id"].isna()]
     if not missing_subplant_test.empty:
         logger.warning(" ")
@@ -279,7 +279,7 @@ def test_for_missing_subplant_id(df):
 
 def validate_gross_to_net_conversion(cems, eia923_allocated):
     """checks whether the calculated net generation matches the reported net generation from EIA-923 at the annual plant level."""
-    logger.info("    Checking that calculated net generation matches reported net generation in EIA-923...  ")
+    logger.info("Checking that calculated net generation matches reported net generation in EIA-923...  ")
     # merge together monthly subplant totals from EIA and calculated from CEMS
     eia_netgen = (
         eia923_allocated.groupby(
@@ -333,7 +333,7 @@ def validate_gross_to_net_conversion(cems, eia923_allocated):
 def test_emissions_adjustments(df):
     """For each emission, tests that mass_lb >= mass_lb_for_electricity >= mass_lb_for_electricity_adjusted."""
 
-    logger.info("    Checking that adjusted emission values are less than total emissions...  ")
+    logger.info("Checking that adjusted emission values are less than total emissions...  ")
 
     pollutants = ["co2", "ch4", "n2o", "co2e", "nox", "so2"]
 
@@ -386,7 +386,7 @@ def ensure_non_overlapping_data_from_all_sources(
 ):
     """Ensures that there is no duplicated subplant-months from each of the four sources of cleaned data."""
 
-    logger.info("    Checking that all data to be combined is unique...  ")
+    logger.info("Checking that all data to be combined is unique...  ")
 
     if "hourly_data_source" in eia_data.columns:
         eia_only_data = eia_data.loc[
@@ -511,7 +511,7 @@ def ensure_non_overlapping_data_from_all_sources(
 def validate_shaped_totals(shaped_eia_data, monthly_eia_data_to_shape, group_keys):
     """Checks that any shaped monthly data still adds up to the monthly total after shaping."""
 
-    logger.info("    Checking that shaped hourly data matches monthly totals...  ")
+    logger.info("Checking that shaped hourly data matches monthly totals...  ")
 
     monthly_group_keys = group_keys + ["report_date"]
 
@@ -1438,7 +1438,7 @@ def test_for_outlier_heat_rates(df):
             ]
             if not heat_rate_test.empty:
                 logger.warning(
-                    f"    {len(heat_rate_test)} of {len(generators_with_pm)} records for {fuel_type} generators with {pm} prime mover have heat rate of zero or > {outlier_threshold.round(2)} mmbtu/MWh"
+                    f"{len(heat_rate_test)} of {len(generators_with_pm)} records for {fuel_type} generators with {pm} prime mover have heat rate of zero or > {outlier_threshold.round(2)} mmbtu/MWh"
                 )
                 logger.warning(
                     f'             median = {heat_rate_stats["50%"].round(2)}, max = {heat_rate_stats["max"].round(2)}, min = {heat_rate_stats["min"].round(2)}'

--- a/src/validation.py
+++ b/src/validation.py
@@ -134,7 +134,6 @@ def test_for_negative_values(df, small: bool = False):
     for column in columns_to_test:
         negative_test = df[df[column] < 0]
         if not negative_test.empty:
-            logger.warning(" ")
             logger.warning(
                 f"There are {len(negative_test)} records where {column} is negative."
             )
@@ -208,7 +207,6 @@ def test_for_missing_values(df, small: bool = False):
     for column in columns_to_test:
         missing_test = df[df[column].isna()]
         if not missing_test.empty:
-            logger.warning(" ")
             logger.warning(
                 f"There are {len(missing_test)} records where {column} is missing."
             )
@@ -251,7 +249,6 @@ def test_for_missing_energy_source_code(df):
         (df["energy_source_code"].isna()) & (df["fuel_consumed_mmbtu"] > 0)
     ]
     if not missing_esc_test.empty:
-        logger.warning(" ")
         logger.warning(
             f"There are {len(missing_esc_test)} records where there is a missing energy source code associated with non-zero fuel consumption. Check `missing_esc_test` for complete list"
         )
@@ -266,7 +263,6 @@ def test_for_missing_subplant_id(df):
     logger.info("Checking that all data has an associated `subplant_id`...  ")
     missing_subplant_test = df[df["subplant_id"].isna()]
     if not missing_subplant_test.empty:
-        logger.warning(" ")
         logger.warning(
             f"There are {len(missing_subplant_test)} records for {len(missing_subplant_test[['plant_id_eia']].drop_duplicates())} plants without a subplant ID. See `missing_subplant_test` for details"
         )
@@ -319,7 +315,6 @@ def validate_gross_to_net_conversion(cems, eia923_allocated):
     cems_net_not_equal_to_eia = validated_ng[validated_ng["pct_error"] != 0]
 
     if len(cems_net_not_equal_to_eia) > 0:
-        logger.warning(" ")
         logger.warning(
             f"There are {len(cems_net_not_equal_to_eia)} plants where calculated annual net generation does not match EIA annual net generation."
         )
@@ -366,7 +361,6 @@ def test_emissions_adjustments(df):
             )
         ]
         if len(bad_adjustment) > 0:
-            logger.warning(" ")
             logger.warning(
                 f"There are {len(bad_adjustment)} records where {pollutant}_mass_lb_for_electricity_adjusted > {pollutant}_mass_lb_for_electricity"
             )
@@ -447,7 +441,6 @@ def ensure_non_overlapping_data_from_all_sources(
             (data_overlap["in_eia"] == 1) & (data_overlap["in_cems"] == 1)
         ]
         if len(eia_cems_overlap) > 0:
-            logger.warning(" ")
             logger.warning(
                 f"There are {len(eia_cems_overlap)} subplant-months that exist in both shaped EIA data and CEMS"
             )
@@ -456,7 +449,6 @@ def ensure_non_overlapping_data_from_all_sources(
             & (data_overlap["in_partial_cems_subplant"] == 1)
         ]
         if len(eia_pcs_overlap) > 0:
-            logger.warning(" ")
             logger.warning(
                 f"There are {len(eia_pcs_overlap)} subplant-months that exist in both shaped EIA data and partial CEMS data"
             )
@@ -465,7 +457,6 @@ def ensure_non_overlapping_data_from_all_sources(
             & (data_overlap["in_partial_cems_subplant"] == 1)
         ]
         if len(cems_pcs_overlap) > 0:
-            logger.warning(" ")
             logger.warning(
                 f"There are {len(cems_pcs_overlap)} subplant-months that exist in both CEMS data and partial CEMS data"
             )
@@ -473,7 +464,6 @@ def ensure_non_overlapping_data_from_all_sources(
             (data_overlap["in_eia"] == 1) & (data_overlap["in_partial_cems_plant"] == 1)
         ]
         if len(eia_pcp_overlap) > 0:
-            logger.warning(" ")
             logger.warning(
                 f"There are {len(eia_pcp_overlap)} subplant-months that exist in both shaped EIA data and partial CEMS data"
             )
@@ -482,7 +472,6 @@ def ensure_non_overlapping_data_from_all_sources(
             & (data_overlap["in_partial_cems_plant"] == 1)
         ]
         if len(cems_pcp_overlap) > 0:
-            logger.warning(" ")
             logger.warning(
                 f"There are {len(cems_pcp_overlap)} subplant-months that exist in both CEMS data and partial CEMS data"
             )
@@ -491,13 +480,11 @@ def ensure_non_overlapping_data_from_all_sources(
             & (data_overlap["in_partial_cems_plant"] == 1)
         ]
         if len(pcs_pcp_overlap) > 0:
-            logger.warning(" ")
             logger.warning(
                 f"There are {len(pcs_pcp_overlap)} subplant-months that exist in both CEMS data and partial CEMS data"
             )
         all_overlap = data_overlap[data_overlap["number_of_locations"] == 4]
         if len(all_overlap) > 0:
-            logger.warning(" ")
             logger.warning(
                 f"There are {len(all_overlap)} subplant-months that exist in shaped EIA data, CEMS data, and partial CEMS data."
             )
@@ -525,7 +512,6 @@ def validate_shaped_totals(shaped_eia_data, monthly_eia_data_to_shape, group_key
     compare = (shaped_data_agg - eia_data_agg).round(0)
 
     if compare.sum().sum() > 0:
-        logger.warning(" ")
         logger.warning("\n" +
             compare[
                 (compare["net_generation_mwh"] != 0)

--- a/src/validation.py
+++ b/src/validation.py
@@ -145,9 +145,7 @@ def test_for_negative_values(df, small: bool = False):
                 " Found negative values during small run, these may be fixed with full data"
             )
         else:
-            logger.warning("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
-            logger.warning("The above negative values are errors and must be fixed")
-            logger.warning("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+            logger.warning("The above negative values are errors and must be fixed!")
             # raise UserWarning("The above negative values are errors and must be fixed")
     else:
         logger.info("OK")

--- a/src/visualization.py
+++ b/src/visualization.py
@@ -1,7 +1,4 @@
-"""
-Helper functions for visualization
-
-"""
+"""Helper functions for visualization."""
 import pandas as pd
 import plotly.express as px
 

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -1,0 +1,28 @@
+import sys
+import logging
+
+sys.path.append('../src')
+sys.path.append('..')
+
+import src.eia930 as eia930
+from src.filepaths import top_folder
+
+from src.logging_util import get_logger, configure_logger
+
+pudl_logger = logging.getLogger(name="catalystcoop.pudl")
+
+configure_logger(logfile=top_folder('test/test_logfile.txt'), level=logging.INFO)
+# If you call this again, nothing bad should happen. Logging statements should
+# still only show up once.
+configure_logger(logfile=top_folder('test/test_logfile.txt'), level=logging.INFO)
+logger = get_logger('test')
+
+
+def main():
+  """These statements should each be printed once in a nice format."""
+  logger.info('This is the OGE logger')
+  pudl_logger.info('This is the PUDL logger')
+
+
+if __name__ == '__main__':
+  main()

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -1,6 +1,8 @@
 import sys
 import logging
 
+import pandas as pd
+
 sys.path.append('../src')
 sys.path.append('..')
 
@@ -22,6 +24,9 @@ def main():
   """These statements should each be printed once in a nice format."""
   logger.info('This is the OGE logger')
   pudl_logger.info('This is the PUDL logger')
+
+  df = pd.DataFrame({"a": [1,2,3], "b": [4,5,6]})
+  logger.info("\n" + df.to_string())
 
 
 if __name__ == '__main__':

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -7,14 +7,14 @@ sys.path.append('..')
 import src.eia930 as eia930
 from src.filepaths import top_folder
 
-from src.logging_util import get_logger, configure_logger
+from src.logging_util import get_logger, configure_root_logger
 
 pudl_logger = logging.getLogger(name="catalystcoop.pudl")
 
-configure_logger(logfile=top_folder('test/test_logfile.txt'), level=logging.INFO)
+configure_root_logger(logfile=top_folder('test/test_logfile.txt'), level=logging.INFO)
 # If you call this again, nothing bad should happen. Logging statements should
 # still only show up once.
-configure_logger(logfile=top_folder('test/test_logfile.txt'), level=logging.INFO)
+configure_root_logger(logfile=top_folder('test/test_logfile.txt'), level=logging.INFO)
 logger = get_logger('test')
 
 


### PR DESCRIPTION
This PR configures logging in `logging_util.py` such that:
- PUDL logging messages are not hidden
- OGE logging messages are formatted similar to PUDL (see below)
- All logging messages from the data pipeline (including PUDL and other imports) are directed to a logfile (`data/outputs/data_pipeline.log`). The logfile could easily be changed to a different filepath.

Here's an example of running the data pipeline with the new logging system:
<img width="743" alt="Screen Shot 2023-02-21 at 5 02 21 PM" src="https://user-images.githubusercontent.com/15068501/220468933-8538bdcc-1ed3-4e8b-a489-fd06633bb023.png">

**Note:**
Unfortunately, if you just do `logger.info(df)`, the header won't line up well with the data. So I replaced all of the dataframe printouts to be `logger.info("\n" + df.to_string())`, which will make everything look nice.