### PR TITLE
Change logfile location to data quality metrics results

### DIFF
--- a/src/data_pipeline.py
+++ b/src/data_pipeline.py
@@ -72,6 +72,17 @@ def main():
     args = get_args()
     year = args.year
 
+    # configure the logger
+    # Log the print statements to a file for debugging.
+    configure_root_logger(
+        logfile=results_folder(f"{year}/data_quality_metrics/data_pipeline.log")
+    )
+    logger = get_logger("data_pipeline")
+    print_args(args, logger)
+
+    logger.info(f"Running data pipeline for year {year}")
+    validation.validate_year(year)
+
     # 0. Set up directory structure
     path_prefix = "" if not args.small else "small/"
     path_prefix += "flat/" if args.flat else ""
@@ -100,17 +111,6 @@ def main():
                     ),
                     exist_ok=True,
                 )
-
-    # configure the logger
-    # Log the print statements to a file for debugging.
-    configure_root_logger(
-        logfile=results_folder(f"{year}/data_quality_metrics/data_pipeline.log")
-    )
-    logger = get_logger("data_pipeline")
-    print_args(args, logger)
-
-    validation.validate_year(year)
-    logger.info(f"Running data pipeline for year {year}")
 
     # 1. Download data
     ####################################################################################

--- a/src/data_pipeline.py
+++ b/src/data_pipeline.py
@@ -71,7 +71,6 @@ def main():
     """Runs the OGE data pipeline."""
     args = get_args()
     year = args.year
-    validation.validate_year(year)
 
     # 0. Set up directory structure
     path_prefix = "" if not args.small else "small/"
@@ -108,9 +107,9 @@ def main():
         logfile=results_folder(f"{year}/data_quality_metrics/data_pipeline.log")
     )
     logger = get_logger("data_pipeline")
-
     print_args(args, logger)
 
+    validation.validate_year(year)
     logger.info(f"Running data pipeline for year {year}")
 
     # 1. Download data

--- a/src/data_pipeline.py
+++ b/src/data_pipeline.py
@@ -71,15 +71,6 @@ def main():
     """Runs the OGE data pipeline."""
     args = get_args()
     year = args.year
-
-    # Log the print statements to a file for debugging.
-    configure_root_logger(logfile=outputs_folder(f"{year}/data_pipeline.log"))
-    logger = get_logger("data_pipeline")
-
-    print_args(args, logger)
-
-    logger.info(f"Running data pipeline for year {year}")
-
     validation.validate_year(year)
 
     # 0. Set up directory structure
@@ -110,6 +101,17 @@ def main():
                     ),
                     exist_ok=True,
                 )
+
+    # configure the logger
+    # Log the print statements to a file for debugging.
+    configure_root_logger(
+        logfile=results_folder(f"{year}/data_quality_metrics/data_pipeline.log")
+    )
+    logger = get_logger("data_pipeline")
+
+    print_args(args, logger)
+
+    logger.info(f"Running data pipeline for year {year}")
 
     # 1. Download data
     ####################################################################################


### PR DESCRIPTION
For transparency, I wanted to propose that we change the location of the data pipeline log file from our outputs folder (which gets archived on Zenodo) to the `data_quality_metrics` directory, which users can download directly from the data download page.  This will help give data users transparency into the options, steps, and warnings associated with the data pipeline, if they choose to take a look at this. 

I also realized that we were specifying the location of the logfile before we created all of the sub directories, so I moved the logfile configuration to after the initial code that creates the directory structure. 