### PR TITLE
Expand historical coverage pre-2019

### DIFF
--- a/src/oge/constants.py
+++ b/src/oge/constants.py
@@ -9,7 +9,9 @@ earliest_data_year = 2005
 earliest_validated_year = 2019
 # latest_validated_year is the most recent year for which OGE data has been published
 latest_validated_year = 2022
-
+# earliest_hourly_data_year is the most recent year for which OGE can produce hourly
+# profiles
+earliest_hourly_data_year = 2019
 # specify the energy_source_codes that are considered clean/carbon-free
 CLEAN_FUELS = ["SUN", "MWH", "WND", "WAT", "WH", "PUR", "NUC"]
 

--- a/src/oge/data_cleaning.py
+++ b/src/oge/data_cleaning.py
@@ -1657,13 +1657,25 @@ def aggregate_plant_data_to_ba_fuel(combined_plant_data, plant_attributes_table)
         raise UserWarning(
             "The plant attributes table is missing ba code or fuel_category data for some plants. This will result in incomplete power sector results."
         )
-    ba_fuel_data = (
-        ba_fuel_data.groupby(
-            ["ba_code", "fuel_category", "datetime_utc", "report_date"], dropna=False
-        )[DATA_COLUMNS]
-        .sum()
-        .reset_index()
-    )
+    # try to group assuming the data is hourly resolution
+    try:
+        ba_fuel_data = (
+            ba_fuel_data.groupby(
+                ["ba_code", "fuel_category", "datetime_utc", "report_date"],
+                dropna=False,
+            )[DATA_COLUMNS]
+            .sum()
+            .reset_index()
+        )
+    # if datetime_utc is missing, groupby month
+    except KeyError:
+        ba_fuel_data = (
+            ba_fuel_data.groupby(
+                ["ba_code", "fuel_category", "report_date"], dropna=False
+            )[DATA_COLUMNS]
+            .sum()
+            .reset_index()
+        )
     return ba_fuel_data
 
 

--- a/src/oge/data_cleaning.py
+++ b/src/oge/data_cleaning.py
@@ -56,9 +56,11 @@ def clean_eia923(
     """This is the coordinating function for cleaning and allocating generation and fuel
     data in EIA-923."""
     # Allocate fuel and generation across each generator-pm-energy source
-    gf = load_data.load_pudl_table("denorm_generation_fuel_combined_eia923", year)
-    bf = load_data.load_pudl_table("denorm_boiler_fuel_eia923", year)
-    gen = load_data.load_pudl_table("denorm_generation_eia923", year)
+    gf = load_data.load_pudl_table(
+        "denorm_generation_fuel_combined_monthly_eia923", year
+    )
+    bf = load_data.load_pudl_table("denorm_boiler_fuel_monthly_eia923", year)
+    gen = load_data.load_pudl_table("denorm_generation_monthly_eia923", year)
     gens = load_data.load_pudl_table("denorm_generators_eia", year)
     bga = load_data.load_pudl_table("boiler_generator_assn_eia860", year)
 

--- a/src/oge/data_pipeline.py
+++ b/src/oge/data_pipeline.py
@@ -25,7 +25,11 @@ import oge.output_data as output_data
 import oge.consumed as consumed
 from oge.filepaths import downloads_folder, outputs_folder, results_folder
 from oge.logging_util import get_logger, configure_root_logger
-from oge.constants import TIME_RESOLUTIONS, latest_validated_year
+from oge.constants import (
+    TIME_RESOLUTIONS,
+    latest_validated_year,
+    earliest_hourly_data_year,
+)
 
 
 def get_args() -> argparse.Namespace:
@@ -417,7 +421,7 @@ def main(args):
         plant_attributes,
     )
 
-    if year >= 2019:
+    if year >= earliest_hourly_data_year:
         del monthly_plant_data
         # 12. Clean and Reconcile EIA-930 data
         ################################################################################
@@ -634,7 +638,7 @@ def main(args):
         ################################################################################
         logger.info("17. Creating and exporting BA-level power sector results")
         ba_fuel_data = data_cleaning.aggregate_plant_data_to_ba_fuel(
-            combined_plant_data, plant_attributes
+            year, combined_plant_data, plant_attributes
         )
         del combined_plant_data
         # Output intermediate data: produced per-fuel annual averages
