### PR TITLE
Add geographical information to the plant static attributes data frame

### DIFF
--- a/src/oge/column_checks.py
+++ b/src/oge/column_checks.py
@@ -20,6 +20,8 @@ checks.
 
 from oge.logging_util import get_logger
 
+import pandas as pd
+
 logger = get_logger(__name__)
 
 
@@ -190,11 +192,17 @@ COLUMNS = {
         "fuel_category_eia930",
         "ba_code",
         "ba_code_physical",
-        "state",
         "distribution_flag",
         "timezone",
         "data_availability",
         "shaped_plant_id",
+        "latitude",
+        "longitude",
+        "state",
+        "county",
+        "city",
+        "plant_name_eia",
+        "capacity_mw",
     },
     "plant_metadata": {
         "plant_id_eia",
@@ -364,9 +372,17 @@ COLUMNS = {
 }
 
 
-def check_columns(df, file_name):
-    """
-    Given a file name and a dataframe to export, check that its columns are as expected.
+def check_columns(df: pd.DataFrame, file_name: str):
+    """Given a file name and a data frame to export, check that its columns are as
+    expected.
+
+    Args:
+        df (pd.DataFrame): table to check.
+        file_name (str): key name of file in `COLUMNS`.
+
+    Raises:
+        ValueError: if `file_name` cannot be found in list of files.
+        ValueError: if columns are missing in `df`.
     """
 
     cols = set(list(df.columns))
@@ -491,13 +507,26 @@ def get_dtypes():
         "subplant_primary_fuel_from_net_generation_mwh": "str",
         "timezone": "str",
         "wet_dry_bottom": "str",
+        "latitude": "float64",
+        "longitude": "float64",
+        "county": "str",
+        "city": "str",
+        "plant_name_eia": "str",
     }
 
     return dtypes_to_use
 
 
-def apply_dtypes(df):
-    """Applies specified dtypes to a dataframe and identifies if a dtype is not specified for a column."""
+def apply_dtypes(df: pd.DataFrame) -> pd.DataFrame:
+    """Applies specified types to a data frame and identifies if a type is not
+    specified for a column.
+
+    Args:
+        df (pd.DataFrame): table whose columns will be converted.
+
+    Returns:
+        pd.DataFrame: original data frame with type converted columns.
+    """
     dtypes = get_dtypes()
     datetime_columns = ["datetime_utc", "datetime_local", "report_date"]
     cols_missing_dtypes = [
@@ -507,7 +536,8 @@ def apply_dtypes(df):
     ]
     if len(cols_missing_dtypes) > 0:
         logger.warning(
-            "The following columns do not have dtypes assigned in `column_checks.get_dtypes()`"
+            "The following columns do not have dtypes assigned in "
+            "`column_checks.get_dtypes()`"
         )
         logger.warning(cols_missing_dtypes)
     return df.astype({col: dtypes[col] for col in df.columns if col in dtypes})

--- a/src/oge/helpers.py
+++ b/src/oge/helpers.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 
 from oge.column_checks import get_dtypes, apply_dtypes
+from oge.constants import latest_validated_year
 from oge.filepaths import reference_table_folder, outputs_folder
 import oge.load_data as load_data
 from oge.logging_util import get_logger
@@ -10,7 +11,24 @@ import oge.validation as validation
 logger = get_logger(__name__)
 
 
-def create_plant_attributes_table(cems, eia923_allocated, year, primary_fuel_table):
+def create_plant_attributes_table(
+    cems: pd.DataFrame,
+    eia923_allocated: pd.DataFrame,
+    year: int,
+    primary_fuel_table: pd.DataFrame,
+) -> pd.DataFrame:
+    """Creates the plant attributes table.
+
+    Args:
+        cems (pd.DataFrame): CEMS table.
+        eia923_allocated (pd.DataFrame): allocated EIA-923 data.
+        year (int): a four-digit year
+        primary_fuel_table (pd.DataFrame): primary fuel table.
+
+    Returns:
+        pd.DataFrame: the plants attributes table. Timezone, geographical and fuel
+            information can be found in this table.
+    """
     # create a table with the unique plantids from both dataframes
     eia_plants = eia923_allocated.copy()[
         ["plant_id_eia", "plant_primary_fuel"]
@@ -38,7 +56,8 @@ def create_plant_attributes_table(cems, eia923_allocated, year, primary_fuel_tab
         ["plant_id_eia", "energy_source_code", "fuel_consumed_mmbtu"],
     ]
 
-    # calculate the total fuel consumption by fuel type and keep the fuel code with the largest fuel consumption
+    # calculate the total fuel consumption by fuel type and keep the fuel code with the
+    # largest fuel consumption
     cems_primary_fuel = (
         cems_primary_fuel.groupby(["plant_id_eia", "energy_source_code"], dropna=False)
         .sum()
@@ -83,7 +102,7 @@ def create_plant_attributes_table(cems, eia923_allocated, year, primary_fuel_tab
         }
     )
 
-    # assign a BA code and state code to each plant
+    # assign a BA code to each plant
     plant_attributes = assign_ba_code_to_plant(plant_attributes, year)
 
     # add a flag about whether the plant is distribution connected
@@ -91,32 +110,36 @@ def create_plant_attributes_table(cems, eia923_allocated, year, primary_fuel_tab
         plant_attributes, year, voltage_threshold_kv=60
     )
 
-    # assign a fuel category to each plant based on what is most likely to match with the category used in EIA-930
+    # assign a fuel category to each plant based on what is most likely to match with
+    # the category used in EIA-930
     plant_attributes = assign_fuel_category_to_ESC(
         df=plant_attributes,
         esc_column="plant_primary_fuel",
     )
 
-    # add tz info
-    plant_attributes = add_plant_local_timezone(plant_attributes, year)
+    # add geographical info
+    plant_attributes = add_plant_entity(plant_attributes)
+
+    # add nameplate capacity
+    plant_attributes = add_plant_nameplate_capacity(plant_attributes)
 
     plant_attributes = apply_dtypes(plant_attributes)
 
     return plant_attributes
 
 
-def assign_ba_code_to_plant(df, year):
-    """
-    Assigns a balancing authority code and state to each plant based on the plant id
-    Inputs:
-        df: a pandas dataframe containing a 'plant_id_eia' column
-        year: four digit year number for the data
-    Returns:
-        df with a new column for 'ba_code' and 'state'
-    """
+def assign_ba_code_to_plant(df: pd.DataFrame, year: int) -> pd.DataFrame:
+    """Assigns a balancing authority code to each plant based on the plant id.
 
+    Args:
+         df (pd.DataFrame): data frame containing a 'plant_id_eia' column.
+         year (int): a four-digit year.
+
+     Returns:
+         pd.DataFrame: original data frame with additional 'ba_code' column.
+    """
     plant_ba = create_plant_ba_table(year)[
-        ["plant_id_eia", "ba_code", "ba_code_physical", "state"]
+        ["plant_id_eia", "ba_code", "ba_code_physical"]
     ]
 
     # merge the ba code into the dataframe
@@ -133,9 +156,14 @@ def assign_ba_code_to_plant(df, year):
     return df
 
 
-def create_plant_ba_table(year):
-    """
-    Creates a table assigning a ba_code and physical ba code to each plant id.
+def create_plant_ba_table(year: int) -> pd.DataFrame:
+    """Creates a table assigning a BA code and physical BA code to each plant ID.
+
+    Args:
+        year (int): a four-digit year.
+
+    Returns:
+        pd.DataFrame: table relating BA codes to plant ID.
     """
 
     plant_ba = load_data.load_pudl_table(
@@ -174,17 +202,11 @@ def create_plant_ba_table(year):
         plant_states, how="left", on="plant_id_eia", validate="m:1"
     )
 
-    # convert the dtype of the balancing authority code column from string to object
-    # this will allow for missing values to be filled
-    plant_ba["balancing_authority_code_eia"] = plant_ba[
-        "balancing_authority_code_eia"
-    ].astype(object)
-    plant_ba["balancing_authority_code_eia"] = plant_ba[
-        "balancing_authority_code_eia"
-    ].fillna(value=np.NaN)
-
     # load the ba name reference
-    ba_name_to_ba_code = pd.read_csv(reference_table_folder("ba_reference.csv"))
+    ba_name_to_ba_code = pd.read_csv(
+        reference_table_folder("ba_reference.csv"),
+        dtype={"ba_name": "string", "ba_code": "string"},
+    )
     ba_name_to_ba_code = dict(
         zip(
             ba_name_to_ba_code["ba_name"],
@@ -194,7 +216,8 @@ def create_plant_ba_table(year):
 
     # specify a ba code for certain utilities
     utility_as_ba_code = pd.read_csv(
-        reference_table_folder("utility_name_ba_code_map.csv")
+        reference_table_folder("utility_name_ba_code_map.csv"),
+        dtype={"name": "string", "ba_code": "string"},
     )
     utility_as_ba_code = dict(
         zip(
@@ -203,7 +226,8 @@ def create_plant_ba_table(year):
         )
     )
 
-    # fill missing BA codes first based on the BA name, then utility name, then on the transmisison owner name
+    # fill missing BA codes first based on the BA name, then utility name, then on
+    # the transmisison owner name
     plant_ba["balancing_authority_code_eia"] = plant_ba[
         "balancing_authority_code_eia"
     ].fillna(plant_ba["balancing_authority_name_eia"].map(ba_name_to_ba_code))
@@ -229,8 +253,9 @@ def create_plant_ba_table(year):
             retired_bas["retirement_date"].dt.year < year, "ba_code"
         ].unique()
     )
-    # if there are any plants that have been assigned to a retired BA, set its BA code as missing
-    plant_ba.loc[plant_ba["ba_code"].isin(retired_bas), "ba_code"] = np.NaN
+    # if there are any plants that have been assigned to a retired BA, set its BA code
+    # as missing
+    plant_ba.loc[plant_ba["ba_code"].isin(retired_bas), "ba_code"] = pd.NA
 
     # for plants without a BA code assign the miscellaneous BA code based on the state
     plant_ba["ba_code"] = plant_ba["ba_code"].fillna(plant_ba["state"] + "MS")
@@ -257,22 +282,55 @@ def create_plant_ba_table(year):
         validate="m:1",
     )
     plant_ba.update({"ba_code_physical": plant_ba["ba_code_physical_map"]})
