### PR TITLE
Expand validation of outputs

### DIFF
--- a/src/gross_to_net_generation.py
+++ b/src/gross_to_net_generation.py
@@ -95,7 +95,12 @@ def convert_gross_to_net_generation(cems, eia923_allocated, plant_attributes, ye
         logger.warning(
             "The following subplants are missing default GTN ratios. Using a default value of 0.97"
         )
-        logger.warning("\n" + missing_defaults[["plant_id_eia", "subplant_id"]].drop_duplicates().to_string())
+        logger.warning(
+            "\n"
+            + missing_defaults[["plant_id_eia", "subplant_id"]]
+            .drop_duplicates()
+            .to_string()
+        )
     # if there is a missing default gtn ratio, fill with 0.97
     cems["default_gtn_ratio"] = cems["default_gtn_ratio"].fillna(0.97)
     cems["net_generation_mwh"] = cems["net_generation_mwh"].fillna(
@@ -425,6 +430,7 @@ def calculate_subplant_nameplate_capacity(year):
         on=["plant_id_eia", "generator_id"],
         validate="1:1",
     )
+    validation.test_for_missing_subplant_id(gen_capacity)
     subplant_capacity = (
         gen_capacity.groupby(["plant_id_eia", "subplant_id"])["capacity_mw"]
         .sum()

--- a/src/load_data.py
+++ b/src/load_data.py
@@ -9,6 +9,7 @@ import pudl.output.pudltabl
 
 from column_checks import get_dtypes
 from filepaths import downloads_folder, manual_folder, outputs_folder
+from validation import validate_unique_datetimes
 from logging_util import get_logger
 
 logger = get_logger(__name__)
@@ -111,6 +112,8 @@ def load_cems_data(year):
             "so2_mass_measurement_code": "category",
         }
     )
+
+    validate_unique_datetimes(cems, "cems", ["plant_id_eia", "emissions_unit_id_epa"])
 
     return cems
 
@@ -832,7 +835,9 @@ def load_boiler_control_id_association_eia860(year, pollutant):
         logger.warning(
             "Environmental association data prior to 2013 have not been integrated into the data pipeline."
         )
-        logger.warning("This may result in less accurate pollutant emissions calculations.")
+        logger.warning(
+            "This may result in less accurate pollutant emissions calculations."
+        )
         boiler_control_id_association_eia860 = pd.DataFrame(
             columns=boiler_association_eia860_names
         )
@@ -881,7 +886,9 @@ def load_boiler_design_parameters_eia860(year):
         logger.warning(
             "Boiler Design data prior to 2013 have not been integrated into the data pipeline."
         )
-        logger.warning("This may result in less accurate NOx and SO2 emissions calculations.")
+        logger.warning(
+            "This may result in less accurate NOx and SO2 emissions calculations."
+        )
         boiler_design_parameters_eia860 = pd.DataFrame(
             columns=list(boiler_design_parameters_eia860_names.values())
         )

--- a/src/output_data.py
+++ b/src/output_data.py
@@ -75,7 +75,9 @@ def zip_results_for_s3(year):
                     # skip the metric hourly plant data since we do not create those outputs
                     pass
                 else:
-                    logger.info(f"zipping {year}_{data_type}_{aggregation}_{unit} for s3")
+                    logger.info(
+                        f"zipping {year}_{data_type}_{aggregation}_{unit} for s3"
+                    )
                     folder = (
                         f"{results_folder()}/{year}/{data_type}/{aggregation}/{unit}"
                     )