@@ -658,12 +662,12 @@ def main(args):
         )
         hourly_consumed_calc.run()
         hourly_consumed_calc.output_results()
-    elif year < 2019:
+    elif year < earliest_hourly_data_year:
         # 12. Aggregate CEMS data to BA-fuel and write power sector results
         ################################################################################
         logger.info("12. Creating and exporting BA-level power sector results")
         ba_fuel_data = data_cleaning.aggregate_plant_data_to_ba_fuel(
-            monthly_plant_data, plant_attributes
+            year, monthly_plant_data, plant_attributes
         )
         # Output intermediate data: produced per-fuel annual averages
         output_data.write_generated_averages(

--- a/src/oge/data_pipeline.py
+++ b/src/oge/data_pipeline.py
@@ -129,7 +129,8 @@ def main(args):
     # eGRID
     download_data.download_egrid_files()
     # EIA-930
-    # for `small` run, we'll only clean 1 week, so need chalander file for making profiles
+    # for `small` run, we'll only clean 1 week, so need chalander file for making
+    # profiles
     if args.small or args.flat:
         download_data.download_chalendar_files()
     # We use balance files for imputing missing hourly profiles.
@@ -140,7 +141,8 @@ def main(args):
     download_data.download_epa_psdc(
         psdc_url="https://github.com/USEPA/camd-eia-crosswalk/releases/download/v0.3/epa_eia_crosswalk.csv"
     )
-    # download the raw EIA-923 and EIA-860 files for use in NOx/SO2 calculations until integrated into pudl
+    # download the raw EIA-923 and EIA-860 files for use in NOx/SO2 calculations until
+    # integrated into pudl
     download_data.download_raw_eia860(year)
     # download eia860 from the latest validated year for use in subplant identification
     download_data.download_raw_eia860(latest_validated_year)
@@ -414,249 +416,263 @@ def main(args):
         args.skip_outputs,
         plant_attributes,
     )
-    del monthly_plant_data
 