+    plant_ba.drop(columns="state")
 
     return plant_ba
 
 
-def identify_distribution_connected_plants(df, year, voltage_threshold_kv=60):
-    """
-    Identifies which plant_id_eia are "distribution grid connected" based on a voltage threshold.
+def add_plant_nameplate_capacity(df: pd.DataFrame) -> pd.DataFrame:
+    """Adds nameplate capacity to input data frame.
 
-    The distribution grid is generally considered to operate at 60-69kV and below.
-    Thus, any plants that have a grid voltage under this threshold will be flagged as distribution connected.
     Args:
-        df: pandas dataframe with a column for plant_id_eia
-        voltage_threshold_kv: the voltage (kV) under which a plant will be considered to be a distribution asset
+        df (pd.DataFrame): table with a 'plant_id_eia' column.
+
     Returns:
-        df: with additional binary column `distribution_flag`
+        pd.DataFrame: original data frame with additional 'capacity_mw' column.
     """
+    generators_capacity = load_data.load_pudl_table(
+        "generators_eia860",
+        columns=["plant_id_eia", "generator_id", "report_date", "capacity_mw"],
+    )
+    generators_capacity[
+        generators_capacity["report_date"] == generators_capacity["report_date"].max()
+    ]
+    plants_capacity = (
+        generators_capacity.groupby(["plant_id_eia"])["capacity_mw"]
+        .sum()
+        .round(2)
+        .reset_index()
+    )
+
+    df = df.merge(plants_capacity, how="left", on=["plant_id_eia"], validate="1:1")
+
+    return df
+
+
+def identify_distribution_connected_plants(
+    df: pd.DataFrame, year: int, voltage_threshold_kv: int = 60
+) -> pd.DataFrame:
+    """Identifies which plant are "distribution grid connected" based on a voltage
+    threshold.
+
+    Args:
+        df (pd.DataFrame): table with a 'plant_id_eia' column.
+        year (int): a four-digit year.
+        voltage_threshold_kv (int, optional): the voltage (kV) under which a plant
+            will be considered to be a distribution asset. Defaults to 60.
+
+    Returns:
+        pd.DataFrame: original column with additional 'distribution_flag' binary column.
+    """
+
     # load the EIA-860 data
     plant_voltage = load_data.load_pudl_table(
         "plants_eia860", year, columns=["plant_id_eia", "grid_voltage_1_kv"]
@@ -295,18 +353,24 @@ def identify_distribution_connected_plants(df, year, voltage_threshold_kv=60):
 
 
 def assign_fuel_category_to_ESC(
-    df,
-    fuel_category_names=["fuel_category", "fuel_category_eia930"],
-    esc_column="energy_source_code",
-):
-    """
-    Assigns a fuel category to each energy source code in a dataframe.
+    df: pd.DataFrame,
+    fuel_category_names: list = ["fuel_category", "fuel_category_eia930"],
+    esc_column: str = "energy_source_code",
+) -> pd.DataFrame:
+    """Assigns a fuel category to each energy source code in a dataframe.
+
     Args:
-        df: pandas dataframe with column name that matches fuel_category_name and contains energy source codes
-        fuel_category_name: list of the columns in energy_source_groups.csv that contains the desired category mapping
-        esc_column: name of the column in df that contains the energy source codes to assign a category to
+        df (pd.DataFrame): table with column name that matches `fuel_category_names`
+            and 'energy_source_codes
+        fuel_category_names (list, optional): columns in
+            reference_tables/energy_source_groups.csv that contains the desired
+            category mapping. Defaults to ["fuel_category", "fuel_category_eia930"].
+        esc_column (str, optional): name of the column in `df` that contains the energy
+            source codes to assign a category to. Defaults to "energy_source_code".
+
     Returns:
-        df with additional column for fuel category
+        pd.DataFrame: original data frame with additional 'fuel_category_names'
+            column(s).
     """
     # load the fuel category table
     energy_source_groups = pd.read_csv(
@@ -325,11 +389,49 @@ def assign_fuel_category_to_ESC(
     return df
 
 
-def add_plant_local_timezone(df, year):
-    plant_tz = load_data.load_pudl_table(
-        "plants_entity_eia", columns=["plant_id_eia", "timezone"]
+def add_plant_entity(df: pd.DataFrame) -> pd.DataFrame:
+    """Adds timezone and geographical information to input data frame.
+
+    Args:
+        df (pd.DataFrame): table with a 'plant_id_eia' column.
+
+    Returns:
+        pd.DataFrame: original data frame with additional 'timezone', 'lat', 'lon',
+            'state', 'county', 'city', 'zip_code' and 'street_address' columns
+    """
+    eia860_info = [
+        "latitude",
+        "longitude",
+        "state",
+        "county",
+        "city",
+        "plant_name_eia",
+    ]
+    plants_entity = load_data.load_pudl_table(
+        "plants_entity_eia",
+        columns=["plant_id_eia", "timezone"] + eia860_info,
     )
-    df = df.merge(plant_tz, how="left", on=["plant_id_eia"], validate="m:1")
+    plants_entity_from_eia860 = load_data.load_raw_eia860_plant_geographical_info(
+        latest_validated_year
+    )
+    complete_plants_entity = plants_entity.merge(
+        plants_entity_from_eia860,
+        how="left",
+        on=["plant_id_eia"],
+        validate="1:1",
+        suffixes=["", "_eia"],
+    )
+
+    for c in eia860_info:
+        if complete_plants_entity[c].isna().sum() > 0:
+            complete_plants_entity[c] = complete_plants_entity[c].fillna(
+                complete_plants_entity[f"{c}_eia"]
+            )
+        complete_plants_entity = complete_plants_entity.drop(columns=f"{c}_eia")
+
+    df = df.merge(
+        complete_plants_entity, how="left", on=["plant_id_eia"], validate="m:1"
+    )
 
     return df
 


### PR DESCRIPTION
### Purpose
Add the following fields to the plant static attributes: "latitude", "longitude", "county", "city", "zip_code", "street_address" and "capacity_mw". Closes CAR-4208.

Add missing typehints and add/format docstrings in modules that were edited.

### What the code is doing
* Create a function to load the geographical information of the plants from the raw EIA-860 data
* Load the `plants_entity_eia` PUDL table to retrieve the geographical information of the plants
* Supplement the PUDL table with data from the raw EIA-860 when entries are missing
* Output the plant static attributes file to disk for years < 2019

### Testing
Successfully ran the 2010 pipeline.

### Where to look
The `oge.load_data` module where the new function load the geographical information from the raw EIA-860 and the `oge.helpers` module where fields to the plant static attributes data frame are added.

### Usage Example/Visuals
Screen shot of the exported 2010 plant static attributes table
<img width="1811" alt="Screenshot 2024-05-21 at 1 25 23 AM" src="https://github.com/singularity-energy/open-grid-emissions/assets/16549571/dec38fd5-bae6-430c-9b59-a530a44e8921">

### Review estimate
15min

### Future work
CAR-4205

### Checklist
- [x] Update the documentation to reflect changes made in this PR
- [x] Format all updated python files using `black`
- [x] Clear outputs from all notebooks modified
- [x] Add docstrings and type hints to any new functions created
