### PR TITLE
Update warning message about validated years

### DIFF
--- a/src/oge/constants.py
+++ b/src/oge/constants.py
@@ -6,7 +6,7 @@ earliest_data_year = 2005
 # earliest_validated_year is the earliest data for which OGE data is currently published
 # and validated. The pipeline could be run for data prior to this year, but it has not
 # been validated
-earliest_validated_year = 2019
+earliest_validated_year = 2005
 # earliest_hourly_data_year is the most recent year for which OGE can produce hourly
 # profiles
 earliest_hourly_data_year = 2019

--- a/src/oge/data_pipeline.py
+++ b/src/oge/data_pipeline.py
@@ -85,13 +85,15 @@ def print_args(args: argparse.Namespace, logger):
 
 def main(args):
     """Runs the OGE data pipeline."""
+    args = get_args()
+    year = args.year
+
+    validation.validate_year(year)
+
     if os.getenv("OGE_DATA_STORE") in ["s3", "2"]:
         raise OSError(
             "Invalid OGE_DATA_STORE environment variable. Should be 'local' or '1'"
         )
-
-    args = get_args()
-    year = args.year
 
     # 0. Set up directory structure
     path_prefix = "" if not args.small else "small/"
@@ -134,7 +136,6 @@ def main(args):
     print_args(args, logger)
 
     logger.info(f"Running data pipeline for year {year}")
-    validation.validate_year(year)
 
     # 1. Download data
     ####################################################################################

--- a/src/oge/load_data.py
+++ b/src/oge/load_data.py
@@ -225,7 +225,7 @@ def load_complete_eia_generators_for_subplants() -> pd.DataFrame:
     under_construction_status_codes = ["U", "V", "TS"]
     complete_gens = complete_gens[
         ~(
-            (complete_gens["report_date"].dt.year < earliest_validated_year)
+            (complete_gens["report_date"].dt.year < latest_validated_year)
             & (
                 complete_gens["operational_status_code"].isin(
                     under_construction_status_codes

--- a/src/oge/validation.py
+++ b/src/oge/validation.py
@@ -8,7 +8,11 @@ from oge.column_checks import get_dtypes
 from oge.helpers import create_plant_ba_table
 from oge.filepaths import reference_table_folder, outputs_folder
 from oge.logging_util import get_logger
-from oge.constants import CLEAN_FUELS, earliest_validated_year, latest_validated_year
+from oge.constants import (
+    CLEAN_FUELS,
+    earliest_data_year,
+    latest_validated_year,
+)
 
 logger = get_logger(__name__)
 
@@ -18,27 +22,27 @@ logger = get_logger(__name__)
 
 
 def validate_year(year):
-    """Returns a warning if the year specified is not known to work with the pipeline."""
+    """Raises a warning if the year specified is not known to work with the pipeline.
 
-    if year < earliest_validated_year:
-        year_warning = f"""
-        ################################################################################
-        The data pipeline has only been validated to work for years {earliest_validated_year}-{latest_validated_year}.
-        Running the pipeline for {year} may cause it to fail or may lead to poor-quality
-        or anomalous results. To check on the progress of validating additional years of
-        data, see: https://github.com/singularity-energy/open-grid-emissions/issues/117
-        ################################################################################
-        """
-        logger.warning(year_warning)
-    elif year > latest_validated_year:
-        year_warning = f"""
-        ################################################################################
-        The most recent available year of input data is currently {latest_validated_year}.
-        Input data for {year} should be available from the EIA in Fall {year+1} and we will
-        work to validate that the pipeline works with {year} data as soon as possible
-        after the data is released.
-        ################################################################################
-        """
+    Args:
+        year (_type_): a four-digit year.
+
+    Raises:
+        UserWarning: if `year` is not supported.
+    """
+    start = earliest_data_year
+    end = latest_validated_year
+    year_warning = f"""
+    #########################################################################
+    Invalid year. The data pipeline has only been validated to work for years 
+    {start}-{end}. 
+    
+    Input data for {end+1} should be available from the EIA in Fall {end+2} and we 
+    will work to validate that the pipeline works with {end+1} data as soon as 
+    possible after the data is released.
+    #########################################################################
+    """
+    if year < earliest_data_year or year > latest_validated_year:
         raise UserWarning(year_warning)
 
 


### PR DESCRIPTION
### Purpose
Update the function validating the year when running the pipeline. Closes CAR-4450

### What the code is doing
Raise an exception if year passed to the `validate_year` function is not within `earliest_data_year` and `latest_validated_year`

### Testing
```log
2024-07-19 16:10:11 [INFO] oge.data_pipeline:83 

Running with the following options:
  * year = 2000
  * shape_individual_plants = True
  * small = False
  * flat = False
  * skip_outputs = False

2024-07-19 16:10:11 [INFO] oge.data_pipeline:136 Running data pipeline for year 2000
Traceback (most recent call last):
  File "/Users/brdo/Singularity/open-grid-emissions/src/oge/data_pipeline.py", line 713, in <module>
    main(sys.argv[1:])
  File "/Users/brdo/Singularity/open-grid-emissions/src/oge/data_pipeline.py", line 137, in main
    validation.validate_year(year)
  File "/Users/brdo/Singularity/open-grid-emissions/src/oge/validation.py", line 47, in validate_year
    raise UserWarning(year_warning)
UserWarning: 
    #########################################################################
    Invalid year. The data pipeline has only been validated to work for years 
    2005-2022. 
    
    Input data for 2023 should be available from the EIA in Fall 2024 and we 
    will work to validate that the pipeline works with 2023 data as soon as 
    possible after the data is released.
    #########################################################################
```
and:
```log
2024-07-19 16:10:42 [INFO] oge.data_pipeline:83 

Running with the following options:
  * year = 2023
  * shape_individual_plants = True
  * small = False
  * flat = False
  * skip_outputs = False

2024-07-19 16:10:42 [INFO] oge.data_pipeline:136 Running data pipeline for year 2023
Traceback (most recent call last):
  File "/Users/brdo/Singularity/open-grid-emissions/src/oge/data_pipeline.py", line 713, in <module>
    main(sys.argv[1:])
  File "/Users/brdo/Singularity/open-grid-emissions/src/oge/data_pipeline.py", line 137, in main
    validation.validate_year(year)
  File "/Users/brdo/Singularity/open-grid-emissions/src/oge/validation.py", line 47, in validate_year
    raise UserWarning(year_warning)
UserWarning: 
    #########################################################################
    Invalid year. The data pipeline has only been validated to work for years 
    2005-2022. 
    
    Input data for 2023 should be available from the EIA in Fall 2024 and we 
    will work to validate that the pipeline works with 2023 data as soon as 
    possible after the data is released.
    #########################################################################
```

### Where to look
Error message in the `validate_year` function.

### Usage Example/Visuals
N/A

### Review estimate
2min

### Future work
N/A

### Checklist
- [x] Update the documentation to reflect changes made in this PR
- [x] Format all updated python files using `black`
- [x] Clear outputs from all notebooks modified
- [x] Add docstrings and type hints to any new functions created
