### PR TITLE
Discard non-operational generators when calculating plant capacity

### DIFF
--- a/src/oge/helpers.py
+++ b/src/oge/helpers.py
@@ -443,7 +443,13 @@ def add_plant_nameplate_capacity(year: int, df: pd.DataFrame) -> pd.DataFrame:
         "core_eia860__scd_generators",
         year=earliest_data_year,
         end_year=latest_validated_year,
-        columns=["plant_id_eia", "generator_id", "report_date", "capacity_mw"],
+        columns=[
+            "plant_id_eia",
+            "generator_id",
+            "report_date",
+            "capacity_mw",
+            "operational_status",
+        ],
     ).sort_values(by=["plant_id_eia", "generator_id", "report_date"], ascending=True)
 
     generator_capacity["capacity_mw"] = generator_capacity.groupby(
@@ -452,6 +458,11 @@ def add_plant_nameplate_capacity(year: int, df: pd.DataFrame) -> pd.DataFrame:
     generator_capacity["capacity_mw"] = generator_capacity.groupby(
         ["plant_id_eia", "generator_id"]
     )["capacity_mw"].ffill()
+
+    # Only consider generators that are existing (operating, standby, etc.)
+    generator_capacity = generator_capacity[
+        generator_capacity["operational_status"] == "existing"
+    ]
 
     # keep only the specified year of data
     generator_capacity = generator_capacity[


### PR DESCRIPTION
### Purpose
Fix bug where nameplate capacity of non-operational generators were considered in the calculation of the nameplate capacity. Closes CAR-4479

### What the code is doing
Add a condition on the operational status.

### Testing
Compared nameplate capacity of plants 113, 117 and 2442 that were flagged with a wrong nameplate capacity before changes. 

### Where to look
Very few changes.

### Usage Example/Visuals
N/A

### Review estimate
2min

### Future work
N/A

### Checklist
- [x] Update the documentation to reflect changes made in this PR
- [x] Format all updated python files using `black`
- [x] Clear outputs from all notebooks modified
- [x] Add docstrings and type hints to any new functions created
