### PR TITLE
Expand EPA-EIA crosswalk manual table and create primary fuel manual table

### DIFF
--- a/src/oge/data_cleaning.py
+++ b/src/oge/data_cleaning.py
@@ -341,6 +341,19 @@ def create_primary_fuel_table(
         on="plant_id_eia",
         validate="many_to_one",
     )
+    # load manual manual assignment of primary fuel
+    # TODO: temporary fix. Need to be removed when EIA adds missing generators at
+    # plants listed in file
+    primary_fuel_manual = pd.read_csv(
+        reference_table_folder("temporary_primary_fuel_manual.csv")
+    )
+    primary_fuel_manual = primary_fuel_manual[primary_fuel_manual["year"] == year]
+
+    primary_fuel_table = pd.concat(
+        [primary_fuel_table, primary_fuel_manual.drop(columns=["year", "notes"])],
+        axis=0,
+        ignore_index=True,
+    ).sort_values(by=["plant_id_eia", "subplant_id"])
 
     return primary_fuel_table
 

--- a/src/oge/eia930.py
+++ b/src/oge/eia930.py
@@ -429,7 +429,7 @@ def manual_930_adjust(raw: pd.DataFrame):
     # we need to shift all data by +1 hour
     ba = "PJM"
     cols = get_columns(ba, raw.columns)
-    new = raw[cols].shift(1, freq="H")
+    new = raw[cols].shift(1, freq="h")
     raw = raw.drop(columns=cols)
     raw = pd.concat([raw, new], axis="columns")
 
@@ -539,4 +539,4 @@ def manual_930_adjust(raw: pd.DataFrame):
     raw = pd.concat([raw, pjm_dat], axis="columns")
 
     # Shift all -1 hour to make start-of-hour
-    return raw.shift(-1, freq="H")
+    return raw.shift(-1, freq="h")

--- a/src/oge/reference_tables/epa_eia_crosswalk_manual.csv
+++ b/src/oge/reference_tables/epa_eia_crosswalk_manual.csv
@@ -157,3 +157,37 @@ plant_id_epa,emissions_unit_id_epa,plant_id_eia,generator_id,start_year,end_year
 1571,SMECO,65285,GT1,2021,2022,This generator switches plant IDs for two years then switches back to its original plant ID
 1571,1,65285,ST1,2021,,This generator switches plant IDs the year it retires (2021)
 1571,2,65285,ST2,2021,,This generator switches plant IDs the year it retires (2021)
+3,8,3,A3C1,,,This generator (CEMS unit) had no CEMS unit (generator) assigned
+3,8,3,A3ST,,,This generator (CEMS unit) had no CEMS unit (generator) assigned
+47,CCT10,47,GT10,,,This generator (CEMS unit) had no CEMS unit (generator) assigned
+47,CCT11,47,GT11,,,This generator (CEMS unit) had no CEMS unit (generator) assigned
+47,CCT9,47,GT9,,,This generator (CEMS unit) had no CEMS unit (generator) assigned
+56,CC1,56,LEC1,,,This generator (CEMS unit) had no CEMS unit (generator) assigned
+56,CC1,56,LEC2,,,This generator (CEMS unit) had no CEMS unit (generator) assigned
+136,CT1,136,CT1,,,Matched based on generator ID
+136,CT2,136,CT2,,,Matched based on generator ID
+492,A1,492,A1,,,Matched based on generator ID
+492,A2,492,A2,,,Matched based on generator ID
+492,A3,492,A3,,,Matched based on generator ID
+492,A4,492,A4,,,Matched based on generator ID
+492,A5,492,A5,,,Matched based on generator ID
+492,A6,492,A6,,,Matched based on generator ID
+54271,A01,54271,CTG1,,,Matched based on generator ID and fuel consumption
+54271,A02,54271,CTG2,,,Matched based on generator ID and fuel consumption
+56350,CT-4B,56350,CT4B,,,Matched based on generator ID
+60387,3,60387,GEN3,,,Matched based on generator ID
+60387,4,60387,GEN4,,,Matched based on generator ID
+62949,P001,62949,GPS1,,,Matched based on generator ID
+62949,P002,62949,GPS2,,,Matched based on generator ID
+62949,P003,62949,GPS3,,,Matched based on generator ID
+63931,1,63931,GEN1,,,Matched based on generator ID
+63931,2,63931,GEN2,,,Matched based on generator ID
+65372,CT-4,65372,CTG-4,,,Matched based on generator ID
+65372,CT-5,65372,CTG-5,,,Matched based on generator ID
+65372,CT-6,65372,CTG-6,,,Matched based on generator ID
+65373,CT-1,65373,CTG-1,,,Matched based on generator ID
+65373,CT-2,65373,CTG-2,,,Matched based on generator ID
+65373,CT-3,65373,CTG-3,,,Matched based on generator ID
+65373,CT-4,65373,CTG-4,,,Matched based on generator ID
+65373,CT-5,65373,CTG-5,,,Matched based on generator ID
+65373,CT-6,65373,CTG-6,,,Matched based on generator ID

