### PR TITLE
Add operating and retirement dates to plant static attributes

### DIFF
--- a/src/oge/column_checks.py
+++ b/src/oge/column_checks.py
@@ -203,6 +203,8 @@ COLUMNS = {
         "city",
         "plant_name_eia",
         "capacity_mw",
+        "plant_operating_date",
+        "plant_retirement_date",
     },
     "plant_metadata": {
         "plant_id_eia",
@@ -422,6 +424,7 @@ def get_dtypes():
         "ch4_mass_lb_adjusted": "float64",
         "ch4_mass_lb_for_electricity": "float64",
         "ch4_mass_lb_for_electricity_adjusted": "float64",
+        "city": "str",
         "co2_mass_lb": "float64",
         "co2_mass_lb_adjusted": "float64",
         "co2_mass_lb_for_electricity": "float64",
@@ -431,6 +434,7 @@ def get_dtypes():
         "co2e_mass_lb_adjusted": "float64",
         "co2e_mass_lb_for_electricity": "float64",
         "co2e_mass_lb_for_electricity_adjusted": "float64",
+        "county": "str",
         "data_availability": "category",
         "distribution_flag": "bool",
         "eia930_profile": "float64",
@@ -455,6 +459,8 @@ def get_dtypes():
         "hourly_data_source": "category",
         "hours_in_service": "float64",
         "imputed_profile": "float64",
+        "latitude": "float64",
+        "longitude": "float64",
         "mercury_control_id_eia": "str",
         "mercury_emission_rate_lb_per_trillion_btu": "float64",
         "mercury_removal_efficiency": "float64",
@@ -478,6 +484,7 @@ def get_dtypes():
         "particulate_removal_efficiency_at_full_load": "float64",
         "plant_id_eia": "Int32",
         "plant_id_epa": "Int32",
+        "plant_name_eia": "str",
         "plant_primary_fuel": "str",
         "plant_primary_fuel_from_capacity_mw": "str",
         "plant_primary_fuel_from_fuel_consumed_for_electricity_mmbtu": "str",
@@ -507,11 +514,6 @@ def get_dtypes():
         "subplant_primary_fuel_from_net_generation_mwh": "str",
         "timezone": "str",
         "wet_dry_bottom": "str",
-        "latitude": "float64",
-        "longitude": "float64",
-        "county": "str",
-        "city": "str",
-        "plant_name_eia": "str",
     }
 
     return dtypes_to_use
@@ -528,7 +530,16 @@ def apply_dtypes(df: pd.DataFrame) -> pd.DataFrame:
         pd.DataFrame: original data frame with type converted columns.
     """
     dtypes = get_dtypes()
-    datetime_columns = ["datetime_utc", "datetime_local", "report_date"]
+    datetime_columns = [
+        "datetime_utc",
+        "datetime_local",
+        "report_date",
+        "generator_operating_date",
+        "generator_retirement_date",
+        "current_planned_generator_operating_date",
+        "plant_operating_date",
+        "plant_retirement_date",
+    ]
     cols_missing_dtypes = [
         col
         for col in df.columns

--- a/src/oge/helpers.py
+++ b/src/oge/helpers.py
@@ -126,7 +126,31 @@ def create_plant_attributes_table(
     # add operating and retirement dates
     plant_attributes = add_plant_operating_and_retirement_dates(plant_attributes)
 
+    # convert types
     plant_attributes = apply_dtypes(plant_attributes)
+
+    # change order of columns
+    new_column_ordering = [
+        "plant_id_eia",
+        "plant_name_eia",
+        "capacity_mw",
+        "plant_primary_fuel",
+        "fuel_category",
+        "fuel_category_eia930",
+        "state",
+        "county",
+        "city",
+        "ba_code",
+        "ba_code_physical",
+        "latitude",
+        "longitude",
+        "plant_operating_date",
+        "plant_retirement_date",
+        "distribution_flag",
+        "timezone",
+        "data_availability",
+    ]
+    plant_attributes = plant_attributes[new_column_ordering]
 
     return plant_attributes
 

--- a/src/oge/helpers.py
+++ b/src/oge/helpers.py
@@ -205,6 +205,18 @@ def create_plant_ba_table(year: int) -> pd.DataFrame:
         ],
     )
 
+    # for some earlier years, the plants data is missing BA codes. 
+    # backfill and forwardfill to make sure that we have complete data for all years, if
+    # data is available for any year
+    for col in [
+        "balancing_authority_code_eia",
+        "utility_id_eia",
+        "balancing_authority_name_eia",
+        "transmission_distribution_owner_name",
+    ]:
+        plant_ba[col] = plant_ba.groupby(["plant_id_eia"])[col].bfill()
+        plant_ba[col] = plant_ba.groupby(["plant_id_eia"])[col].ffill()
+
     # remove report dates newer than the current year
     plant_ba = plant_ba[plant_ba["report_date"].dt.year <= year]
 

--- a/src/oge/helpers.py
+++ b/src/oge/helpers.py
@@ -205,7 +205,7 @@ def create_plant_ba_table(year: int) -> pd.DataFrame:
         ],
     )
 
-    # for some earlier years, the plants data is missing BA codes. 
+    # for some earlier years, the plants data is missing BA codes.
     # backfill and forwardfill to make sure that we have complete data for all years, if
     # data is available for any year
     for col in [


### PR DESCRIPTION
### Purpose
Add operating and retirement dates to plant static attributes.

A bug is fixed when calculating the nameplate capacity at the plant level

This PR also fixes an issue for years < 2013 where missing BA codes were being assigned, resulting in inaccurate BA-level results.

### What the code is doing
Create a new function that adds the operating and retirement dates of a plant to the plant static attributes data frame. The operating date of a plant is taken as the earliest date among all generators' operating date over all report dates. Likewise, the retirement date of a plant is taken as the latest date among all generators' retirement date over all report dates.

### Testing
Successfully ran the 2013 pipeline. 

### Where to look
* the new `add_plant_operating_and_retirement_dates` in the `oge.helpers` module.
* the `oge.column_checks` module where the new fields were added. Note that I added some missing datetime to the list of columns defined in the `apply_dtypes` function. These columns won't be converted.

### Usage Example/Visuals
<img width="1983" alt="Screenshot 2024-05-22 at 7 28 14 PM" src="https://github.com/singularity-energy/open-grid-emissions/assets/16549571/3a62e36e-a49b-4241-b42f-b610bc7f178a">

### Review estimate
10min

### Future work
N/A

### Checklist
- [x] Update the documentation to reflect changes made in this PR
- [x] Format all updated python files using `black`
- [x] Clear outputs from all notebooks modified
- [x] Add docstrings and type hints to any new functions created
