### PR TITLE
Finish logger conversion

### DIFF
--- a/src/consumed.py
+++ b/src/consumed.py
@@ -183,9 +183,9 @@ def consumption_emissions(F, P, ID):
 
     for j in perturbed:
         if X[j] != 0.0:
-            print(b[j])
-            print(np.abs(A[j, :]).sum())
-            print(np.abs(A[:, j]).sum())
+            logger.warning("\n" + b[j].to_string())
+            logger.warning("\n" + np.abs(A[j, :]).sum())
+            logger.warning("\n" + np.abs(A[:, j]).sum())
             raise ValueError("X[%d] is %.2f instead of 0" % (j, X[j]))
 
     return X, len(perturbed)
@@ -486,7 +486,7 @@ class HourlyConsumed:
             for adj in ADJUSTMENTS:
                 total_failed = 0
                 col = get_rate_column(pol, adjustment=adj, generated=False)
-                print(f"{pol}, {adj}", end="...")
+                logger.info(f"Solving consumed {pol} {adj} emissions...")
                 # Calculate emissions
                 for date in self.generation.index:
                     if self.small and (

--- a/src/consumed.py
+++ b/src/consumed.py
@@ -184,8 +184,8 @@ def consumption_emissions(F, P, ID):
     for j in perturbed:
         if X[j] != 0.0:
             logger.warning("\n" + b[j].to_string())
-            logger.warning("\n" + np.abs(A[j, :]).sum())
-            logger.warning("\n" + np.abs(A[:, j]).sum())
+            logger.warning("\n" + np.abs(A[j, :]).sum().to_string())
+            logger.warning("\n" + np.abs(A[:, j]).sum().to_string())
             raise ValueError("X[%d] is %.2f instead of 0" % (j, X[j]))
 
     return X, len(perturbed)

--- a/src/download_data.py
+++ b/src/download_data.py
@@ -41,7 +41,9 @@ def download_helper(
     # If the file already exists, do not re-download it.
     final_destination = output_path if output_path is not None else download_path
     if os.path.exists(final_destination):
-        logger.info(f"    {final_destination.split('/')[-1]} already downloaded, skipping.")
+        logger.info(
+            f"    {final_destination.split('/')[-1]} already downloaded, skipping."
+        )
         return False
 
     # Otherwise, download to the file in chunks.
@@ -109,11 +111,19 @@ def download_pudl_data(zenodo_url: str):
 def download_pudl(zenodo_url, pudl_version):
     r = requests.get(zenodo_url, params={"download": "1"}, stream=True)
     # specify parameters for progress bar
+    total_size_in_bytes = int(r.headers.get("content-length", 0))
     block_size = 1024 * 1024 * 10  # 10 MB
+    downloaded = 0
     logger.info("    Downloading PUDL data...")
     with open(downloads_folder("pudl.tgz"), "wb") as fd:
         for chunk in r.iter_content(chunk_size=block_size):
+            print(
+                f"    Progress: {(round(downloaded/total_size_in_bytes*100,2))}%   \r",
+                end="",
+            )
             fd.write(chunk)
+            downloaded += block_size
+        print("    Progress: 100.0%")
 
     # extract the tgz file
     logger.info("    Extracting PUDL data...")

--- a/src/download_data.py
+++ b/src/download_data.py
@@ -109,18 +109,11 @@ def download_pudl_data(zenodo_url: str):
 def download_pudl(zenodo_url, pudl_version):
     r = requests.get(zenodo_url, params={"download": "1"}, stream=True)
     # specify parameters for progress bar
-    total_size_in_bytes = int(r.headers.get("content-length", 0))
     block_size = 1024 * 1024 * 10  # 10 MB
-    downloaded = 0
+    logger.info("    Downloading PUDL data...")
     with open(downloads_folder("pudl.tgz"), "wb") as fd:
         for chunk in r.iter_content(chunk_size=block_size):
-            print(
-                f"    Downloading PUDL. Progress: {(round(downloaded/total_size_in_bytes*100,2))}%   \r",
-                end="",
-            )
             fd.write(chunk)
-            downloaded += block_size
-    logger.info("    Downloading PUDL. Progress: 100.0%")
 
     # extract the tgz file
     logger.info("    Extracting PUDL data...")

--- a/src/validation.py
+++ b/src/validation.py
@@ -273,9 +273,8 @@ def test_for_missing_energy_source_code(df):
 
 def check_non_missing_cems_co2_values_unchanged(cems_original, cems):
     """Checks that no non-missing CO2 values were modified during the process of filling."""
-    print(
+    logger.info(
         "    Checking that original CO2 data in CEMS was not modified by filling missing values...",
-        end="",
     )
     # only keep non-zero and non-missing co2 values, since these should have not been modified
     cems_original = cems_original.loc[
@@ -294,12 +293,11 @@ def check_non_missing_cems_co2_values_unchanged(cems_original, cems):
     )
     num_nonzero_rows = len(test_fill[test_fill["diff"] != 0])
     if num_nonzero_rows > 0:
-        print(" ")
-        print(
-            f"WARNING: There are {num_nonzero_rows} non-missing CO2 CEMS records that were modified by `fill_cems_missing_co2` in error"
+        logger.warning(
+            f"There are {num_nonzero_rows} non-missing CO2 CEMS records that were modified by `fill_cems_missing_co2` in error"
         )
     else:
-        print("OK")
+        logger.info("OK")
 
 
 def check_removed_data_is_empty(cems):
@@ -316,8 +314,8 @@ def check_removed_data_is_empty(cems):
         ],
     ].sum(numeric_only=True)
     if check_that_data_is_zero.sum() > 0:
-        print("WARNING: Some data being removed has non-zero data associated with it:")
-        print(check_that_data_is_zero)
+        logger.warning("Some data being removed has non-zero data associated with it:")
+        logger.warning("\n" + check_that_data_is_zero.to_string())
 
 
 def test_for_missing_subplant_id(df):

--- a/src/validation.py
+++ b/src/validation.py
@@ -227,12 +227,10 @@ def test_for_missing_values(df, small: bool = False):
     if missing_warnings > 0:
         if small:
             logger.warning(
-                " Found missing values during small run, these may be fixed with full data"
+                "Found missing values during small run, these may be fixed with full data"
             )
         else:
-            logger.warning("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
             logger.warning("The above missing values are errors and must be fixed")
-            logger.warning("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
     else:
         logger.info("OK")
     return missing_test


### PR DESCRIPTION
This finishes up the work started in https://github.com/singularity-energy/open-grid-emissions/pull/285, converting a few more print statements that we did not originally catch to logger.info or logger.warning.