### PR TITLE
Get EIA-860 data from latest validated year

### DIFF
--- a/src/oge/data_pipeline.py
+++ b/src/oge/data_pipeline.py
@@ -25,7 +25,7 @@ import oge.output_data as output_data
 import oge.consumed as consumed
 from oge.filepaths import downloads_folder, outputs_folder, results_folder
 from oge.logging_util import get_logger, configure_root_logger
-from oge.constants import TIME_RESOLUTIONS
+from oge.constants import TIME_RESOLUTIONS, latest_validated_year
 
 
 def get_args() -> argparse.Namespace:
@@ -142,6 +142,8 @@ def main(args):
     )
     # download the raw EIA-923 and EIA-860 files for use in NOx/SO2 calculations until integrated into pudl
     download_data.download_raw_eia860(year)
+    # download eia860 from the latest validated year for use in subplant identification
+    download_data.download_raw_eia860(latest_validated_year)
     download_data.download_raw_eia923(year)
 
     # 2. Identify subplants


### PR DESCRIPTION
### Purpose
In https://github.com/singularity-energy/open-grid-emissions/pull/353, we required that the subplant identification code load raw EIA-860 data from the latest validated year (2022). However, if running the pipeline for the first time for any year other than the latest validated year, this would lead to an error, since that file is not downloaded. This PR adds code to download the EIA-860 file for the latest validated year. 

Fixed CAR-3907

### What the code is doing
See data_pipeline.py

### Testing
Ran the download part of the data pipeline for 2019. 

### Where to look
See data_pipeline.py

### Usage Example/Visuals
![image](https://github.com/singularity-energy/open-grid-emissions/assets/45949268/35d52c35-fa4b-46f5-b4ed-45ef7400edea)

### Review estimate
1 min

### Future work
What issues were identified that are not being addressed in this PR but should be addressed in future work?

### Checklist
- [ ] Update the documentation to reflect changes made in this PR
- [ ] Format all updated python files using `black`
- [ ] Clear outputs from all notebooks modified
- [ ] Add docstrings and type hints to any new functions created
