### PR TITLE
Fill missing generated rates

### DIFF
--- a/src/output_data.py
+++ b/src/output_data.py
@@ -275,12 +275,9 @@ def write_generated_averages(ba_fuel_data, year, path_prefix, skip_outputs):
                         avg_fuel_type_production[f"{emission}_mass_lb{emission_type}"]
                         / avg_fuel_type_production["net_generation_mwh"]
                     )
-                    .fillna(0)
                     .replace(np.inf, np.NaN)
                     .replace(-np.inf, np.NaN)
-                    .replace(
-                        np.NaN, 0
-                    )  # TODO: temporary placeholder while solar is broken. Eventually there should be no NaNs.
+                    .fillna(0)  # TODO: temporary placeholder while solar is broken. Eventually there should be no NaNs.
                 )
         output_intermediate_data(
             avg_fuel_type_production,
@@ -515,9 +512,9 @@ def write_power_sector_results(ba_fuel_data, path_prefix, skip_outputs):
                                 df[f"{emission}_mass_lb{emission_type}"]
                                 / df["net_generation_mwh"]
                             )
-                            .fillna(0)
                             .replace(np.inf, np.NaN)
                             .replace(-np.inf, np.NaN)
+                            .fillna(0)
                         )
                         # Set negative rates to zero, following eGRID methodology
                         df.loc[df[col_name] < 0, col_name] = 0

--- a/src/output_data.py
+++ b/src/output_data.py
@@ -277,7 +277,7 @@ def write_generated_averages(ba_fuel_data, year, path_prefix, skip_outputs):
                     )
                     .replace(np.inf, np.NaN)
                     .replace(-np.inf, np.NaN)
-                    .fillna(0)  # TODO: temporary placeholder while solar is broken. Eventually there should be no NaNs.
+                    .fillna(0)
                 )
         output_intermediate_data(
             avg_fuel_type_production,
@@ -514,8 +514,15 @@ def write_power_sector_results(ba_fuel_data, path_prefix, skip_outputs):
                             )
                             .replace(np.inf, np.NaN)
                             .replace(-np.inf, np.NaN)
-                            .fillna(0)
                         )
+                        # where the rate is missing because of a divide by zero (i.e.
+                        # net_generation_mwh is zero), replace the emission rate with
+                        # zero. We want to keep all other NAs so that they get flagged
+                        # by our validation checks since this indicates an unexpected
+                        # issue
+                        df.loc[df["net_generation_mwh"] == 0, col_name] = df.loc[
+                            df["net_generation_mwh"] == 0, col_name
+                        ].fillna(0)
                         # Set negative rates to zero, following eGRID methodology
                         df.loc[df[col_name] < 0, col_name] = 0
                 return df


### PR DESCRIPTION
When outputting power sector data with consumed rates using the new warnings, the warnings caught that there were some missing generated rates in the outputs. After looking into this, it looks like this was happening because we were implementing `.fillna(0)` before we replaced `inf` values with `na`. 

This PR moves the fillna after the `inf` replacement, and also explicitly only fills na values that were a result of `net_generation_mwh` (the denominator in the generated rate calculation) being zero. This means that the expected behavior should be:
- If there is zero net generation but positive emissions mass, the reported emission rate should be zero instead of NA.
- If there is some other reason why the generated rate is missing, these missing values should be left so that they are flagged by our validation checks, since this is unexpected behavior.