### PR TITLE
Small logging updates

### DIFF
--- a/src/data_cleaning.py
+++ b/src/data_cleaning.py
@@ -54,11 +54,11 @@ def identify_subplants(year, number_of_years=5):
     end_year = year
 
     # load 5 years of monthly data from CEMS
-    logger.info("    loading CEMS ids")
+    logger.info("loading CEMS ids")
     cems_ids = load_data.load_cems_ids(start_year, end_year)
 
     # add subplant ids to the data
-    logger.info("    identifying unique subplants")
+    logger.info("identifying unique subplants")
     generate_subplant_ids(start_year, end_year, cems_ids)
 
 
@@ -883,7 +883,7 @@ def remove_plants(
             ].plant_id_eia.unique()
         )
         logger.info(
-            f"    Removing {len(plants_in_states_to_remove)} plants located in the following states: {remove_states}"
+            f"Removing {len(plants_in_states_to_remove)} plants located in the following states: {remove_states}"
         )
         df = df[~df["plant_id_eia"].isin(plants_in_states_to_remove)]
     if steam_only_plants:
@@ -918,7 +918,7 @@ def remove_non_grid_connected_plants(df):
             "plant_id_eia"
         ].unique()
     )
-    logger.info(f"    Removing {num_plants} plants that are not grid-connected")
+    logger.info(f"Removing {num_plants} plants that are not grid-connected")
 
     df = df[~df["plant_id_eia"].isin(ngc_plants)]
 
@@ -1005,7 +1005,7 @@ def clean_cems(year: int, small: bool, primary_fuel_table, subplant_emission_fac
 
 
 def smallerize_test_data(df, random_seed=None):
-    logger.info("    Randomly selecting 5% of plants for faster test run.")
+    logger.info("Randomly selecting 5% of plants for faster test run.")
     # Select 5% of plants
     selected_plants = df.plant_id_eia.unique()
     if random_seed is not None:
@@ -1031,7 +1031,7 @@ def manually_remove_steam_units(df):
     )[["plant_id_eia", "emissions_unit_id_epa"]]
 
     logger.info(
-        f"    Removing {len(units_to_remove)} units that only produce steam and do not report to EIA"
+        f"Removing {len(units_to_remove)} units that only produce steam and do not report to EIA"
     )
 
     df = df.merge(
@@ -1063,7 +1063,7 @@ def remove_incomplete_unit_months(cems):
     ].drop(columns="datetime_utc")
 
     logger.info(
-        f"    Removing {len(unit_months_to_remove)} unit-months with incomplete hourly data"
+        f"Removing {len(unit_months_to_remove)} unit-months with incomplete hourly data"
     )
 
     cems = cems.merge(
@@ -1296,7 +1296,7 @@ def remove_cems_with_zero_monthly_data(cems):
     )
     # remove any observations with the missing data flag
     logger.info(
-        f"    Removing {len(cems[cems['missing_data_flag'] == 'remove'])} observations from cems for unit-months where no data reported"
+        f"Removing {len(cems[cems['missing_data_flag'] == 'remove'])} observations from cems for unit-months where no data reported"
     )
     validation.check_removed_data_is_empty(cems)
     cems = cems[cems["missing_data_flag"] != "remove"]
@@ -1670,7 +1670,7 @@ def identify_partial_cems_plants(all_data):
         # likely resulting from mixed fuel types.
         # If subplant_id assignment is working, there shouldn't be any
         raise Exception(
-            f"    ERROR: {len(mixed_method_subplants)} subplant-months have multiple hourly methods assigned."
+            f"ERROR: {len(mixed_method_subplants)} subplant-months have multiple hourly methods assigned."
         )
 
     # remove the intermediate indicator column
@@ -1960,7 +1960,7 @@ def assign_ba_code_to_plant(df, year):
     df = df.merge(plant_ba, how="left", on="plant_id_eia", validate="m:1")
 
     if len(df[df["ba_code"].isna()]) > 0:
-        logger.warning("    the following plants are missing ba_code:")
+        logger.warning("the following plants are missing ba_code:")
         logger.warning("\n" + df[df["ba_code"].isna()].tostring())
 
     # replace missing ba codes with NA

