### PR TITLE
Check for complete timeseries

### DIFF
--- a/src/data_pipeline.py
+++ b/src/data_pipeline.py
@@ -238,6 +238,12 @@ def main():
         df_name="partial_cems_plant",
         keys=["plant_id_eia", "subplant_id"],
     )
+    validation.check_for_complete_timeseries(
+        df=partial_cems_plant,
+        df_name="partial_cems_plant",
+        keys=["plant_id_eia", "subplant_id"],
+        period="month",
+    )
     output_data.output_intermediate_data(
         partial_cems_plant,
         "partial_cems_plant",
@@ -255,6 +261,12 @@ def main():
         df=partial_cems_subplant,
         df_name="partial_cems_subplant",
         keys=["plant_id_eia", "subplant_id"],
+    )
+    validation.check_for_complete_timeseries(
+        df=partial_cems_subplant,
+        df_name="partial_cems_subplant",
+        keys=["plant_id_eia", "subplant_id"],
+        period="month",
     )
     output_data.output_intermediate_data(
         partial_cems_subplant,
@@ -298,6 +310,12 @@ def main():
         df=cems,
         df_name="cems_subplant",
         keys=["plant_id_eia", "subplant_id"],
+    )
+    validation.check_for_complete_timeseries(
+        df=cems,
+        df_name="cems_subplant",
+        keys=["plant_id_eia", "subplant_id"],
+        period="month",
     )
     output_data.output_intermediate_data(
         cems, "cems_subplant", path_prefix, year, args.skip_outputs
@@ -456,6 +474,12 @@ def main():
         df_name="shaped_eia_data",
         keys=["plant_id_eia"],
     )
+    validation.check_for_complete_timeseries(
+        df=shaped_eia_data,
+        df_name="shaped_eia_data",
+        keys=["plant_id_eia"],
+        period="month",
+    )
     output_data.output_intermediate_data(
         shaped_eia_data, "shaped_eia923_data", path_prefix, year, args.skip_outputs
     )
@@ -514,6 +538,12 @@ def main():
         df=combined_plant_data,
         df_name="combined_plant_data",
         keys=["plant_id_eia"],
+    )
+    validation.check_for_complete_timeseries(
+        df=combined_plant_data,
+        df_name="combined_plant_data",
+        keys=["plant_id_eia"],
+        period="year",
     )
     if not args.shape_individual_plants:
         output_data.output_plant_data(

--- a/src/output_data.py
+++ b/src/output_data.py
@@ -181,6 +181,9 @@ def output_plant_data(df, path_prefix, resolution, skip_outputs, plant_attribute
             validation.validate_unique_datetimes(
                 df, "individual_plant_data", ["plant_id_eia"]
             )
+            validation.check_for_complete_timeseries(
+                df, "individual_plant_data", ["plant_id_eia"], "year"
+            )
             # Separately save real and aggregate plants
             output_to_results(
                 df[df.plant_id_eia > 900000],
@@ -550,6 +553,12 @@ def write_power_sector_results(ba_fuel_data, path_prefix, skip_outputs):
                 df=ba_table_hourly,
                 df_name="power sector hourly ba table",
                 keys=["fuel_category"],
+            )
+            validation.check_for_complete_timeseries(
+                ba_table_hourly,
+                "power sector hourly ba table",
+                ["fuel_category"],
+                "year",
             )
 
             # export to a csv

--- a/src/validation.py
+++ b/src/validation.py
@@ -523,8 +523,8 @@ def check_for_complete_timeseries(df, df_name, keys, period):
 
     If the `period` is a 'year', checks that the length of the timeseries is 8760 (for a
     non-leap year) or 8784 (for a leap year). If the `period` is a 'month', checks that
-    the length of the timeseries is equal to number of days * 24 in the month associated
-    with the `report_date` column.
+    the length of the timeseries is equal to the length of the complete date_range
+    between the earliest and latest timestamp in a month. 
 
     Args:
         df: dataframe containing datetime columns


### PR DESCRIPTION
This PR adds a validation function that each hourly timeseries. When this function is called, you can specify whether you want to check for a complete annual timeseries, or a complete timeseries within each month, depending on the context. 

If the `period` is a 'year', checks that the length of the timeseries is 8760 (for a non-leap year) or 8784 (for a leap year). If the `period` is a 'month', checks that the length of the timeseries is equal to the length of the complete date_range between the earliest and latest timestamp in a month.

This PR fixes CAR-1996. 