### PR TITLE
Update EPA/EIA crosswalk of plant 55641

### DIFF
--- a/src/oge/reference_tables/epa_eia_crosswalk_manual.csv
+++ b/src/oge/reference_tables/epa_eia_crosswalk_manual.csv
@@ -85,8 +85,8 @@ plant_id_epa,emissions_unit_id_epa,plant_id_eia,generator_id,notes
 61241,CT2,61241,VC-2,Manual fuzzy match of generator ID
 61242,CT1,61242,VP-1,Manual fuzzy match of generator ID
 61242,CT2,61242,VP-2,Manual fuzzy match of generator ID
-55641,CT-03,55641,CTG3,Manual fuzzy match of generator ID
-55641,CT-04,55641,CTG4,Manual fuzzy match of generator ID
+55641,CT-03,64020,CTG3,Proposed plant number changed when generator became operational
+55641,CT-04,64020,CTG4,Proposed plant number changed when generator became operational
 568,BHB5,568,501,Matched based on total net generation
 568,BHB5,568,502,Matched based on total net generation
 60925,CT1,60925,1A,Matched based on generator ID and prime mover code


### PR DESCRIPTION
### Purpose
Generators CTG3, CTG4, STG2, and PV1 were proposed to be added to the Riverside Energy Center (Plant 55641) and were in testing as of 2019 with scheduled COD in 2020. However, starting in the 2020 EIA data, these generators disappeared from this plant, and reappeared as the West Riverside Energy Center (Plant 64020). Closes CAR-4543.

2019 Proposed Generator Data:
![image](https://github.com/user-attachments/assets/80c5753e-f56c-4bb6-80cd-8ad67e083c2d)

2020 Operational Generator Data:
![image](https://github.com/user-attachments/assets/ceabb0df-65c4-490c-8371-43adc44e7b70)

I've updated the manual EPA-EIA crosswalk file to represent this. STG2 does not appear to directly show up in the data

### Testing
We would expect the subplant crosswalk to reflect the new mapping.

As expected, the EPA 55641 is no longer associated with those two units at EIA 55641 (although they still appear in the crosswalk, which is strange since they were never built)
![image](https://github.com/user-attachments/assets/1424596a-2433-430e-9d38-fd809d0ae158)
These two units are now associated with plant 64020, and are correctly linked to the same subplant as STG2
![image](https://github.com/user-attachments/assets/8ac8d711-4de4-4381-8951-987f20ed5530)



### Review estimate
5 min

### Future work
What issues were identified that are not being addressed in this PR but should be addressed in future work?

### Checklist
- [x] Update the documentation to reflect changes made in this PR
- [x] Format all updated python files using `black`
- [x] Clear outputs from all notebooks modified
- [x] Add docstrings and type hints to any new functions created
