### PR TITLE
Fix circular import of CLEAN_FUELS and add constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ There are many ways that you can contribute!
 ## Repository Structure
 ### Modules
 - `column_checks`: functions that check that all data outputs have the correct column names
+- `constants`: specifies conversion factors and constants used across all modules
 - `data_pipeline`: main script for running the data pipeline from start to finish
 - `download_data`: functions that download data from the internet
 - `data_cleaning`: functions that clean loaded data

--- a/src/oge/constants.py
+++ b/src/oge/constants.py
@@ -1,0 +1,6 @@
+# specify the energy_source_codes that are considered clean/carbon-free
+CLEAN_FUELS = ["SUN", "MWH", "WND", "WAT", "WH", "PUR", "NUC"]
+
+UNIT_CONVERSIONS = {"lb": ("kg", 0.453592), "mmbtu": ("GJ", 1.055056)}
+
+TIME_RESOLUTIONS = {"hourly": "H", "monthly": "M", "annual": "A"}

--- a/src/oge/constants.py
+++ b/src/oge/constants.py
@@ -1,6 +1,36 @@
 # specify the energy_source_codes that are considered clean/carbon-free
 CLEAN_FUELS = ["SUN", "MWH", "WND", "WAT", "WH", "PUR", "NUC"]
 
-UNIT_CONVERSIONS = {"lb": ("kg", 0.453592), "mmbtu": ("GJ", 1.055056)}
+# specify the energy_source_codes that are considerd to be biomass
+BIOMASS_FUELS = [
+    "AB",
+    "BG",
+    "BLQ",
+    "DG",
+    "LFG",
+    "MSB",
+    "OBG",
+    "OBL",
+    "OBS",
+    "SLW",
+    "WDL",
+    "WDS",
+]
 
 TIME_RESOLUTIONS = {"hourly": "H", "monthly": "M", "annual": "A"}
+
+# derived from table 2.4-4 of the EPA's AP-42 document
+nox_lb_per_mmbtu_flared_landfill_gas = 0.078
+
+# values assumed by eGRID for CHP efficiency
+chp_gross_thermal_output_efficiency = 0.8
+chp_useful_thermal_output_efficiency = 0.75
+
+
+class ConversionFactors(float):
+    """Defines conversion factors between common units."""
+
+    lb_to_kg = 0.453592
+    mmbtu_to_GJ = 1.055056
+    mwh_to_mmbtu = 3.412142
+    short_ton_to_lbs = 2000

--- a/src/oge/consumed.py
+++ b/src/oge/consumed.py
@@ -7,12 +7,11 @@ from gridemissions.load import BaData
 from gridemissions.eia_api import KEYS, SRC
 from oge.filepaths import outputs_folder, reference_table_folder, results_folder
 from oge.logging_util import get_logger
-
+from oge.constants import TIME_RESOLUTIONS
 from oge.output_data import (
     GENERATED_EMISSION_RATE_COLS,
     CONSUMED_EMISSION_RATE_COLS,
     output_to_results,
-    TIME_RESOLUTIONS,
 )
 
 logger = get_logger(__name__)

--- a/src/oge/data_cleaning.py
+++ b/src/oge/data_cleaning.py
@@ -9,7 +9,7 @@ from pudl.etl.glue_assets import make_subplant_ids
 import oge.load_data as load_data
 import oge.validation as validation
 import oge.emissions as emissions
-from oge.emissions import CLEAN_FUELS
+from oge.constants import CLEAN_FUELS
 from oge.column_checks import get_dtypes, apply_dtypes
 from oge.filepaths import reference_table_folder, outputs_folder
 from oge.logging_util import get_logger

--- a/src/oge/data_pipeline.py
+++ b/src/oge/data_pipeline.py
@@ -22,6 +22,7 @@ import oge.output_data as output_data
 import oge.consumed as consumed
 from oge.filepaths import downloads_folder, outputs_folder, results_folder
 from oge.logging_util import get_logger, configure_root_logger
