### PR TITLE
Add geopy to pyproject dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
 dependencies = [
   "cvxopt",
   "cvxpy",
+  "geopy",
   "osqp",
   "numpy",
   "openpyxl",


### PR DESCRIPTION
### Purpose
In https://github.com/singularity-energy/open-grid-emissions/pull/368 we added `geopy` as a dependency to OGE, but this dependency was not updated in the `pyproject.toml` file, which means that certain modules are unusable if imported into another repo. This PR adds this dependency.

