### PR TITLE
Create notebook looking at subplant id across years

### DIFF
--- a/notebooks/validation/validate_subplant_crosswalk.ipynb
+++ b/notebooks/validation/validate_subplant_crosswalk.ipynb
@@ -1,0 +1,134 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Compare Subplant Crosswalk Across Years "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import pandas as pd\n",
+    "\n",
+    "from oge.filepaths import outputs_folder"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load Data from S3\n",
+    "Drop NAs in `subplan_id`, `plant_id_eia` and`generator_id` in order to compare `subplan_id` across years for same (`plant_id_eia`, `generator_id`) combination"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.environ[\"OGE_DATA_STORE\"] = \"s3\"\n",
+    "subplant = {\n",
+    "    y: pd.read_csv(outputs_folder(f\"{y}/subplant_crosswalk_{y}.csv\"))\n",
+    "    .dropna(axis=0, subset=[\"plant_id_eia\", \"generator_id\", \"subplant_id\"])\n",
+    "    .set_index([\"plant_id_eia\", \"generator_id\"])[\"subplant_id\"]\n",
+    "    for y in range(2019, 2023)\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Look at length of series. It should be different from year to year as generators come online or are retired. It seems to increase from one year to the next."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "[len(df) for df in subplant.values()]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look at Difference"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mismatch = {\n",
+    "    f\"{i}-{j}\": subplant[i]\n",
+    "    .reset_index()\n",
+    "    .merge(\n",
+    "        subplant[j].reset_index(),\n",
+    "        on=[\"plant_id_eia\", \"generator_id\"],\n",
+    "        how=\"inner\",\n",
+    "        suffixes=[f\"_{i}\", f\"_{j}\"],\n",
+    "    )\n",
+    "    .query(f\"subplant_id_{i} - subplant_id_{j} != 0\")\n",
+    "    .set_index([\"plant_id_eia\", \"generator_id\"])\n",
+    "    for i in range(2019, 2022)\n",
+    "    for j in range(i + 1, 2023)\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\n",
+    "    \"Number of difference in subplant_id for same (plant_id_eia, generator_id) combination\"\n",
+    ")\n",
+    "for k, v in mismatch.items():\n",
+    "    print(f\"{k}: {len(v)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mismatch[\"2021-2022\"]"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "open-grid-emissions-zm3GQQDc",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
### Purpose
Compare mapping of (`plant_id_eia`, `generator_id`) to `subplant_id` across years. Closes CAR-3518

### What the code is doing
Load the sub-plant crosswalk files for years 2019 through 2022. For each year combination, the intersection of (`plant_id_eia`, `generator_id`) is retrieved and occurrences where the `subplant_id` values differ are saved as a `pandas` data frame.

### Testing
N/A

### Where to look
A new notebook named `validate_subplant_crosswalk` encloses this short analysis

### Usage Example/Visuals
See notebook outputs [here](https://github.com/singularity-energy/open-grid-emissions/blob/ben/crosswalk/notebooks/validation/validate_subplant_crosswalk.ipynb), e.g.,
```
Number of difference in subplant_id for same (plant_id_eia, generator_id) combination
2019-2020: 448
2019-2021: 895
2019-2022: 1193
2020-2021: 488
2020-2022: 831
2021-2022: 435
```

### Review estimate
10min

### Future work
N/A

### Checklist
- [x] Update the documentation to reflect changes made in this PR
- [x] Format all updated python files using `black`
- [x] Clear outputs from all notebooks modified
- [x] Add docstrings and type hints to any new functions created