+from oge.constants import TIME_RESOLUTIONS
 
 
 def get_args() -> argparse.Namespace:
@@ -97,7 +98,7 @@ def main(args):
     )
     # Make results subfolders
     for unit in ["us_units", "metric_units"]:
-        for time_resolution in output_data.TIME_RESOLUTIONS.keys():
+        for time_resolution in TIME_RESOLUTIONS.keys():
             for subfolder in ["plant_data", "carbon_accounting", "power_sector_data"]:
                 os.makedirs(
                     results_folder(

--- a/src/oge/emissions.py
+++ b/src/oge/emissions.py
@@ -6,12 +6,12 @@ import oge.validation as validation
 from oge.column_checks import get_dtypes
 from oge.filepaths import reference_table_folder
 from oge.logging_util import get_logger
+from oge.constants import CLEAN_FUELS
 
 from pudl.analysis.allocate_gen_fuel import (
     distribute_annually_reported_data_to_months_if_annual,
 )
 
-CLEAN_FUELS = ["SUN", "MWH", "WND", "WAT", "WH", "PUR", "NUC"]
 
 logger = get_logger(__name__)
 

--- a/src/oge/emissions.py
+++ b/src/oge/emissions.py
@@ -6,7 +6,14 @@ import oge.validation as validation
 from oge.column_checks import get_dtypes
 from oge.filepaths import reference_table_folder
 from oge.logging_util import get_logger
-from oge.constants import CLEAN_FUELS
+from oge.constants import (
+    BIOMASS_FUELS,
+    CLEAN_FUELS,
+    ConversionFactors,
+    chp_gross_thermal_output_efficiency,
+    chp_useful_thermal_output_efficiency,
+    nox_lb_per_mmbtu_flared_landfill_gas,
+)
 
 from pudl.analysis.allocate_gen_fuel import (
     distribute_annually_reported_data_to_months_if_annual,
@@ -284,21 +291,25 @@ def calculate_electric_allocation_factor(df):
     Requires a dataframe with the following columns: net_generation_mwh, fuel_consumed_mmbtu, fuel_consumed_for_electricity_mmbtu
     """
 
-    mwh_to_mmbtu = 3.412142
-
-    # calculate the useful thermal output
+    # calculate the gross thermal output
     # 0.8 is an assumed efficiency factor used by eGRID
-    df["useful_thermal_output"] = 0.8 * (
-        df["fuel_consumed_mmbtu"] - df["fuel_consumed_for_electricity_mmbtu"]
+    df["gross_thermal_output_for_heating_mmbtu"] = (
+        chp_gross_thermal_output_efficiency
+        * (df["fuel_consumed_mmbtu"] - df["fuel_consumed_for_electricity_mmbtu"])
+    )
+    # calculate the useful thermal output
+    # 0.75 is an assumed efficiency factor used by eGRID
+    df["useful_thermal_output_mmbtu"] = (
+        chp_useful_thermal_output_efficiency
+        * df["gross_thermal_output_for_heating_mmbtu"]
     )
 
     # convert generation to mmbtu
-    df["generation_mmbtu"] = df["net_generation_mwh"] * mwh_to_mmbtu
+    df["generation_mmbtu"] = df["net_generation_mwh"] * ConversionFactors.mwh_to_mmbtu
 
     # calculate the electric allocation factor
-    # 0.75 is an assumed efficiency factor used by eGRID
     df["electric_allocation_factor"] = df["generation_mmbtu"] / (
-        df["generation_mmbtu"] + (0.75 * df["useful_thermal_output"])
+        df["generation_mmbtu"] + df["useful_thermal_output_mmbtu"]
     )
 
     # if the allocation factor < 0, set to zero
@@ -318,25 +329,11 @@ def adjust_emissions_for_biomass(df):
     """Creates a new adjusted co2 emissions column that sets any biomass emissions to zero."""
 
     # create a column for adjusted biomass emissions, setting these emissions to zero
-    biomass_fuels = [
-        "AB",
-        "BG",
-        "BLQ",
-        "DG",
-        "LFG",
-        "MSB",
-        "OBG",
-        "OBL",
-        "OBS",
-        "SLW",
-        "WDL",
-        "WDS",
-    ]
 
     # CO2: adjust emissions for co2 for all biomass generators
     if "co2_mass_lb" in df.columns:
         df["co2_mass_lb_adjusted"] = df["co2_mass_lb"]
-        df.loc[df["energy_source_code"].isin(biomass_fuels), "co2_mass_lb_adjusted"] = 0
+        df.loc[df["energy_source_code"].isin(BIOMASS_FUELS), "co2_mass_lb_adjusted"] = 0
 
     # CH4: for landfill gas (LFG), all other emissions are set to zero
     # this assumes that the gas would have been flared anyway if not used for electricity generation
@@ -356,7 +353,10 @@ def adjust_emissions_for_biomass(df):
         df["nox_mass_lb_adjusted"] = df["nox_mass_lb"]
         df.loc[df["energy_source_code"] == "LFG", "nox_mass_lb_adjusted"] = df.loc[
             df["energy_source_code"] == "LFG", "nox_mass_lb_adjusted"
-        ] - (df.loc[df["energy_source_code"] == "LFG", "fuel_consumed_mmbtu"] * 0.078)
+        ] - (
+            df.loc[df["energy_source_code"] == "LFG", "fuel_consumed_mmbtu"]
+            * nox_lb_per_mmbtu_flared_landfill_gas
+        )
         df.loc[df["nox_mass_lb_adjusted"] < 0, "nox_mass_lb_adjusted"] = 0
 
     # SO2: LFG plants set to zero

--- a/src/oge/load_data.py
+++ b/src/oge/load_data.py
@@ -8,7 +8,7 @@ from oge.column_checks import get_dtypes
 from oge.filepaths import downloads_folder, reference_table_folder, outputs_folder
 import oge.validation as validation
 from oge.logging_util import get_logger
-from oge.emissions import CLEAN_FUELS
+from oge.constants import CLEAN_FUELS
 
 from pudl.metadata.fields import apply_pudl_dtypes
 

--- a/src/oge/load_data.py
+++ b/src/oge/load_data.py
@@ -8,7 +8,7 @@ from oge.column_checks import get_dtypes
 from oge.filepaths import downloads_folder, reference_table_folder, outputs_folder
 import oge.validation as validation
 from oge.logging_util import get_logger
-from oge.constants import CLEAN_FUELS
+from oge.constants import CLEAN_FUELS, ConversionFactors
 
 from pudl.metadata.fields import apply_pudl_dtypes
 
@@ -76,7 +76,7 @@ def load_cems_data(year):
     cems["steam_load_1000_lb"] = cems["steam_load_1000_lb"].fillna(0)
 
     # convert co2 mass in tons to lb
-    cems["co2_mass_lb"] = cems["co2_mass_tons"] * 2000
+    cems["co2_mass_lb"] = cems["co2_mass_tons"] * ConversionFactors.short_ton_to_lbs
 
     # re-order columns
     cems = cems[
@@ -294,7 +294,9 @@ def load_ghg_emission_factors():
     )
 
     # convert co2 mass in short tons to lb
-    efs["co2_tons_per_mmbtu"] = efs["co2_tons_per_mmbtu"] * 2000
+    efs["co2_tons_per_mmbtu"] = (
+        efs["co2_tons_per_mmbtu"] * ConversionFactors.short_ton_to_lbs
+    )
 
     # rename the columns
     efs = efs.rename(columns={"co2_tons_per_mmbtu": "co2_lb_per_mmbtu"})
@@ -943,20 +945,30 @@ def load_egrid_plant_file(year):
     )
 
     # convert mass tons to lb
-    egrid_plant["co2_mass_lb"] = egrid_plant["co2_mass_lb"] * 2000
-    egrid_plant["nox_mass_lb"] = egrid_plant["nox_mass_lb"] * 2000
-    egrid_plant["so2_mass_lb"] = egrid_plant["so2_mass_lb"] * 2000
+    egrid_plant["co2_mass_lb"] = (
+        egrid_plant["co2_mass_lb"] * ConversionFactors.short_ton_to_lbs
+    )
+    egrid_plant["nox_mass_lb"] = (
+        egrid_plant["nox_mass_lb"] * ConversionFactors.short_ton_to_lbs
+    )
+    egrid_plant["so2_mass_lb"] = (
+        egrid_plant["so2_mass_lb"] * ConversionFactors.short_ton_to_lbs
+    )
     egrid_plant["co2_mass_lb_for_electricity_adjusted"] = (
-        egrid_plant["co2_mass_lb_for_electricity_adjusted"] * 2000
+        egrid_plant["co2_mass_lb_for_electricity_adjusted"]
+        * ConversionFactors.short_ton_to_lbs
     )
     egrid_plant["co2e_mass_lb_for_electricity_adjusted"] = (
-        egrid_plant["co2e_mass_lb_for_electricity_adjusted"] * 2000
+        egrid_plant["co2e_mass_lb_for_electricity_adjusted"]
+        * ConversionFactors.short_ton_to_lbs
     )
     egrid_plant["nox_mass_lb_for_electricity_adjusted"] = (
-        egrid_plant["nox_mass_lb_for_electricity_adjusted"] * 2000
+        egrid_plant["nox_mass_lb_for_electricity_adjusted"]
+        * ConversionFactors.short_ton_to_lbs
     )
     egrid_plant["so2_mass_lb_for_electricity_adjusted"] = (
-        egrid_plant["so2_mass_lb_for_electricity_adjusted"] * 2000
+        egrid_plant["so2_mass_lb_for_electricity_adjusted"]
+        * ConversionFactors.short_ton_to_lbs
     )
 
     # if egrid has a missing value for co2 for a clean plant, replace with zero
@@ -1029,7 +1041,9 @@ def load_egrid_ba_file(year):
         }
     )
     egrid_ba = egrid_ba.sort_values(by="ba_code", ascending=True)
-    egrid_ba["co2_mass_lb_adjusted"] = egrid_ba["co2_mass_lb_adjusted"] * 2000
+    egrid_ba["co2_mass_lb_adjusted"] = (
+        egrid_ba["co2_mass_lb_adjusted"] * ConversionFactors.short_ton_to_lbs
+    )
 
     return egrid_ba
 

--- a/src/oge/output_data.py
+++ b/src/oge/output_data.py
@@ -9,6 +9,7 @@ import oge.column_checks as column_checks
 import oge.validation as validation
 from oge.filepaths import outputs_folder, results_folder, data_folder
 from oge.logging_util import get_logger
+from oge.constants import UNIT_CONVERSIONS
 
 logger = get_logger(__name__)
 
@@ -42,10 +43,6 @@ CONSUMED_EMISSION_RATE_COLS = [
     "consumed_nox_rate_lb_per_mwh_for_electricity_adjusted",
     "consumed_so2_rate_lb_per_mwh_for_electricity_adjusted",
 ]
-
-UNIT_CONVERSIONS = {"lb": ("kg", 0.453592), "mmbtu": ("GJ", 1.055056)}
-
-TIME_RESOLUTIONS = {"hourly": "H", "monthly": "M", "annual": "A"}
 
 
 def prepare_files_for_upload(years):

--- a/src/oge/output_data.py
+++ b/src/oge/output_data.py
@@ -9,7 +9,7 @@ import oge.column_checks as column_checks
 import oge.validation as validation
 from oge.filepaths import outputs_folder, results_folder, data_folder
 from oge.logging_util import get_logger
-from oge.constants import UNIT_CONVERSIONS
+from oge.constants import ConversionFactors
 
 logger = get_logger(__name__)
 
@@ -43,6 +43,11 @@ CONSUMED_EMISSION_RATE_COLS = [
     "consumed_nox_rate_lb_per_mwh_for_electricity_adjusted",
     "consumed_so2_rate_lb_per_mwh_for_electricity_adjusted",
 ]
+
+UNIT_CONVERSIONS = {
+    "lb": ("kg", ConversionFactors.lb_to_kg),
+    "mmbtu": ("GJ", ConversionFactors.mmbtu_to_GJ),
+}
 
 
 def prepare_files_for_upload(years):

--- a/src/oge/validation.py
+++ b/src/oge/validation.py
@@ -3,10 +3,10 @@ import numpy as np
 
 import oge.load_data as load_data
 import oge.impute_hourly_profiles as impute_hourly_profiles
-import oge.emissions as emissions
 from oge.column_checks import get_dtypes
 from oge.filepaths import reference_table_folder, outputs_folder
 from oge.logging_util import get_logger
+from oge.constants import CLEAN_FUELS
 
 logger = get_logger(__name__)
 
@@ -1106,28 +1106,28 @@ def identify_percent_of_data_by_input_source(
     # use the generator-specific energy source code for the eia data, otherwise use the pliant primary fuel
     eia_only_data = eia_only_data.assign(
         emitting_net_generation_mwh=lambda x: np.where(
-            ~x.energy_source_code.isin(emissions.CLEAN_FUELS + ["GEO"]),
+            ~x.energy_source_code.isin(CLEAN_FUELS + ["GEO"]),
             x.net_generation_mwh,
             0,
         )
     )
     cems = cems.assign(
         emitting_net_generation_mwh=lambda x: np.where(
-            ~x.plant_primary_fuel.isin(emissions.CLEAN_FUELS + ["GEO"]),
+            ~x.plant_primary_fuel.isin(CLEAN_FUELS + ["GEO"]),
             x.net_generation_mwh,
             0,
         )
     )
     partial_cems_subplant = partial_cems_subplant.assign(
         emitting_net_generation_mwh=lambda x: np.where(
-            ~x.plant_primary_fuel.isin(emissions.CLEAN_FUELS + ["GEO"]),
+            ~x.plant_primary_fuel.isin(CLEAN_FUELS + ["GEO"]),
             x.net_generation_mwh,
             0,
         )
     )
     partial_cems_plant = partial_cems_plant.assign(
         emitting_net_generation_mwh=lambda x: np.where(
-            ~x.plant_primary_fuel.isin(emissions.CLEAN_FUELS + ["GEO"]),
+            ~x.plant_primary_fuel.isin(CLEAN_FUELS + ["GEO"]),
             x.net_generation_mwh,
             0,
         )


### PR DESCRIPTION
### Purpose
Some of the changes implemented in https://github.com/singularity-energy/open-grid-emissions/pull/337 introduced a circular import between the `load_data` and `emissions` modules, due to the import of `CLEAN_FUELS` into the `load_data` module. 

### What the code is doing
Moves `CLEAN_FUELS` (along with some other constants) to a new `constants.py` module to prevent a circular import. 

While in the process of fixing this specific circular import, I also searched the repo for where other constants / assumptions were specified and consolidated them into `constants`.

In `emissions.calculate_electric_allocation_factor()` updated the calculation steps and column names to match the process described in the "Adjusting Emissions for CHP" docs (there is no methodological change here, just separating out several steps and renaming some variables to be more clear). 

### Testing
Tested importing OGE with this new branch in another package, and the circular import error was resolved. 

### Where to look
All files

### Usage Example/Visuals
N/A

### Review estimate
5 min

### Future work
N/A

### Checklist
- [x] Update the documentation to reflect changes made in this PR
- [x] Format all updated python files using `ruff`
- [x] Clear outputs from all notebooks modified
- [x] Add docstrings and type hints to any new functions created