-    # 12. Clean and Reconcile EIA-930 data
-    ####################################################################################
-    logger.info("12. Cleaning EIA-930 data")
-    # Scrapes and cleans data in data/downloads, outputs cleaned file at EBA_elec.csv
-    if args.flat:
-        logger.info("Not running 930 cleaning because we'll be using a flat profile.")
-    elif not (os.path.exists(outputs_folder(f"{path_prefix}/eia930/eia930_elec.csv"))):
-        eia930.clean_930(year, small=args.small, path_prefix=path_prefix)
-    else:
-        logger.info(
-            f"Not re-running 930 cleaning. If you'd like to re-run, please delete data/outputs/{path_prefix}/eia930/"
+    if year >= 2019:
+        del monthly_plant_data
+        # 12. Clean and Reconcile EIA-930 data
+        ################################################################################
+        logger.info("12. Cleaning EIA-930 data")
+        # Scrapes and cleans data in data/downloads, outputs cleaned file at
+        # EBA_elec.csv
+        if args.flat:
+            logger.info(
+                "Not running 930 cleaning because we'll be using a flat profile."
+            )
+        elif not (
+            os.path.exists(outputs_folder(f"{path_prefix}/eia930/eia930_elec.csv"))
+        ):
+            eia930.clean_930(year, small=args.small, path_prefix=path_prefix)
+        else:
+            logger.info(
+                f"Not re-running 930 cleaning. If you'd like to re-run, please delete data/outputs/{path_prefix}/eia930/"
+            )
+
+        # If running small, we didn't clean the whole year, so need to use the
+        # Chalender file to build residual profiles.
+        clean_930_file = (
+            downloads_folder("eia930/chalendar/EBA_elec.csv")
+            if (args.small or args.flat)
+            else outputs_folder(f"{path_prefix}/eia930/eia930_elec.csv")
         )
+        eia930_data = eia930.load_chalendar_for_pipeline(clean_930_file, year=year)
+        # until we can fix the physics reconciliation, we need to apply some
+        # post-processing steps
+        eia930_data = eia930.remove_imputed_ones(eia930_data)
+        eia930_data = eia930.remove_months_with_zero_data(eia930_data)
 
-    # If running small, we didn't clean the whole year, so need to use the Chalender file to build residual profiles.
-    clean_930_file = (
-        downloads_folder("eia930/chalendar/EBA_elec.csv")
-        if (args.small or args.flat)
-        else outputs_folder(f"{path_prefix}/eia930/eia930_elec.csv")
-    )
-    eia930_data = eia930.load_chalendar_for_pipeline(clean_930_file, year=year)
-    # until we can fix the physics reconciliation, we need to apply some post-processing steps
-    eia930_data = eia930.remove_imputed_ones(eia930_data)
-    eia930_data = eia930.remove_months_with_zero_data(eia930_data)
-
-    # 13. Calculate hourly profiles for monthly EIA data
-    ####################################################################################
-    logger.info("13. Estimating hourly profiles for EIA data")
-    hourly_profiles = impute_hourly_profiles.calculate_hourly_profiles(
-        cems,
-        partial_cems_subplant,
-        partial_cems_plant,
-        eia930_data,
-        plant_attributes,
-        monthly_eia_data_to_shape,
-        year,
-        transmission_only=False,
-        ba_column_name="ba_code",
-        use_flat=args.flat,
-    )
-    del eia930_data
-    # validate how well the wind and solar imputation methods work
-    output_data.output_data_quality_metrics(
-        validation.validate_wind_solar_imputation(hourly_profiles, year),
-        "wind_solar_profile_imputation_performance",
-        path_prefix,
-        args.skip_outputs,
-    )
-    output_data.output_intermediate_data(
-        hourly_profiles, "hourly_profiles", path_prefix, year, args.skip_outputs
-    )
-
-    hourly_profiles = impute_hourly_profiles.convert_profile_to_percent(
-        hourly_profiles,
-        group_keys=["ba_code", "fuel_category", "profile_method"],
-        columns_to_convert=["profile", "flat_profile"],
-    )
-
-    # 14. Export hourly plant-level data
-    ####################################################################################
-    # The data pipeline offers two options for exporting plant-level data. The first
-    # option, executed here in step 14 is to shape hourly data for each individual plant
-    # This option provides a complete hourly timeseries for each plant, but is more
-    # memory-intensive and results in larger output files.
-    # This data is immediately exported and not held in memory for the rest of the pipe-
-    # line. Instead, this data is re-combined again using the aggregated shaped plants
-    # in step 16.
-    # The other option happens in step 16 if step 14 is not run: instead of shaping each
-    # plant, only an aggregate fleet-level synthetic plant is exported, which represents
-    # the characteristics of all plants that do not report hourly data elsewhere in each
-    # month.
-    logger.info("14. Exporting Hourly Plant-level data for each BA")
-    if args.shape_individual_plants and not args.small:
-        impute_hourly_profiles.combine_and_export_hourly_plant_data(
-            year,
+        # 13. Calculate hourly profiles for monthly EIA data
+        ################################################################################
+        logger.info("13. Estimating hourly profiles for EIA data")
+        hourly_profiles = impute_hourly_profiles.calculate_hourly_profiles(
             cems,
             partial_cems_subplant,
             partial_cems_plant,
-            monthly_eia_data_to_shape,
+            eia930_data,
             plant_attributes,
-            hourly_profiles,
+            monthly_eia_data_to_shape,
+            year,
+            transmission_only=False,
+            ba_column_name="ba_code",
+            use_flat=args.flat,
+        )
+        del eia930_data
+        # validate how well the wind and solar imputation methods work
+        output_data.output_data_quality_metrics(
+            validation.validate_wind_solar_imputation(hourly_profiles, year),
+            "wind_solar_profile_imputation_performance",
             path_prefix,
             args.skip_outputs,
-            region_to_group="ba_code",
         )
-    else:
-        logger.info(
-            "Not shaping and exporting individual plant data since `shape_individual_plants` is False."
-        )
-        logger.info(
-            "Plants that only report to EIA will be aggregated to the fleet level before shaping."
+        output_data.output_intermediate_data(
+            hourly_profiles, "hourly_profiles", path_prefix, year, args.skip_outputs
         )
 
-    # 15. Shape fleet-level data
-    ####################################################################################
-    logger.info("15. Assigning hourly profiles to monthly EIA-923 data")
-    hourly_profiles = impute_hourly_profiles.convert_profile_to_percent(
-        hourly_profiles,
-        group_keys=["ba_code", "fuel_category", "profile_method"],
-        columns_to_convert=["profile", "flat_profile"],
-    )
-    # Aggregate EIA data to BA/fuel/month, then assign hourly profile per BA/fuel
-    (
-        monthly_eia_data_to_shape,
-        plant_attributes,
-    ) = impute_hourly_profiles.aggregate_eia_data_to_ba_fuel(
-        monthly_eia_data_to_shape, plant_attributes, path_prefix
-    )
-    shaped_eia_data = impute_hourly_profiles.shape_monthly_eia_data_as_hourly(
-        monthly_eia_data_to_shape, hourly_profiles, year
-    )
-    output_data.output_data_quality_metrics(
-        validation.hourly_profile_source_metric(
+        hourly_profiles = impute_hourly_profiles.convert_profile_to_percent(
+            hourly_profiles,
+            group_keys=["ba_code", "fuel_category", "profile_method"],
+            columns_to_convert=["profile", "flat_profile"],
+        )
+
+        # 14. Export hourly plant-level data
+        ################################################################################
+        # The data pipeline offers two options for exporting plant-level data. The
+        # first option, executed here in step 14 is to shape hourly data for each
+        # individual plant.
+        # This option provides a complete hourly timeseries for each plant, but is more
+        # memory-intensive and results in larger output files.
+        # This data is immediately exported and not held in memory for the rest of the
+        # pipeline. Instead, this data is re-combined again using the aggregated shaped
+        # plants in step 16.
+        # The other option happens in step 16 if step 14 is not run: instead of shaping
+        # each plant, only an aggregate fleet-level synthetic plant is exported, which
+        # represents the characteristics of all plants that do not report hourly data
+        # elsewhere in each month.
+        logger.info("14. Exporting Hourly Plant-level data for each BA")
+        if args.shape_individual_plants and not args.small:
+            impute_hourly_profiles.combine_and_export_hourly_plant_data(
+                year,
+                cems,
+                partial_cems_subplant,
+                partial_cems_plant,
+                monthly_eia_data_to_shape,
+                plant_attributes,
+                hourly_profiles,
+                path_prefix,
+                args.skip_outputs,
+                region_to_group="ba_code",
+            )
+        else:
+            logger.info(
+                "Not shaping and exporting individual plant data since `shape_individual_plants` is False."
+            )
+            logger.info(
+                "Plants that only report to EIA will be aggregated to the fleet level before shaping."
+            )
+
+        # 15. Shape fleet-level data
+        ################################################################################
+        logger.info("15. Assigning hourly profiles to monthly EIA-923 data")
+        hourly_profiles = impute_hourly_profiles.convert_profile_to_percent(
+            hourly_profiles,
+            group_keys=["ba_code", "fuel_category", "profile_method"],
+            columns_to_convert=["profile", "flat_profile"],
+        )
+        # Aggregate EIA data to BA/fuel/month, then assign hourly profile per BA/fuel
+        (
+            monthly_eia_data_to_shape,
+            plant_attributes,
+        ) = impute_hourly_profiles.aggregate_eia_data_to_ba_fuel(
+            monthly_eia_data_to_shape, plant_attributes, path_prefix
+        )
+        shaped_eia_data = impute_hourly_profiles.shape_monthly_eia_data_as_hourly(
+            monthly_eia_data_to_shape, hourly_profiles, year
+        )
+        output_data.output_data_quality_metrics(
+            validation.hourly_profile_source_metric(
+                cems,
+                partial_cems_subplant,
+                partial_cems_plant,
+                shaped_eia_data,
+                plant_attributes,
+            ),
+            "hourly_profile_method",
+            path_prefix,
+            args.skip_outputs,
+        )
+        # Export data
+        validation.validate_unique_datetimes(
+            year,
+            df=shaped_eia_data,
+            df_name="shaped_eia_data",
+            keys=["plant_id_eia"],
+        )
+        output_data.output_intermediate_data(
+            shaped_eia_data, "shaped_eia923_data", path_prefix, year, args.skip_outputs
+        )
+        output_data.output_intermediate_data(
+            plant_attributes,
+            "plant_static_attributes",
+            path_prefix,
+            year,
+            args.skip_outputs,
+        )
+        if not args.skip_outputs:
+            plant_attributes.to_csv(
+                results_folder(f"{path_prefix}plant_data/plant_static_attributes.csv"),
+                index=False,
+            )
+        # validate that the shaping did not alter data at the monthly level
+        validation.validate_shaped_totals(
+            shaped_eia_data,
+            monthly_eia_data_to_shape,
+            year,
+            group_keys=["ba_code", "fuel_category"],
+        )
+
+        # 16. Combine plant-level data from all sources
+        ################################################################################
+        logger.info("16. Combining plant-level hourly data")
+        # write metadata outputs
+        output_data.write_plant_metadata(
+            plant_attributes,
+            eia923_allocated,
             cems,
             partial_cems_subplant,
             partial_cems_plant,
             shaped_eia_data,
-            plant_attributes,
-        ),
-        "hourly_profile_method",
-        path_prefix,
-        args.skip_outputs,
-    )
-    # Export data
-    validation.validate_unique_datetimes(
-        year,
-        df=shaped_eia_data,
-        df_name="shaped_eia_data",
-        keys=["plant_id_eia"],
-    )
-    validation.check_for_complete_hourly_timeseries(
-        df=shaped_eia_data,
-        df_name="shaped_eia_data",
-        keys=["plant_id_eia"],
-        period="month",
-    )
-    output_data.output_intermediate_data(
-        shaped_eia_data, "shaped_eia923_data", path_prefix, year, args.skip_outputs
-    )
-    output_data.output_intermediate_data(
-        plant_attributes,
-        "plant_static_attributes",
-        path_prefix,
-        year,
-        args.skip_outputs,
-    )
-    if not args.skip_outputs:
-        plant_attributes.to_csv(
-            results_folder(f"{path_prefix}plant_data/plant_static_attributes.csv"),
-            index=False,
-        )
-    # validate that the shaping did not alter data at the monthly level
-    validation.validate_shaped_totals(
-        shaped_eia_data,
-        monthly_eia_data_to_shape,
-        year,
-        group_keys=["ba_code", "fuel_category"],
-    )
-
-    # 16. Combine plant-level data from all sources
-    ####################################################################################
-    logger.info("16. Combining plant-level hourly data")
-    # write metadata outputs
-    output_data.write_plant_metadata(
-        plant_attributes,
-        eia923_allocated,
-        cems,
-        partial_cems_subplant,
-        partial_cems_plant,
-        shaped_eia_data,
-        path_prefix,
-        args.skip_outputs,
-        year,
-    )
-    # set validate parameter to False since validating non-overlapping data requires subplant-level data
-    # since the shaped eia data is at the fleet level, this check will not work.
-    # However, we already checked for non-overlapping data in step 11 when combining monthly data
-    combined_plant_data = data_cleaning.combine_plant_data(
-        cems,
-        partial_cems_subplant,
-        partial_cems_plant,
-        shaped_eia_data,
-        "hourly",
-        False,
-    )
-    del (
-        shaped_eia_data,
-        cems,
-        partial_cems_subplant,
-        partial_cems_plant,
-    )  # free memory back to python
-    # export to a csv.
-    validation.validate_unique_datetimes(
-        year,
-        df=combined_plant_data,
-        df_name="combined_plant_data",
-        keys=["plant_id_eia"],
-    )
-    validation.check_for_complete_hourly_timeseries(
-        df=combined_plant_data,
-        df_name="combined_plant_data",
-        keys=["plant_id_eia"],
-        period="year",
-    )
-    if not args.shape_individual_plants:
-        output_data.output_plant_data(
-            combined_plant_data,
-            year,
             path_prefix,
-            "hourly",
             args.skip_outputs,
-            plant_attributes,
+            year,
+        )
+        # set validate parameter to False since validating non-overlapping data
+        # requires subplant-level data since the shaped eia data is at the fleet level,
+        # this check will not work.
+        # However, we already checked for non-overlapping data in step 11 when
+        # combining monthly data
+        combined_plant_data = data_cleaning.combine_plant_data(
+            cems,
+            partial_cems_subplant,
+            partial_cems_plant,
+            shaped_eia_data,
+            "hourly",
+            False,
+        )
+        del (
+            shaped_eia_data,
+            cems,
+            partial_cems_subplant,
+            partial_cems_plant,
+        )  # free memory back to python
+        # export to a csv.
+        validation.validate_unique_datetimes(
+            year,
+            df=combined_plant_data,
+            df_name="combined_plant_data",
+            keys=["plant_id_eia"],
+        )
+        if not args.shape_individual_plants:
+            output_data.output_plant_data(
+                combined_plant_data,
+                year,
+                path_prefix,
+                "hourly",
+                args.skip_outputs,
+                plant_attributes,
+            )
+
+        # 17. Aggregate CEMS data to BA-fuel and write power sector results
+        ################################################################################
+        logger.info("17. Creating and exporting BA-level power sector results")
+        ba_fuel_data = data_cleaning.aggregate_plant_data_to_ba_fuel(
+            combined_plant_data, plant_attributes
+        )
+        del combined_plant_data
+        # Output intermediate data: produced per-fuel annual averages
+        output_data.write_generated_averages(
+            ba_fuel_data, year, path_prefix, args.skip_outputs
+        )
+        # Output final data: per-ba hourly generation and rate
+        output_data.write_power_sector_results(
+            ba_fuel_data, year, path_prefix, args.skip_outputs, include_hourly=True
         )
 
-    # 17. Aggregate CEMS data to BA-fuel and write power sector results
-    ####################################################################################
-    logger.info("17. Creating and exporting BA-level power sector results")
-    ba_fuel_data = data_cleaning.aggregate_plant_data_to_ba_fuel(
-        combined_plant_data, plant_attributes
-    )
-    del combined_plant_data
-    # Output intermediate data: produced per-fuel annual averages
-    output_data.write_generated_averages(
-        ba_fuel_data, year, path_prefix, args.skip_outputs
-    )
-    # Output final data: per-ba hourly generation and rate
-    output_data.write_power_sector_results(
-        ba_fuel_data, year, path_prefix, args.skip_outputs
-    )
-
-    # 18. Calculate consumption-based emissions and write carbon accounting results
-    ####################################################################################
-    logger.info("18. Calculating and exporting consumption-based results")
-    hourly_consumed_calc = consumed.HourlyConsumed(
-        clean_930_file,
-        path_prefix,
-        year,
-        small=args.small,
-        skip_outputs=args.skip_outputs,
-    )
-    hourly_consumed_calc.run()
-    hourly_consumed_calc.output_results()
+        # 18. Calculate consumption-based emissions and write carbon accounting results
+        ################################################################################
+        logger.info("18. Calculating and exporting consumption-based results")
+        hourly_consumed_calc = consumed.HourlyConsumed(
+            clean_930_file,
+            path_prefix,
+            year,
+            small=args.small,
+            skip_outputs=args.skip_outputs,
+        )
+        hourly_consumed_calc.run()
+        hourly_consumed_calc.output_results()
+    elif year < 2019:
+        # 12. Aggregate CEMS data to BA-fuel and write power sector results
+        ################################################################################
+        logger.info("12. Creating and exporting BA-level power sector results")
+        ba_fuel_data = data_cleaning.aggregate_plant_data_to_ba_fuel(
+            monthly_plant_data, plant_attributes
+        )
+        # Output intermediate data: produced per-fuel annual averages
+        output_data.write_generated_averages(
+            ba_fuel_data, year, path_prefix, args.skip_outputs
+        )
+        # Output final data: per-ba hourly generation and rate
+        output_data.write_power_sector_results(
+            ba_fuel_data, year, path_prefix, args.skip_outputs, include_hourly=False
+        )
 
 
 if __name__ == "__main__":

--- a/src/oge/download_data.py
+++ b/src/oge/download_data.py
@@ -262,13 +262,18 @@ def download_eia930_data(years_to_download: list[int]):
     os.makedirs(downloads_folder("eia930"), exist_ok=True)
 
     for year in years_to_download:
-        for description in ["BALANCE", "INTERCHANGE"]:
-            for months in ["Jan_Jun", "Jul_Dec"]:
-                download_url = f"https://www.eia.gov/electricity/gridmonitor/sixMonthFiles/EIA930_{description}_{year}_{months}.csv"
-                download_filepath = downloads_folder(
-                    f"eia930/EIA930_{description}_{year}_{months}.csv"
-                )
-                download_helper(download_url, download_filepath, chunk_size=1024 * 1024)
+        if year >= 2018:
+            for description in ["BALANCE", "INTERCHANGE"]:
+                for months in ["Jan_Jun", "Jul_Dec"]:
+                    download_url = f"https://www.eia.gov/electricity/gridmonitor/sixMonthFiles/EIA930_{description}_{year}_{months}.csv"
+                    download_filepath = downloads_folder(
+                        f"eia930/EIA930_{description}_{year}_{months}.csv"
+                    )
+                    download_helper(
+                        download_url, download_filepath, chunk_size=1024 * 1024
+                    )
+        else:
+            pass
 
 
 def download_epa_psdc(psdc_url: str):

--- a/src/oge/validation.py
+++ b/src/oge/validation.py
@@ -726,6 +726,15 @@ def test_emissions_adjustments(df, year):
 
     pollutants = ["co2", "ch4", "n2o", "co2e", "nox", "so2"]
 
+    columns_to_show = [
+        "report_date",
+        "plant_id_eia",
+        "generator_id",
+        "emissions_unit_id_epa",
+        "prime_mover_code",
+        "energy_source_code",
+    ]
+
     bad_adjustment_count = 0
 
     for pollutant in pollutants:
@@ -739,14 +748,10 @@ def test_emissions_adjustments(df, year):
             )
             logger.warning(
                 bad_adjustment[
-                    [
-                        "report_date",
-                        "plant_id_eia",
-                        "generator_id",
-                        "prime_mover_code",
-                        "energy_source_code",
+                    [col for col in columns_to_show if col in bad_adjustment.columns]
+                    + [
                         f"{pollutant}_mass_lb",
-                        f"{pollutant}_mass_lb_for_electricity",
+                        f"{pollutant}_mass_lb_adjusted",
                     ]
                 ]
                 .merge(
@@ -769,12 +774,8 @@ def test_emissions_adjustments(df, year):
             )
             logger.warning(
                 bad_adjustment[
-                    [
-                        "report_date",
-                        "plant_id_eia",
-                        "generator_id",
-                        "prime_mover_code",
-                        "energy_source_code",
+                    [col for col in columns_to_show if col in bad_adjustment.columns]
+                    + [
                         f"{pollutant}_mass_lb",
                         f"{pollutant}_mass_lb_adjusted",
                     ]
@@ -802,14 +803,10 @@ def test_emissions_adjustments(df, year):
             )
             logger.warning(
                 bad_adjustment[
-                    [
-                        "report_date",
-                        "plant_id_eia",
-                        "generator_id",
-                        "prime_mover_code",
-                        "energy_source_code",
-                        f"{pollutant}_mass_lb_for_electricity",
-                        f"{pollutant}_mass_lb_for_electricity_adjusted",
+                    [col for col in columns_to_show if col in bad_adjustment.columns]
+                    + [
+                        f"{pollutant}_mass_lb",
+                        f"{pollutant}_mass_lb_adjusted",
                     ]
                 ]
                 .merge(


### PR DESCRIPTION
## Summary

This PR updates the data pipeline to allow for the creation of historical data from 2013-2018. Because EIA-930 data is not available for a complete year prior to 2019, the data outputs prior to that year will be limited to the following:
- Only monthly and annual-resolution data will be available (no hourly data) - we could potentially still include hourly data for the plants that report to CEMS.
- Only generated data will be available since interchange data from EIA-930 is not available.

## Where to look

Most of the updates are in `data_pipeline.py` with minor changes in other files to update allowed year ranges, and update certain functions to accept an argument to specify different behavior based on whether hourly data is available or not.

## Update details

Document in more depth the changes being made

## Screenshots

A couple screenshots of the changes/data if relevant.

## Testing / Validation

- [ ] Run the entire pipeline for 2018 without Errors, examine warning messages
- [ ] Run the entire pipeline for 2017 without Errors, examine warning messages
- [ ] Run the entire pipeline for 2016 without Errors, examine warning messages
- [ ] Run the entire pipeline for 2015 without Errors, examine warning messages
- [ ] Run the entire pipeline for 2014 without Errors, examine warning messages

After running the 2018 pipeline, I noticed the following warnings that are not tripped in the more recent data:
- Negative Nox emissions detected in CEMS
- Columns missing in the column_checks
- "Missing" data being dropped from cems with non-zero data
- SO2 emission factors appear to be missing for JF and certain boiler configs
- Some data is getting dropped or changed during the EIA-923 allocation process

## Linear ticket

Closes CAR-2968, CAR-1823, CAR-4206

## Concerns

Anything you'd like to point out that the reviewers should pay special attention to

## Next steps / Not addressed here

The availability of certain input data prior to 2013 may be different so that will be addressed in a future PR.

## Checklist

- [ ] Update the documentation to reflect changes made in this PR