### PR TITLE
Fix logging bug

### DIFF
--- a/src/data_pipeline.py
+++ b/src/data_pipeline.py
@@ -72,17 +72,6 @@ def main():
     args = get_args()
     year = args.year
 
-    # configure the logger
-    # Log the print statements to a file for debugging.
-    configure_root_logger(
-        logfile=results_folder(f"{year}/data_quality_metrics/data_pipeline.log")
-    )
-    logger = get_logger("data_pipeline")
-    print_args(args, logger)
-
-    logger.info(f"Running data pipeline for year {year}")
-    validation.validate_year(year)
-
     # 0. Set up directory structure
     path_prefix = "" if not args.small else "small/"
     path_prefix += "flat/" if args.flat else ""
@@ -111,6 +100,17 @@ def main():
                     ),
                     exist_ok=True,
                 )
+
+    # configure the logger
+    # Log the print statements to a file for debugging.
+    configure_root_logger(
+        logfile=results_folder(f"{year}/data_quality_metrics/data_pipeline.log")
+    )
+    logger = get_logger("data_pipeline")
+    print_args(args, logger)
+
+    logger.info(f"Running data pipeline for year {year}")
+    validation.validate_year(year)
 
     # 1. Download data
     ####################################################################################


### PR DESCRIPTION
In `data_pipeline.main()` we were configuring the root logger to log to `results_folder(f"{year}/data_quality_metrics/data_pipeline.log")` as one of the first lines of code. However, in the next block of code we remove the results folder if it already exists:
```
if os.path.exists(results_folder(f"{path_prefix}")):
            shutil.rmtree(results_folder(f"{path_prefix}"))
```
However, this was raising the following error:
```
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'A:\\GitHub\\open-grid-emissions\\data\\results\\2019/data_quality_metrics\\data_pipeline.log'
```

This PR moves the logging configuration after the block of code that sets up the directory structure to avoid this error.

NOTE: I am proposing that we merge this directly into `main` instead of `dev` since this is a bug fix that does not affect any of the outputs. I would merge this into main without doing another versioned release for now.
