### PR TITLE
Small improvements to command line arguments

### DIFF
--- a/src/data_pipeline.py
+++ b/src/data_pipeline.py
@@ -39,33 +39,43 @@ def get_args() -> argparse.Namespace:
     parser.add_argument(
         "--shape_individual_plants",
         help="Assign an hourly profile to each individual plant with EIA-only data, instead of aggregating to the fleet level before shaping.",
-        type=bool,
         default=True,
+        action=argparse.BooleanOptionalAction
     )
     parser.add_argument(
         "--small",
         help="Run on subset of data for quicker testing, outputs to outputs/small and results to results/small.",
-        type=bool,
         default=False,
+        action=argparse.BooleanOptionalAction
     )
     parser.add_argument(
         "--flat",
         help="Use flat hourly profiles?",
+        default=False,
+        action=argparse.BooleanOptionalAction
     )
     parser.add_argument(
         "--skip_outputs",
         help="Skip outputting data to csv files for quicker testing.",
-        type=bool,
         default=False,
+        action=argparse.BooleanOptionalAction
     )
 
     args = parser.parse_args()
+
     return args
+
+
+def print_args(args: argparse.Namespace):
+    """Print out the command line arguments."""
+    s = "\n".join([f"  * {argname} = {argvalue}" for argname, argvalue in vars(args).items()])
+    logger.info(f"\n\nRunning with the following options:\n{s}\n")
 
 
 def main():
     """Runs the OGE data pipeline."""
     args = get_args()
+    print_args(args)
     year = args.year
     logger.info(f'Running data pipeline for year {year}')
 

--- a/src/data_pipeline.py
+++ b/src/data_pipeline.py
@@ -68,14 +68,15 @@ def get_args() -> argparse.Namespace:
 
 def print_args(args: argparse.Namespace):
     """Print out the command line arguments."""
-    s = "\n".join([f"  * {argname} = {argvalue}" for argname, argvalue in vars(args).items()])
-    logger.info(f"\n\nRunning with the following options:\n{s}\n")
+    argstring = "\n".join([f"  * {k} = {v}" for k, v in vars(args).items()])
+    logger.info(f"\n\nRunning with the following options:\n{argstring}\n")
 
 
 def main():
     """Runs the OGE data pipeline."""
     args = get_args()
     print_args(args)
+
     year = args.year
     logger.info(f'Running data pipeline for year {year}')
 

--- a/src/filepaths.py
+++ b/src/filepaths.py
@@ -32,3 +32,13 @@ def results_folder(rel=""):
 
 def outputs_folder(rel=""):
     return os.path.join(data_folder("outputs"), rel)
+
+
+def containing_folder(filepath: str) -> str:
+    """Returns the folder containing `filepath`."""
+    return os.path.dirname(os.path.realpath(filepath))
+
+
+def make_containing_folder(filepath: str):
+    """Make sure the the folder where `filepath` goes exists."""
+    os.makedirs(containing_folder(filepath), exist_ok=True)

--- a/src/logging_util.py
+++ b/src/logging_util.py
@@ -2,6 +2,8 @@
 import logging
 import coloredlogs
 
+from filepaths import make_containing_folder
+
 
 def get_logger(name: str) -> logging.Logger:
   """Helper function to append `oge` to the logger name and return a logger.
@@ -41,6 +43,7 @@ def configure_root_logger(logfile: str | None = None, level: str = "INFO"):
 
   # Send everything to the log file by adding a file handler to the root logger.
   if logfile is not None:
+    make_containing_folder(logfile)
     file_logger = logging.FileHandler(logfile, mode='w')
     file_logger.setFormatter(logging.Formatter(log_format))
 


### PR DESCRIPTION
I was originally debugging the `--small` option for the data pipeline, which crashes at the EIA-930 cleaning step. During that process, I made a couple improvements to how command line arguments are handled in `data_pipeline.py`:
- Boolean flags like `--small`, `--flat`, and `--skip_outputs` don't need a value after them any more. If you omit these arguments, the default is used. If you include `--small`, that value will be true. This is to be more consistent with other command line interfaces.
- I added a step to print out the command line arguments that are being used, so that they're clearly shown to the user and captured in the logs.

EDIT: Added one more change to this PR:
- If the logger is outputting to a file, makes sure that the directory for that file exists (otherwise an error will be thrown)