--- a/src/oge/reference_tables/temporary_primary_fuel_manual.csv
+++ b/src/oge/reference_tables/temporary_primary_fuel_manual.csv
@@ -1,0 +1,3 @@
+plant_id_eia,subplant_id,energy_source_code,subplant_primary_fuel,plant_primary_fuel,year,notes
+65373,7,NG,NG,NG,2023,CEMS unit ID but no EIA generator ID
+65373,8,NG,NG,NG,2023,CEMS unit ID but no EIA generator ID


### PR DESCRIPTION
### Purpose
When running the 2023 pipeline, I encountered the following error:
```
2024-12-02 11:57:59 [INFO] oge.data_pipeline:370 11. Exporting monthly and annual plant-level results
2024-12-02 11:58:32 [WARNING] oge.oge.helpers:328                                                 net_generation_mwh
plant_id_eia subplant_id ba_code fuel_category                    
3            9           SOCO    <NA>                 2.744806e+05
47           17          TVA     <NA>                 3.646287e+04
             18          TVA     <NA>                 4.581131e+04
             19          TVA     <NA>                 4.091488e+04
56           5           SOCO    <NA>                 1.702325e+06
136          4           SEC     <NA>                 2.810318e+06
             5           SEC     <NA>                 2.827317e+06
492          10          WACM    <NA>                 2.271158e+04
             11          WACM    <NA>                 2.587960e+04
             12          WACM    <NA>                 2.094618e+04
             13          WACM    <NA>                 2.462927e+04
             14          WACM    <NA>                 2.398325e+04
             15          WACM    <NA>                 2.152721e+04
54271        2           NEVP    <NA>                 1.046688e+05
             3           NEVP    <NA>                 1.038608e+05
56350        5           ERCO    <NA>                 4.624383e+04
60387        3           PJM     <NA>                 1.394996e+05
             4           PJM     <NA>                 1.238671e+05
62949        4           PJM     <NA>                 3.083711e+06
             5           PJM     <NA>                 2.650896e+06
             6           PJM     <NA>                 2.618570e+06
63931        3           PJM     <NA>                 1.648514e+06
             4           PJM     <NA>                 1.738279e+06
65372        7           ERCO    <NA>                 1.669801e+04
             8           ERCO    <NA>                 1.366411e+04
             9           ERCO    <NA>                 1.474079e+04
65373        7           ERCO    <NA>                 4.413112e+04
             8           ERCO    <NA>                 4.159748e+04
             9           ERCO    <NA>                 2.679625e+04
             10          ERCO    <NA>                 3.826553e+04
             11          ERCO    <NA>                 3.338158e+04
             12          ERCO    <NA>                 3.398007e+04
             13          ERCO    <NA>                 2.097722e+04
             14          ERCO    <NA>                 2.079486e+04
Traceback (most recent call last):
  File "/Users/brdo/Singularity/open-grid-emissions/src/oge/data_pipeline.py", line 704, in <module>
    main(sys.argv[1:])
  File "/Users/brdo/Singularity/open-grid-emissions/src/oge/data_pipeline.py", line 376, in main
    validation.identify_percent_of_data_by_input_source(
  File "/Users/brdo/Singularity/open-grid-emissions/src/oge/validation.py", line 1408, in identify_percent_of_data_by_input_source
    cems = assign_fleet_to_subplant_data(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/brdo/Singularity/open-grid-emissions/src/oge/helpers.py", line 345, in assign_fleet_to_subplant_data
    raise UserWarning(
UserWarning: The plant attributes table is missing ba_code or fuel_category data for some plants. This will result in incomplete power sector results.
```
To the exception of two generators at `plant_id_eia` 65373 (Brotman, TX), this has been fixed by expanding the mapping the CEMS' `emissions_unit_id_epa` to the EIA's `generator_id` in the **src/oge/reference_tables/epa_eia_crosswalk_manual.csv** file. There are 2 additional generator at this power station that consume natural gas that can be find in the EPA's CAMPD database but not in EIA-860. The remedy was to create a new  **src/oge/reference_tables/primary_fuel_manual.csv** table that assigns fuel dor the subplant/plant.


### What the code is doing
Load the **src/oge/reference_tables/primary_fuel_manual.csv** table and merge it to the `primary_fuel_table` data frame in the `data_cleaning.create_primary_fuel_table` function 

### Testing
Successfully ran the 2023 pipeline

### Where to look
The manual tables

### Usage Example/Visuals
N/A

### Review estimate
10min

### Future work
N/A

### Checklist
- [x] Update the documentation to reflect changes made in this PR
- [x] Format all updated python files using `black`
- [x] Clear outputs from all notebooks modified
- [x] Add docstrings and type hints to any new functions created
