### PR TITLE
Validate subplants have both combined cycle parts

### DIFF
--- a/src/column_checks.py
+++ b/src/column_checks.py
@@ -18,6 +18,7 @@ After any change, re-run data_pipeline to regenerate all files and re-run these
 checks.
 """
 from logging_util import get_logger
+
 logger = get_logger(__name__)
 
 
@@ -324,6 +325,17 @@ COLUMNS = {
         "plant_regression_ratio",
         "plant_regression_shift_mw",
         "plant_regression_rsq_adj",
+    },
+    "subplant_crosswalk": {
+        "plant_id_epa",
+        "emissions_unit_id_epa",
+        "plant_id_eia",
+        "generator_id",
+        "subplant_id",
+        "unit_id_pudl",
+        "current_planned_operating_date",
+        "retirement_date",
+        "prime_mover_code",
     },
     "shaped_aggregated_plants": {
         "plant_id_eia",

--- a/src/data_pipeline.py
+++ b/src/data_pipeline.py
@@ -147,7 +147,14 @@ def main():
     # 2. Identify subplants
     ####################################################################################
     logger.info("2. Identifying subplant IDs")
-    data_cleaning.identify_subplants(year)
+    subplant_crosswalk = data_cleaning.identify_subplants(year)
+    output_data.output_intermediate_data(
+        subplant_crosswalk,
+        "subplant_crosswalk",
+        path_prefix,
+        year,
+        args.skip_outputs,
+    )
 
     # 3. Clean EIA-923 Generation and Fuel Data at the Monthly Level
     ####################################################################################

--- a/src/validation.py
+++ b/src/validation.py
@@ -143,6 +143,43 @@ def test_for_missing_values(df, small: bool = False):
     return missing_test
 
 
+def check_for_orphaned_cc_part_in_subplant(subplant_crosswalk):
+    """
+    Combined cycle generators contain a steam part (CA) and turbine part (CT) that are
+    linked together. Thus, our subplant groups that contain one part of a combined cycle
+    plant should always in theory contain the other part as well. This test checks that
+    both parts exist in a subplant if one exists.
+
+    Besides CT and CA prime movers, there is also CS prime movers which represent a
+    "single shaft" combined cycle unit where the steam and turbine parts share a single
+    generator. These prime movers are allowed to be by themselves in a subplant, as are
+    CC prime movers, which represent a "total unit."
+    """
+    cc_pm_codes = ["CA", "CT", "CS", "CC"]
+    # keep all rows that contain a combined cycle prime mover part
+    cc_subplants = subplant_crosswalk[
+        subplant_crosswalk["prime_mover_code"].isin(cc_pm_codes)
+    ]
+    # for each subplant, identify a list of all CC prime movers in that subplant
+    cc_subplants = cc_subplants.groupby(["plant_id_eia", "subplant_id"])[
+        "prime_mover_code"
+    ].agg(["unique"])
+    cc_subplants["unique_cc_pms"] = [
+        ",".join(map(str, l)) for l in cc_subplants["unique"]
+    ]
+    cc_subplants = cc_subplants.drop(columns="unique")
+    # identify where there are subplants that only contain a single CC part
+    orphaned_cc_parts = cc_subplants[
+        (cc_subplants["unique_cc_pms"] == "CA")
+        | (cc_subplants["unique_cc_pms"] == "CT")
+    ]
+    if len(orphaned_cc_parts) > 0:
+        logger.warning(
+            f"There are {len(orphaned_cc_parts)} subplants that only contain one part of a combined cycle system.\nSubplants that represent combined cycle generation should contain both CA and CT parts."
+        )
+        logger.warning("\n" + orphaned_cc_parts.to_string())
+
+
 def test_chp_allocation(df):
     """Checks that the CHP allocation didn't create any anomalous values."""
     logger.info(


### PR DESCRIPTION
This PR fixes CAR-1909.

Combined cycle generators contain a steam part (CA) and turbine part (CT) that are linked together. Thus, our subplant groups that contain one part of a combined cycle plant should always in theory contain the other part as well. This PR adds a test that checks that both parts exist in a subplant if one exists.

Besides CT and CA prime movers, there is also CS prime movers which represent a "single shaft" combined cycle unit where the steam and turbine parts share a single generator. These prime movers are allowed to be by themselves in a subplant, as are CC prime movers, which represent a "total unit."

This PR adds a `prime_mover_code` column to the subplant crosswalk table to help validating this.  

This PR also updates the code to export the subplant crosswalk using `output_intermediate_data` instead of just exporting using `pd.to_csv()` which bypassed our column checks. 

The warning looks like this:
![image](https://user-images.githubusercontent.com/45949268/224513475-ed9ab517-ea47-43b4-bcdc-7f5da558ba48.png)
