### PR TITLE
Remove extra comma in energy source groups csv file

### DIFF
--- a/src/oge/reference_tables/energy_source_groups.csv
+++ b/src/oge/reference_tables/energy_source_groups.csv
@@ -3,7 +3,7 @@ AB,Agricultural Byproducts,other_biomass,other,biomass,biomass
 ANT,Anthracite Coal,coal,coal,coal,coal
 BFG,Blast Furnace Gas,natural_gas,natural_gas,other_fossil,natural_gas
 BIT,Bituminous Coal,coal,coal,coal,coal
-BU,Butane Gas,,petroleum_products,petroleum,oil,petroleum
+BU,Butane Gas,petroleum_products,petroleum,oil,petroleum
 BLQ,Black Liquor,wood,other,biomass,biomass
 COG,Coke Oven Gas,coal,coal,coal,coal
 DFO,Distillate Fuel Oil/Diesel,petroleum_products,petroleum,oil,petroleum


### PR DESCRIPTION
### Purpose
Remove extra comma in a CSV that was adding an extra empty field and in turn pandas' `read_csv` to fail

### What the code is doing
NA

### Testing
N/A

### Where to look
The **src/oge/reference_tables/energy_source_groups.csv** file

### Usage Example/Visuals
N/A

### Review estimate
1min

### Future work
N/A

### Checklist
- [x] Update the documentation to reflect changes made in this PR
- [x] Format all updated python files using `black`
- [x] Clear outputs from all notebooks modified
- [x] Add docstrings and type hints to any new functions created
