### PR TITLE
Compare plants coordinates from PUDL and EIA-860

### DIFF
--- a/notebooks/explore_data/compare_plant_coordinates.ipynb
+++ b/notebooks/explore_data/compare_plant_coordinates.ipynb
@@ -1,0 +1,231 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Compare Plant Coordinates from PUDL and EIA-860 "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "from math import acos, asin, cos, degrees, radians, sin, sqrt\n",
+    "\n",
+    "from oge.load_data import load_pudl_table, load_raw_eia860_plant_geographical_info"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plant_entity_pudl = load_pudl_table(\n",
+    "    \"core_eia__entity_plants\",\n",
+    "    columns=[\n",
+    "        \"plant_id_eia\",\n",
+    "        \"timezone\",\n",
+    "        \"latitude\",\n",
+    "        \"longitude\",\n",
+    "        \"state\",\n",
+    "        \"county\",\n",
+    "        \"city\",\n",
+    "    ],\n",
+    ").set_index(\"plant_id_eia\")\n",
+    "\n",
+    "plant_entity_eia860 = load_raw_eia860_plant_geographical_info(2022).set_index(\n",
+    "    \"plant_id_eia\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Take intersection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plant_in_common = plant_entity_pudl.index.intersection(plant_entity_eia860.index)\n",
+    "print(f\"Number of plants in both dataset: {len(plant_in_common)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Define helper functions to calculate angular distance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def ll2uv(lon: float, lat: float) -> list[float]:\n",
+    "    \"\"\"Convert (longitude, latitude) to unit vector.\n",
+    "\n",
+    "    Args:\n",
+    "        lon (float): longitude of the site (in deg.) measured eastward from\n",
+    "            Greenwich, UK.\n",
+    "        lat (float): latitude of the site (in deg.). Equator is the zero point.\n",
+    "\n",
+    "    Returns:\n",
+    "        list[float]: 3-components (x,y,z) unit vector.\n",
+    "    \"\"\"\n",
+    "    cos_lat = cos(radians(lat))\n",
+    "    sin_lat = sin(radians(lat))\n",
+    "    cos_lon = cos(radians(lon))\n",
+    "    sin_lon = sin(radians(lon))\n",
+    "\n",
+    "    uv = [cos_lat * cos_lon, cos_lat * sin_lon, sin_lat]\n",
+    "\n",
+    "    return uv\n",
+    "\n",
+    "\n",
+    "def angular_distance(uv1: list[float], uv2: list[float]) -> float:\n",
+    "    \"\"\"Calculate the angular distance between two vectors.\n",
+    "\n",
+    "    Args:\n",
+    "        uv1 (list[float]): 3-components vector as returned by the `ll2uv` function.\n",
+    "        uv2 (list[float]): 3-components vector as returned by the `ll2uv` function.\n",
+    "\n",
+    "    Returns:\n",
+    "        float -- angle (in degrees).\n",
+    "    \"\"\"\n",
+    "    cos_angle = uv1[0] * uv2[0] + uv1[1] * uv2[1] + uv1[2] * uv2[2]\n",
+    "    if cos_angle >= 1:\n",
+    "        cos_angle = 1\n",
+    "    if cos_angle <= -1:\n",
+    "        cos_angle = -1\n",
+    "    angle = degrees(acos(cos_angle))\n",
+    "\n",
+    "    return angle"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Calculate angular distance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plant_to_distance = {}\n",
+    "plant_to_distance_gt_1deg = {}\n",
+    "for i in plant_in_common:\n",
+    "    # ensure longitude and latitude are real number not NAs\n",
+    "    try:\n",
+    "        uv_pudl = ll2uv(\n",
+    "            plant_entity_pudl.loc[i, \"longitude\"], plant_entity_pudl.loc[i, \"latitude\"]\n",
+    "        )\n",
+    "        uv_eia860 = ll2uv(\n",
+    "            plant_entity_eia860.loc[i, \"longitude\"],\n",
+    "            plant_entity_eia860.loc[i, \"latitude\"],\n",
+    "        )\n",
+    "        distance = angular_distance(uv_pudl, uv_eia860)\n",
+    "        plant_to_distance[i] = distance\n",
+    "        if distance > 1:\n",
+    "            plant_to_distance_gt_1deg[i] = distance\n",
+    "    except TypeError:\n",
+    "        continue"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.subplots(figsize=(12, 6))\n",
+    "plt.hist(plant_to_distance.values(), bins=20, range=(0, 1))\n",
+    "plt.xlabel(\"Angular Distance between plant in PUDL and EIA-860 (in deg.)\", fontsize=12)\n",
+    "plt.ylabel(\"Count\", fontsize=12)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\n",
+    "    f\"Number of plants with an angular distance greater than 1 deg.: {len(plant_to_distance_gt_1deg)}\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.subplots(figsize=(12, 6))\n",
+    "plt.hist(plant_to_distance_gt_1deg.values(), bins=20, range=(1, 180))\n",
+    "plt.xlabel(\n",
+    "    \"Angular Distance between plant in PUDL and EIA-860 separated by more than 1 deg.\",\n",
+    "    fontsize=12,\n",
+    ")\n",
+    "plt.ylabel(\"Count\", fontsize=12)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plant_to_distance_gt_1deg"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "open-grid-emissions-zm3GQQDc",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
### Purpose
Compare plants coordinates from PUDL and EIA-860. Closes CAR-4443. 

Outputs from notebook will be cleared after review

### What the code is doing
* Load plants entity in PUDL and EIA-860
* Get plants available in both dataset
* Calculate for each plant the angular distance between its coordinates from PUDL and EIA-860

### Testing
N/A

### Where to look
Scroll through the notebook

### Usage Example/Visuals
![image](https://github.com/user-attachments/assets/92f8a3b8-5120-43a1-9b63-57f5555664e7)

### Review estimate
5min

### Future work
Look at plants with large angular separation

### Checklist
- [x] Update the documentation to reflect changes made in this PR
- [x] Format all updated python files using `black`
- [x] Clear outputs from all notebooks modified
- [x] Add docstrings and type hints to any new functions created
