### PR TITLE
Validate Primary Fuel Assignment

### DIFF
--- a/notebooks/work_in_progress/sandbox.ipynb
+++ b/notebooks/work_in_progress/sandbox.ipynb
@@ -30,6 +30,10 @@
     "import validation\n",
     "import gross_to_net_generation\n",
     "import eia930\n",
+    "from logging_util import get_logger, configure_root_logger\n",
+    "configure_root_logger()\n",
+    "logger = get_logger(\"test\")\n",
+    "\n",
     "\n",
     "year = 2021\n",
     "path_prefix = f\"{year}/\""

--- a/src/column_checks.py
+++ b/src/column_checks.py
@@ -18,6 +18,7 @@ After any change, re-run data_pipeline to regenerate all files and re-run these
 checks.
 """
 from logging_util import get_logger
+
 logger = get_logger(__name__)
 
 
@@ -331,6 +332,22 @@ COLUMNS = {
         "fuel_category",
         "ba_code",
         "aggregated_plants",
+    },
+    "primary_fuel_table": {
+        "plant_id_eia",
+        "generator_id",
+        "subplant_id",
+        "energy_source_code",
+        "plant_primary_fuel_from_fuel_consumed_for_electricity_mmbtu",
+        "plant_primary_fuel_from_net_generation_mwh",
+        "plant_primary_fuel_from_capacity_mw",
+        "plant_primary_fuel_from_mode",
+        "plant_primary_fuel",
+        "subplant_primary_fuel_from_fuel_consumed_for_electricity_mmbtu",
+        "subplant_primary_fuel_from_net_generation_mwh",
+        "subplant_primary_fuel_from_capacity_mw",
+        "subplant_primary_fuel_from_mode",
+        "subplant_primary_fuel",
     },
 }
 

--- a/src/data_pipeline.py
+++ b/src/data_pipeline.py
@@ -157,9 +157,37 @@ def main():
         primary_fuel_table,
         subplant_emission_factors,
     ) = data_cleaning.clean_eia923(year, args.small)
+    # output primary fuel table
+    output_data.output_intermediate_data(
+        primary_fuel_table,
+        "primary_fuel_table",
+        path_prefix,
+        year,
+        args.skip_outputs,
+    )
+    # remove intermediate columns from primary fuel table
+    primary_fuel_table = primary_fuel_table[
+        [
+            "plant_id_eia",
+            "subplant_id",
+            "generator_id",
+            "energy_source_code",
+            "plant_primary_fuel",
+            "subplant_primary_fuel",
+        ]
+    ]
     # Add primary fuel data to each generator
     eia923_allocated = eia923_allocated.merge(
-        primary_fuel_table,
+        primary_fuel_table[
+            [
+                "plant_id_eia",
+                "subplant_id",
+                "generator_id",
+                "energy_source_code",
+                "plant_primary_fuel",
+                "subplant_primary_fuel",
+            ]
+        ],
         how="left",
         on=["plant_id_eia", "subplant_id", "generator_id"],
         validate="m:1",


### PR DESCRIPTION
This PR advances work on https://github.com/singularity-energy/open-grid-emissions/issues/281 and CAR-1890:
- Exports the primary_fuel_table with all intermediate columns to outputs to help with validation. 
- Adds a new validation check to flag when the plant primary fuel assigned by the pipeline does not match the capacity-based primary fuel assignment. 
- Adds logging configuration to the sandbox notebook.

As noted in the documentation for the validation check:
> Since we do not know exactly how plants are assigned to fuel categories in EIA-930,
    it is possible that the primary fuel we assign to the plant may differ from the
    primary fuel category used in EIA-930. The most likely source of this disconnect is
    if these plants are assigned a primary fuel based on the type of generation with the
    highest nameplate capacity (since this is relatively static over time), rather than
    based on fuel consumption (which may change year-to-year).
  >  This test identifies where the primary fuel that the pipeline assigns would lead to
    the plant being categorized under a different fuel category than if a capacity-based
    method were used.
>Plants flagged by this test are not necessarily incorrectly assigned, but rather
    this is intended to bring this issue to our attention as a potential source of
    inconsistency.