@@ -176,6 +178,9 @@ def output_plant_data(df, path_prefix, resolution, skip_outputs, plant_attribute
     if not skip_outputs:
         if resolution == "hourly":
             # output hourly data
+            validation.validate_unique_datetimes(
+                df, "individual_plant_data", ["plant_id_eia"]
+            )
             # Separately save real and aggregate plants
             output_to_results(
                 df[df.plant_id_eia > 900000],

--- a/src/validation.py
+++ b/src/validation.py
@@ -79,78 +79,35 @@ def check_allocated_gf_matches_input_gf(pudl_out, gen_fuel_allocated):
         logger.warning("Percentage Difference:")
         logger.warning("\n" + mismatched_allocation.to_string())
         logger.warning("EIA-923 Input Totals:")
-        logger.warning("\n" + plant_total_gf.loc[mismatched_allocation.index, :].to_string())
+        logger.warning(
+            "\n" + plant_total_gf.loc[mismatched_allocation.index, :].to_string()
+        )
         logger.warning("Allocated Totals:")
-        logger.warning("\n" + plant_total_alloc.loc[mismatched_allocation.index, :].to_string())
-
+        logger.warning(
+            "\n" + plant_total_alloc.loc[mismatched_allocation.index, :].to_string()
+        )
 
 
 def test_for_negative_values(df, small: bool = False):
     """Checks that there are no unexpected negative values in the data."""
     logger.info("Checking that fuel and emissions values are positive...  ")
-    columns_that_should_be_positive = [
-        "fuel_consumed_mmbtu",
-        "fuel_consumed_for_electricity_mmbtu",
-        "co2_mass_lb",
-        "ch4_mass_lb",
-        "n2o_mass_lb",
-        "co2e_mass_lb",
-        "nox_mass_lb",
-        "so2_mass_lb",
-        "co2_mass_lb_for_electricity",
-        "ch4_mass_lb_for_electricity",
-        "n2o_mass_lb_for_electricity",
-        "co2e_mass_lb_for_electricity",
-        "nox_mass_lb_for_electricity",
-        "so2_mass_lb_for_electricity",
-        "co2_mass_lb_adjusted",
-        "ch4_mass_lb_adjusted",
-        "n2o_mass_lb_adjusted",
-        "co2e_mass_lb_adjusted",
-        "nox_mass_lb_adjusted",
-        "so2_mass_lb_adjusted",
-        "co2_mass_lb_for_electricity_adjusted",
-        "ch4_mass_lb_for_electricity_adjusted",
-        "n2o_mass_lb_for_electricity_adjusted",
-        "co2e_mass_lb_for_electricity_adjusted",
-        "nox_mass_lb_for_electricity_adjusted",
-        "so2_mass_lb_for_electricity_adjusted",
-        "generated_co2_rate_lb_per_mwh_for_electricity",
-        "generated_ch4_rate_lb_per_mwh_for_electricity",
-        "generated_n2o_rate_lb_per_mwh_for_electricity",
-        "generated_co2e_rate_lb_per_mwh_for_electricity",
-        "generated_nox_rate_lb_per_mwh_for_electricity",
-        "generated_so2_rate_lb_per_mwh_for_electricity",
-        "generated_co2_rate_lb_per_mwh_for_electricity_adjusted",
-        "generated_ch4_rate_lb_per_mwh_for_electricity_adjusted",
-        "generated_n2o_rate_lb_per_mwh_for_electricity_adjusted",
-        "generated_co2e_rate_lb_per_mwh_for_electricity_adjusted",
-        "generated_nox_rate_lb_per_mwh_for_electricity_adjusted",
-        "generated_so2_rate_lb_per_mwh_for_electricity_adjusted",
-        "consumed_co2_rate_lb_per_mwh_for_electricity",
-        "consumed_ch4_rate_lb_per_mwh_for_electricity",
-        "consumed_n2o_rate_lb_per_mwh_for_electricity",
-        "consumed_co2e_rate_lb_per_mwh_for_electricity",
-        "consumed_nox_rate_lb_per_mwh_for_electricity",
-        "consumed_so2_rate_lb_per_mwh_for_electricity",
-        "consumed_co2_rate_lb_per_mwh_for_electricity_adjusted",
-        "consumed_ch4_rate_lb_per_mwh_for_electricity_adjusted",
-        "consumed_n2o_rate_lb_per_mwh_for_electricity_adjusted",
-        "consumed_co2e_rate_lb_per_mwh_for_electricity_adjusted",
-        "consumed_nox_rate_lb_per_mwh_for_electricity_adjusted",
-        "consumed_so2_rate_lb_per_mwh_for_electricity_adjusted",
-    ]
-    columns_to_test = [
-        col for col in columns_that_should_be_positive if col in df.columns
-    ]
+    columns_that_can_be_negative = ["net_generation_mwh"]
     negative_warnings = 0
-    for column in columns_to_test:
-        negative_test = df[df[column] < 0]
-        if not negative_test.empty:
-            logger.warning(
-                f"There are {len(negative_test)} records where {column} is negative."
-            )
-            negative_warnings += 1
+    for column in df.columns:
+        # if the column is allowed to be negative, skip the test
+        if column in columns_that_can_be_negative:
+            pass
+        else:
+            # if the column is not numeric, skip the test
+            if pd.api.types.is_numeric_dtype(df[column].dtype):
+                negative_test = df[df[column] < 0]
+                if not negative_test.empty:
+                    logger.warning(
+                        f"There are {len(negative_test)} records where {column} is negative."
+                    )
+                    negative_warnings += 1
+            else:
+                pass
     if negative_warnings > 0:
         if small:
             logger.warning(
@@ -158,7 +115,6 @@ def test_for_negative_values(df, small: bool = False):
             )
         else:
             logger.warning("The above negative values are errors and must be fixed!")
-            # raise UserWarning("The above negative values are errors and must be fixed")
     else:
         logger.info("OK")
     return negative_test
@@ -167,57 +123,8 @@ def test_for_negative_values(df, small: bool = False):
 def test_for_missing_values(df, small: bool = False):
     """Checks that there are no unexpected missing values in the output data."""
     logger.info("Checking that no values are missing...  ")
-    columns_that_should_be_complete = [
-        "plant_id_eia",
-        "fuel_category",
-        "datetime_local",
-        "datetime_utc",
-        "month",
-        "net_generation_mwh",
-        "fuel_consumed_mmbtu",
-        "fuel_consumed_for_electricity_mmbtu",
-        "co2_mass_lb",
-        "ch4_mass_lb",
-        "n2o_mass_lb",
-        "co2e_mass_lb",
-        "nox_mass_lb",
-        "so2_mass_lb",
-        "co2_mass_lb_for_electricity",
-        "ch4_mass_lb_for_electricity",
-        "n2o_mass_lb_for_electricity",
-        "co2e_mass_lb_for_electricity",
-        "nox_mass_lb_for_electricity",
-        "so2_mass_lb_for_electricity",
-        "co2_mass_lb_adjusted",
-        "ch4_mass_lb_adjusted",
-        "n2o_mass_lb_adjusted",
-        "co2e_mass_lb_adjusted",
-        "nox_mass_lb_adjusted",
-        "so2_mass_lb_adjusted",
-        "co2_mass_lb_for_electricity_adjusted",
-        "ch4_mass_lb_for_electricity_adjusted",
-        "n2o_mass_lb_for_electricity_adjusted",
-        "co2e_mass_lb_for_electricity_adjusted",
-        "nox_mass_lb_for_electricity_adjusted",
-        "so2_mass_lb_for_electricity_adjusted",
-        "consumed_co2_rate_lb_per_mwh_for_electricity",
-        "consumed_ch4_rate_lb_per_mwh_for_electricity",
-        "consumed_n2o_rate_lb_per_mwh_for_electricity",
-        "consumed_co2e_rate_lb_per_mwh_for_electricity",
-        "consumed_nox_rate_lb_per_mwh_for_electricity",
-        "consumed_so2_rate_lb_per_mwh_for_electricity",
-        "consumed_co2_rate_lb_per_mwh_for_electricity_adjusted",
-        "consumed_ch4_rate_lb_per_mwh_for_electricity_adjusted",
-        "consumed_n2o_rate_lb_per_mwh_for_electricity_adjusted",
-        "consumed_co2e_rate_lb_per_mwh_for_electricity_adjusted",
-        "consumed_nox_rate_lb_per_mwh_for_electricity_adjusted",
-        "consumed_so2_rate_lb_per_mwh_for_electricity_adjusted",
-    ]
-    columns_to_test = [
-        col for col in columns_that_should_be_complete if col in df.columns
-    ]
     missing_warnings = 0
-    for column in columns_to_test:
+    for column in df.columns:
         missing_test = df[df[column].isna()]
         if not missing_test.empty:
             logger.warning(
@@ -230,9 +137,7 @@ def test_for_missing_values(df, small: bool = False):
                 " Found missing values during small run, these may be fixed with full data"
             )
         else:
-            logger.warning("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
             logger.warning("The above missing values are errors and must be fixed")
-            logger.warning("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
     else:
         logger.info("OK")
     return missing_test
@@ -240,7 +145,9 @@ def test_for_missing_values(df, small: bool = False):
 
 def test_chp_allocation(df):
     """Checks that the CHP allocation didn't create any anomalous values."""
-    logger.info("Checking that total fuel consumed >= fuel consumed for electricity...  ")
+    logger.info(
+        "Checking that total fuel consumed >= fuel consumed for electricity...  "
+    )
     chp_allocation_test = df[
         df["fuel_consumed_for_electricity_mmbtu"] > df["fuel_consumed_mmbtu"]
     ]
@@ -257,7 +164,8 @@ def test_chp_allocation(df):
 def test_for_missing_energy_source_code(df):
     """Checks that there are no missing energy source codes associated with non-zero fuel consumption."""
     logger.info(
-        "Checking that there are no missing energy source codes associated with non-zero fuel consumption...  ")
+        "Checking that there are no missing energy source codes associated with non-zero fuel consumption...  "
+    )
     missing_esc_test = df[
         (df["energy_source_code"].isna()) & (df["fuel_consumed_mmbtu"] > 0)
     ]
@@ -335,7 +243,9 @@ def test_for_missing_subplant_id(df):
 
 def validate_gross_to_net_conversion(cems, eia923_allocated):
     """checks whether the calculated net generation matches the reported net generation from EIA-923 at the annual plant level."""
-    logger.info("Checking that calculated net generation matches reported net generation in EIA-923...  ")
+    logger.info(
+        "Checking that calculated net generation matches reported net generation in EIA-923...  "
+    )
     # merge together monthly subplant totals from EIA and calculated from CEMS
     eia_netgen = (
         eia923_allocated.groupby(
@@ -388,7 +298,9 @@ def validate_gross_to_net_conversion(cems, eia923_allocated):
 def test_emissions_adjustments(df):
     """For each emission, tests that mass_lb >= mass_lb_for_electricity >= mass_lb_for_electricity_adjusted."""
 
-    logger.info("Checking that adjusted emission values are less than total emissions...  ")
+    logger.info(
+        "Checking that adjusted emission values are less than total emissions...  "
+    )
 
     pollutants = ["co2", "ch4", "n2o", "co2e", "nox", "so2"]
 
@@ -574,8 +486,9 @@ def validate_shaped_totals(shaped_eia_data, monthly_eia_data_to_shape, group_key
     compare = (shaped_data_agg - eia_data_agg).round(0)
 
     if compare.sum().sum() > 0:
-        logger.warning("\n" +
-            compare[
+        logger.warning(
+            "\n"
+            + compare[
                 (compare["net_generation_mwh"] != 0)
                 | (compare["fuel_consumed_mmbtu"] != 0)
             ].to_string()
@@ -1355,9 +1268,12 @@ def check_for_anomalous_co2_factors(
             on="plant_id_eia",
             validate="m:1",
         )
-        logger.warning("Potentially anomalous co2 factors detected for the following plants:")
-        logger.warning("\n" +
-            factor_anomaly[
+        logger.warning(
+            "Potentially anomalous co2 factors detected for the following plants:"
+        )
+        logger.warning(
+            "\n"
+            + factor_anomaly[
                 [
                     "plant_id_eia",
                     "plant_primary_fuel",
@@ -1366,7 +1282,9 @@ def check_for_anomalous_co2_factors(
                     f"{pollutant}_mass_lb_for_electricity",
                     factor,
                 ]
-            ].sort_values(by=factor).to_string()
+            ]
+            .sort_values(by=factor)
+            .to_string()
         )
 
 


### PR DESCRIPTION
This PR includes a series of improvements to address many of the small/easy validation coverage tasks. Fixes CAR-1878, CAR-1877, CAR-1876, CAR-1875, CAR-1872, CAR-1867, CAR-1866. 

Specifically, this PR does the following:
1. Expand the coverage of `validate_unique_datetimes` to check whenever we are loading hourly data inputs, concat-ing hourly dataframes together, and outputting hourly data. (This does not yet check the datetimes in EIA-930 data)
2. Expand the coverage of `validate_shaped_totals`. Previously we had been running this check separately from `impute_hourly_profiles.shape_monthly_eia_data_as_hourly()`. We now embed this check within that function so that it has to be run after shaping.
3. I checked that `ensure_non_overlapping_data_from_all_sources` was being run every time that we concat-ed CEMS data, partial CEMS data, and shaped hourly EIA data together.
4. Expand the coverage of `test_for_missing_subplant_id` so that it is run every time the `subplant_crosswalk` dataframe is merged into another dataframe to ensure that all merge keys are associated with a subplant_id.
5. Expand the column coverage of `test_for_missing_values`. Previously we had been checking specified named columns for missing values when outputting results. However, in theory there should be no missing values in any columns in final results, so this test now checks every column in the df for missing values. 
6. Expand the column coverage of `test_for_negative_values`. Previously, we had specified a list of columns that should be positive. We now take the opposite approach, assuming that all numerical columns should only contain positive values, unless a column is explicitly allowed to be negative (in this case, the only column that should be allowed negative is `net_generation_mwh`)

This PR also applies black formatting to all modified files, which changed a few lines that hadn't been formatted in previous PRs