### PR TITLE
Fix filepaths for s3

### DIFF
--- a/src/oge/filepaths.py
+++ b/src/oge/filepaths.py
@@ -23,24 +23,24 @@ def top_folder(rel=""):
 
 
 def reference_table_folder(rel=""):
-    return os.path.join(top_folder("reference_tables"), rel).replace("\\","/")
+    return os.path.join(top_folder("reference_tables"), rel).replace("\\", "/")
 
 
 def data_folder(rel=""):
     """Returns a path relative to the `data` folder."""
-    return os.path.join(get_data_store(), rel).replace("\\","/")
+    return os.path.join(get_data_store(), rel).replace("\\", "/")
 
 
 def downloads_folder(rel=""):
-    return os.path.join(data_folder("downloads"), rel).replace("\\","/")
+    return os.path.join(data_folder("downloads"), rel).replace("\\", "/")
 
 
 def outputs_folder(rel=""):
-    return os.path.join(data_folder("outputs"), rel).replace("\\","/")
+    return os.path.join(data_folder("outputs"), rel).replace("\\", "/")
 
 
 def results_folder(rel=""):
-    return os.path.join(data_folder("results"), rel).replace("\\","/")
+    return os.path.join(data_folder("results"), rel).replace("\\", "/")
 
 
 def containing_folder(filepath: str) -> str:

--- a/src/oge/filepaths.py
+++ b/src/oge/filepaths.py
@@ -23,24 +23,24 @@ def top_folder(rel=""):
 
 
 def reference_table_folder(rel=""):
-    return os.path.join(top_folder("reference_tables"), rel)
+    return os.path.join(top_folder("reference_tables"), rel).replace("\\","/")
 
 
 def data_folder(rel=""):
     """Returns a path relative to the `data` folder."""
-    return os.path.join(get_data_store(), rel)
+    return os.path.join(get_data_store(), rel).replace("\\","/")
 
 
 def downloads_folder(rel=""):
-    return os.path.join(data_folder("downloads"), rel)
+    return os.path.join(data_folder("downloads"), rel).replace("\\","/")
 
 
 def outputs_folder(rel=""):
-    return os.path.join(data_folder("outputs"), rel)
+    return os.path.join(data_folder("outputs"), rel).replace("\\","/")
 
 
 def results_folder(rel=""):
-    return os.path.join(data_folder("results"), rel)
+    return os.path.join(data_folder("results"), rel).replace("\\","/")
 
 
 def containing_folder(filepath: str) -> str:


### PR DESCRIPTION
### Purpose
When importing OGE into another module on windows, and attempting to load data from s3, the current way filepaths are handled results in a FileNotFound error.

For example, running `oge.filepaths.results_folder("2022/plant_data/plant_static_attributes.csv")` returns:
```
's3://open-grid-emissions/open_grid_emissions_data\\results\\2022/plant_data/plant_static_attributes.csv'
```
Where `os.path.join()` is concatting parts of the filepath together, it is adding a "\\" rather than a "/".
When attempting to read from this location, for example using `pd.read_csv(oge.filepaths.results_folder("2022/plant_data/plant_static_attributes.csv")`, this results in:
```
FileNotFoundError: open-grid-emissions/open_grid_emissions_data\results\2022/plant_data/plant_static_attributes.csv
```
Here, the mix of forward and back slashes does not seem to be compatible with reading from s3. 
If instead I try `pd.read_csv(oge.filepaths.results_folder("2022/plant_data/plant_static_attributes.csv").replace("\\","/"))`, this successfully returns the dataframe

### What the code is doing
This PR adds `.replace("\\","/")` to all of the functions that return folder locations where data is saved to help prevent this issue in any package that imports OGE and reads the data from s3.

### Testing
Did a fresh install of the local oge version, and ran the pipeline long enough to check that local data loading still works.

### Where to look

### Usage Example/Visuals

### Review estimate
Code review: < 5 min. If you test on a mac, it may take longer. 

### Future work
What issues were identified that are not being addressed in this PR but should be addressed in future work?

### Checklist
- [ ] Update the documentation to reflect changes made in this PR
- [ ] Format all updated python files using `black`
- [ ] Clear outputs from all notebooks modified
- [ ] Add docstrings and type hints to any new functions created