--- a/src/data_pipeline.py
+++ b/src/data_pipeline.py
@@ -24,11 +24,6 @@ from filepaths import downloads_folder, outputs_folder, results_folder
 from logging_util import get_logger, configure_root_logger
 
 
-# Log the print statements to a file for debugging.
-configure_root_logger(logfile=outputs_folder("data_pipeline.log"))
-logger = get_logger("data_pipeline")
-
-
 def get_args() -> argparse.Namespace:
     """Specify arguments here.
 
@@ -66,7 +61,7 @@ def get_args() -> argparse.Namespace:
     return args
 
 
-def print_args(args: argparse.Namespace):
+def print_args(args: argparse.Namespace, logger):
     """Print out the command line arguments."""
     argstring = "\n".join([f"  * {k} = {v}" for k, v in vars(args).items()])
     logger.info(f"\n\nRunning with the following options:\n{argstring}\n")
@@ -75,9 +70,14 @@ def print_args(args: argparse.Namespace):
 def main():
     """Runs the OGE data pipeline."""
     args = get_args()
-    print_args(args)
-
     year = args.year
+
+    # Log the print statements to a file for debugging.
+    configure_root_logger(logfile=outputs_folder(f"{year}/data_pipeline.log"))
+    logger = get_logger("data_pipeline")
+
+    print_args(args, logger)
+
     logger.info(f"Running data pipeline for year {year}")
 
     validation.validate_year(year)
@@ -549,11 +549,6 @@ def main():
     )
     hourly_consumed_calc.run()
     hourly_consumed_calc.output_results()
-
-    # move the log file into the specific year output folder
-    shutil.move(
-        outputs_folder("data_pipeline.log"), outputs_folder(f"{year}/data_pipeline.log")
-    )
 
 
 if __name__ == "__main__":

--- a/src/data_pipeline.py
+++ b/src/data_pipeline.py
@@ -40,25 +40,25 @@ def get_args() -> argparse.Namespace:
         "--shape_individual_plants",
         help="Assign an hourly profile to each individual plant with EIA-only data, instead of aggregating to the fleet level before shaping.",
         default=True,
-        action=argparse.BooleanOptionalAction
+        action=argparse.BooleanOptionalAction,
     )
     parser.add_argument(
         "--small",
         help="Run on subset of data for quicker testing, outputs to outputs/small and results to results/small.",
         default=False,
-        action=argparse.BooleanOptionalAction
+        action=argparse.BooleanOptionalAction,
     )
     parser.add_argument(
         "--flat",
         help="Use flat hourly profiles?",
         default=False,
-        action=argparse.BooleanOptionalAction
+        action=argparse.BooleanOptionalAction,
     )
     parser.add_argument(
         "--skip_outputs",
         help="Skip outputting data to csv files for quicker testing.",
         default=False,
-        action=argparse.BooleanOptionalAction
+        action=argparse.BooleanOptionalAction,
     )
 
     args = parser.parse_args()
@@ -78,7 +78,7 @@ def main():
     print_args(args)
 
     year = args.year
-    logger.info(f'Running data pipeline for year {year}')
+    logger.info(f"Running data pipeline for year {year}")
 
     validation.validate_year(year)
 
@@ -344,12 +344,12 @@ def main():
     logger.info("12. Cleaning EIA-930 data")
     # Scrapes and cleans data in data/downloads, outputs cleaned file at EBA_elec.csv
     if args.flat:
-        logger.info("    Not running 930 cleaning because we'll be using a flat profile.")
+        logger.info("Not running 930 cleaning because we'll be using a flat profile.")
     elif not (os.path.exists(outputs_folder(f"{path_prefix}/eia930/eia930_elec.csv"))):
         eia930.clean_930(year, small=args.small, path_prefix=path_prefix)
     else:
         logger.info(
-            f"    Not re-running 930 cleaning. If you'd like to re-run, please delete data/outputs/{path_prefix}/eia930/"
+            f"Not re-running 930 cleaning. If you'd like to re-run, please delete data/outputs/{path_prefix}/eia930/"
         )
 
     # If running small, we didn't clean the whole year, so need to use the Chalender file to build residual profiles.
@@ -413,10 +413,10 @@ def main():
         )
     else:
         logger.info(
-            "    Not shaping and exporting individual plant data since `shape_individual_plants` is False."
+            "Not shaping and exporting individual plant data since `shape_individual_plants` is False."
         )
         logger.info(
-            "    Plants that only report to EIA will be aggregated to the fleet level before shaping."
+            "Plants that only report to EIA will be aggregated to the fleet level before shaping."
         )
 
     # 15. Shape fleet-level data
@@ -549,6 +549,11 @@ def main():
     )
     hourly_consumed_calc.run()
     hourly_consumed_calc.output_results()
+
+    # move the log file into the specific year output folder
+    shutil.move(
+        outputs_folder("data_pipeline.log"), outputs_folder(f"{year}/data_pipeline.log")
+    )
 
 
 if __name__ == "__main__":

--- a/src/download_data.py
+++ b/src/download_data.py
@@ -42,12 +42,12 @@ def download_helper(
     final_destination = output_path if output_path is not None else download_path
     if os.path.exists(final_destination):
         logger.info(
-            f"    {final_destination.split('/')[-1]} already downloaded, skipping."
+            f"{final_destination.split('/')[-1]} already downloaded, skipping."
         )
         return False
 
     # Otherwise, download to the file in chunks.
-    logger.info(f"    Downloading {final_destination.split('/')[-1]}")
+    logger.info(f"Downloading {final_destination.split('/')[-1]}")
     r = requests.get(input_url, stream=True)
     with open(download_path, "wb") as fd:
         for chunk in r.iter_content(chunk_size=chunk_size):
@@ -99,10 +99,10 @@ def download_pudl_data(zenodo_url: str):
         with open(pudl_version_file, "r") as f:
             existing_version = f.readlines()[0].replace("\n", "")
         if pudl_version == existing_version:
-            logger.info("    PUDL version already downloaded")
+            logger.info("PUDL version already downloaded")
             return
         else:
-            logger.info("    Downloading new version of pudl")
+            logger.info("Downloading new version of pudl")
             shutil.rmtree(downloads_folder("pudl"))
 
     download_pudl(zenodo_url, pudl_version)
@@ -114,19 +114,19 @@ def download_pudl(zenodo_url, pudl_version):
     total_size_in_bytes = int(r.headers.get("content-length", 0))
     block_size = 1024 * 1024 * 10  # 10 MB
     downloaded = 0
-    logger.info("    Downloading PUDL data...")
+    logger.info("Downloading PUDL data...")
     with open(downloads_folder("pudl.tgz"), "wb") as fd:
         for chunk in r.iter_content(chunk_size=block_size):
             print(
-                f"    Progress: {(round(downloaded/total_size_in_bytes*100,2))}%   \r",
+                f"Progress: {(round(downloaded/total_size_in_bytes*100,2))}%   \r",
                 end="",
             )
             fd.write(chunk)
             downloaded += block_size
-        print("    Progress: 100.0%")
+        print("Progress: 100.0%")
 
     # extract the tgz file
-    logger.info("    Extracting PUDL data...")
+    logger.info("Extracting PUDL data...")
     with tarfile.open(downloads_folder("pudl.tgz")) as tar:
         tar.extractall(data_folder())
 

--- a/src/eia930.py
+++ b/src/eia930.py
@@ -145,14 +145,14 @@ def clean_930(year: int, small: bool = False, path_prefix: str = ""):
         df = df.loc[start:end]  # Don't worry about processing everything
 
     # Adjust
-    logger.info("    Adjusting EIA-930 time stamps")
+    logger.info("Adjusting EIA-930 time stamps")
     df = manual_930_adjust(df)
     df.to_csv(
         join(data_folder, "eia930_raw.csv")
     )  # Will be read by gridemissions workflow
 
     # Run cleaning
-    logger.info("    Running physics-based data cleaning")
+    logger.info("Running physics-based data cleaning")
     make_dataset(
         start,
         end,
@@ -289,7 +289,7 @@ def remove_imputed_ones(eia930_data):
     filter = eia930_data["net_generation_mwh_930"].abs() < 1.5
 
     # replace all 1.0 values with zero
-    logger.info(f"  replacing {sum(filter)} imputed 1 values with 0")
+    logger.info(f"Replacing {sum(filter)} imputed 1 values with 0")
     eia930_data.loc[filter, "net_generation_mwh_930"] = 0
 
     return eia930_data

--- a/src/gross_to_net_generation.py
+++ b/src/gross_to_net_generation.py
@@ -775,7 +775,7 @@ def load_monthly_gross_and_net_generation(start_year, end_year):
     )
 
     # allocate net generation and heat input to each generator-fuel grouping
-    logger.info("    Allocating EIA-923 generation data")
+    logger.info("Allocating EIA-923 generation data")
     gen_fuel_allocated = allocate_gen_fuel.allocate_gen_fuel_by_generator_energy_source(
         pudl_out, drop_interim_cols=True
     )

--- a/src/impute_hourly_profiles.py
+++ b/src/impute_hourly_profiles.py
@@ -710,7 +710,7 @@ def average_diba_wind_solar_profiles(
     ]
     if len(df_temporary) == 0 and not validation_run:
         # if this error is raised, we might have to implement an approach that uses average values for the wider region
-        logger.warning(f"    There is no {fuel} data in the DIBAs for {ba}: {ba_dibas}")
+        logger.warning(f"There is no {fuel} data in the DIBAs for {ba}: {ba_dibas}")
         df_temporary = average_national_wind_solar_profiles(
             residual_profiles, ba, fuel, report_date
         )

--- a/src/load_data.py
+++ b/src/load_data.py
@@ -156,7 +156,7 @@ def load_cems_gross_generation(start_year, end_year):
     cems_all = []
 
     for year in range(start_year, end_year + 1):
-        logger.info(f"    loading {year} CEMS data")
+        logger.info(f"loading {year} CEMS data")
         # specify the path to the CEMS data
         cems_path = downloads_folder(
             "pudl/pudl_data/parquet/epacems/hourly_emissions_epacems/"

--- a/src/logging_util.py
+++ b/src/logging_util.py
@@ -6,47 +6,46 @@ from filepaths import make_containing_folder
 
 
 def get_logger(name: str) -> logging.Logger:
-  """Helper function to append `oge` to the logger name and return a logger.
+    """Helper function to append `oge` to the logger name and return a logger.
 
-  As a result, all returned loggers a children of the top-level `oge` logger.
-  """
-  return logging.getLogger(f"oge.{name}")
+    As a result, all returned loggers a children of the top-level `oge` logger.
+    """
+    return logging.getLogger(f"oge.{name}")
 
 
 def configure_root_logger(logfile: str | None = None, level: str = "INFO"):
-  """Configure the OGE logger to print to the console, and optionally to a file.
+    """Configure the OGE logger to print to the console, and optionally to a file.
 
-  This function is safe to call multiple times, since it will check if logging
-  handlers have already been installed and skip them if so.
+    This function is safe to call multiple times, since it will check if logging
+    handlers have already been installed and skip them if so.
 
-  Logging is printed with the same format as PUDL:
-  ```
-  2023-02-21 16:10:44 [INFO] oge.test:21 This is an example
-  ```
-  """
-  root_logger = logging.getLogger()
+    Logging is printed with the same format as PUDL:
+    ```
+    2023-02-21 16:10:44 [INFO] oge.test:21 This is an example
+    ```
+    """
+    root_logger = logging.getLogger()
 
-  # Unfortunately, the `gridemissions` package adds a handler to the root logger
-  # which means that the output of other loggers propagates up and is printed
-  # twice. Remove the root handlers to avoid this.
-  for handler in root_logger.handlers:
-    root_logger.removeHandler(handler)
+    # Unfortunately, the `gridemissions` package adds a handler to the root logger
+    # which means that the output of other loggers propagates up and is printed
+    # twice. Remove the root handlers to avoid this.
+    for handler in root_logger.handlers:
+        root_logger.removeHandler(handler)
 
-  oge_logger = logging.getLogger("oge")
-  log_format = "%(asctime)s [%(levelname)4s] %(name)s:%(lineno)s %(message)s"
+    oge_logger = logging.getLogger("oge")
+    log_format = "%(asctime)s [%(levelname)4s] %(name)s:%(lineno)s %(message)s"
 
-  # Direct the output of the OGE logger to the terminal (and color it). Make
-  # sure this hasn't been done already to avoid adding duplicate handlers.
-  if len(oge_logger.handlers) == 0:
-    coloredlogs.install(fmt=log_format, level=level, logger=oge_logger)
-    oge_logger.addHandler(logging.NullHandler())
+    # Direct the output of the OGE logger to the terminal (and color it). Make
+    # sure this hasn't been done already to avoid adding duplicate handlers.
+    if len(oge_logger.handlers) == 0:
+        coloredlogs.install(fmt=log_format, level=level, logger=oge_logger)
+        oge_logger.addHandler(logging.NullHandler())
 
-  # Send everything to the log file by adding a file handler to the root logger.
-  if logfile is not None:
-    make_containing_folder(logfile)
-    file_logger = logging.FileHandler(logfile, mode='w')
-    file_logger.setFormatter(logging.Formatter(log_format))
+    # Send everything to the log file by adding a file handler to the root logger.
+    if logfile is not None:
+        make_containing_folder(logfile)
+        file_logger = logging.FileHandler(logfile, mode="w")
+        file_logger.setFormatter(logging.Formatter(log_format))
 
-    if file_logger not in root_logger.handlers:
-      root_logger.addHandler(file_logger)
-
+        if file_logger not in root_logger.handlers:
+            root_logger.addHandler(file_logger)

--- a/src/output_data.py
+++ b/src/output_data.py
@@ -117,7 +117,7 @@ def zip_data_for_zenodo(year):
 def output_intermediate_data(df, file_name, path_prefix, year, skip_outputs):
     column_checks.check_columns(df, file_name)
     if not skip_outputs:
-        logger.info(f"    Exporting {file_name} to data/outputs")
+        logger.info(f"Exporting {file_name} to data/outputs")
         df.to_csv(outputs_folder(f"{path_prefix}{file_name}_{year}.csv"), index=False)
 
 
@@ -126,7 +126,7 @@ def output_to_results(
 ):
     # Always check columns that should not be negative.
     small = "small" in path_prefix
-    logger.info(f"    Exporting {file_name} to data/results/{path_prefix}{subfolder}")
+    logger.info(f"Exporting {file_name} to data/results/{path_prefix}{subfolder}")
 
     if include_metric:
         metric = convert_results(df)
@@ -154,7 +154,7 @@ def output_to_results(
 def output_data_quality_metrics(df, file_name, path_prefix, skip_outputs):
     if not skip_outputs:
         logger.info(
-            f"    Exporting {file_name} to data/results/{path_prefix}data_quality_metrics"
+            f"Exporting {file_name} to data/results/{path_prefix}data_quality_metrics"
         )
 
         # TODO: Add column checks

--- a/src/validation.py
+++ b/src/validation.py
@@ -272,7 +272,7 @@ def test_for_missing_energy_source_code(df):
 def check_non_missing_cems_co2_values_unchanged(cems_original, cems):
     """Checks that no non-missing CO2 values were modified during the process of filling."""
     logger.info(
-        "    Checking that original CO2 data in CEMS was not modified by filling missing values...",
+        "Checking that original CO2 data in CEMS was not modified by filling missing values...",
     )
     # only keep non-zero and non-missing co2 values, since these should have not been modified
     cems_original = cems_original.loc[


### PR DESCRIPTION
Currently, the pipeline outputs the log file to `outputs_folder("data_pipeline.log")`, but it would be better if the log were saved to the directory for the specific year for which the pipeline was run, e.g. `outputs_folder("{year}/data_pipeline.log")`. However, the root logger is configured outside of `main()` where the year was defined. To get around this, I just made the final step of the data pipeline `shutil.move(outputs_folder("data_pipeline.log"), outputs_folder(f"{year}/data_pipeline.log"))`. However, I'm not sure if this is a good way to do this. @miloknowles would there be a better / easy way to write directly to the specific year folder?

This PR also makes a few small formatting changes:
- formats `logging_util.py` using black
- Removes the indent from all logging messages