### PR TITLE
Clean up warnings for 2023 data pipeline

### DIFF
--- a/notebooks/manual_data/update_steam_units_to_remove.ipynb
+++ b/notebooks/manual_data/update_steam_units_to_remove.ipynb
@@ -131,7 +131,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "open-grid-emissions-zm3GQQDc",
+   "display_name": "open-grid-emissions-QkuIZ37I",
    "language": "python",
    "name": "python3"
   },
@@ -145,7 +145,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.2"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/src/oge/data_cleaning.py
+++ b/src/oge/data_cleaning.py
@@ -924,7 +924,9 @@ def remove_unmapped_fuel(cems: pd.DataFrame, year: int) -> pd.DataFrame:
             "These may need to be mapped to prevent double-counting of generation"
         )
         logger.error(
-            validation.limit_error_output_df(potential_missing_map.to_string())
+            validation.limit_error_output_df(potential_missing_map).to_string(
+                index=False
+            )
         )
 
     # flag units that report fuel input but no generation or steam output, and which
@@ -947,7 +949,7 @@ def remove_unmapped_fuel(cems: pd.DataFrame, year: int) -> pd.DataFrame:
             "To prevent these fuel and emissions from being counted, they will be removed"
         )
         logger.warning(
-            validation.limit_error_output_df(fuel_only_unmapped.to_string(index=False))
+            validation.limit_error_output_df(fuel_only_unmapped).to_string(index=False)
         )
 
         cems = cems.merge(
@@ -1191,7 +1193,7 @@ def identify_and_remove_steam_only_units(cems: pd.DataFrame, year: int) -> pd.Da
             "To prevent these fuel and emissions from being counted, they will be removed"
         )
         logger.warning(
-            validation.limit_error_output_df(steam_only_unmapped.to_string(index=False))
+            validation.limit_error_output_df(steam_only_unmapped).to_string(index=False)
         )
 
         cems = cems.merge(
@@ -1218,7 +1220,7 @@ def identify_and_remove_steam_only_units(cems: pd.DataFrame, year: int) -> pd.Da
             "This may result in anomalous results for these units until steam output data is handled in the pipeline"
         )
         logger.warning(
-            validation.limit_error_output_df(mapped_steam.to_string(index=False))
+            validation.limit_error_output_df(mapped_steam).to_string(index=False)
         )
 
     return cems

--- a/src/oge/data_cleaning.py
+++ b/src/oge/data_cleaning.py
@@ -972,7 +972,7 @@ def clean_cems(year: int, small: bool, primary_fuel_table, subplant_emission_fac
     # load the CEMS data
     cems = load_data.load_cems_data(year)
 
-    cems = remove_negative_cems_data(cems)
+    cems = remove_negative_cems_data(cems, year)
 
     if small:
         cems = smallerize_test_data(df=cems, random_seed=42)

--- a/src/oge/data_cleaning.py
+++ b/src/oge/data_cleaning.py
@@ -1184,13 +1184,10 @@ def identify_and_remove_steam_only_units(cems: pd.DataFrame, year: int) -> pd.Da
     ]
     if len(steam_only_unmapped) > 0:
         logger.warning(
-            "The following CEMS units report fuel consumption but no generation or steam output"
+            "The following CEMS units report only steam output and are missing a generator ID mapping"
         )
         logger.warning(
-            "These units also are missing a mapping to an EIA generator, meaning they will have their own subplant ID"
-        )
-        logger.warning(
-            "To prevent these fuel and emissions from being counted, they will be removed"
+            "This means they would have their own subplant ID and potentially be double counted, so will be removed"
         )
         logger.warning(
             validation.limit_error_output_df(steam_only_unmapped).to_string(index=False)
@@ -1211,7 +1208,9 @@ def identify_and_remove_steam_only_units(cems: pd.DataFrame, year: int) -> pd.Da
     # flag units that report non-zero steam output and are mapped to a generator. We
     # are still not entirely certain how to interpret steam data in CEMS, so its
     # inclusion could result in potentially anomalous results
-    mapped_steam = annual_cems[(annual_cems["steam_load_1000_lb"] > 0)]
+    mapped_steam = annual_cems[
+        (annual_cems["steam_load_1000_lb"] > 0) & (~annual_cems["generator_id"].isna())
+    ]
     if len(mapped_steam) > 0:
         logger.warning(
             "The following CEMS units report non-zero steam output and are mapped to an EIA generator"

--- a/src/oge/data_cleaning.py
+++ b/src/oge/data_cleaning.py
@@ -307,6 +307,11 @@ def create_primary_fuel_table(
         validate_merge="m:1",
     )
 
+    # flag and remove any missing ESCs
+    gen_fuel_allocated = validation.test_for_missing_energy_source_code(
+        gen_fuel_allocated, drop_missing=True
+    )
+
     # get a table of primary energy source codes by generator
     # this will be used in `calculate_aggregated_primary_fuel()` to determine the
     # mode of energy source codes by plant
@@ -1976,6 +1981,7 @@ def aggregate_subplant_data_to_fleet(
     combined_subplant_data: pd.DataFrame,
     plant_attributes_table: pd.DataFrame,
     primary_fuel_table: pd.DataFrame,
+    year: int,
 ) -> pd.DataFrame:
     """Group plant data by BA and fuel category (fleet).
 
@@ -1997,6 +2003,7 @@ def aggregate_subplant_data_to_fleet(
         combined_subplant_data,
         plant_attributes_table,
         primary_fuel_table,
+        year,
         ba_col="ba_code",
         primary_fuel_col="subplant_primary_fuel",
         fuel_category_col="fuel_category",

--- a/src/oge/data_cleaning.py
+++ b/src/oge/data_cleaning.py
@@ -164,6 +164,7 @@ def clean_eia923(
     gen_fuel_allocated = emissions.adjust_emissions_for_biomass(gen_fuel_allocated)
 
     # adjust emissions for CHP
+    logger.info("Adding subplant_id to gen_fuel_allocated for CHP adjustment")
     gen_fuel_allocated = add_subplant_ids_to_df(
         gen_fuel_allocated,
         year,
@@ -208,6 +209,7 @@ def clean_eia923(
     ].round(1)
 
     # map subplant ids to the data
+    logger.info("Adding subplant_id to gen_fuel_allocated")
     gen_fuel_allocated = add_subplant_ids_to_df(
         gen_fuel_allocated,
         year,
@@ -286,7 +288,7 @@ def create_primary_fuel_table(
     Returns:
         pd.DataFrame: the primary fuel table.
     """
-
+    logger.info("Creating Primary Fuel Table")
     # add under construction generators to the dataframe
     gen_fuel_allocated = add_under_construction_generator_ids_to_df(
         gen_fuel_allocated, year
@@ -296,6 +298,7 @@ def create_primary_fuel_table(
     )
 
     # add subplant ids so that we can create subplant-specific primary fuels
+    logger.info("Adding subplant_id to gen_fuel_allocated for primary_fuel_table")
     gen_fuel_allocated = add_subplant_ids_to_df(
         gen_fuel_allocated,
         year,
@@ -522,6 +525,7 @@ def calculate_capacity_based_primary_fuel(
     )
 
     if "subplant_id" in agg_keys:
+        logger.info("Adding subplant_id to gen_capacity")
         gen_capacity = add_subplant_ids_to_df(
             gen_capacity,
             year,
@@ -592,7 +596,7 @@ def add_under_construction_generator_ids_to_df(
     ).rename(columns={"energy_source_code_1": "energy_source_code"})
 
     # keep operating generators and proposed generators that are already under construction
-    under_construction_status_codes = ["U", "V", "TS"]
+    under_construction_status_codes = ["U", "V", "TS", "OT"]
     gen_cap_under_construction = gen_capacity[
         (
             (gen_capacity["operational_status"] == "proposed")
@@ -605,6 +609,7 @@ def add_under_construction_generator_ids_to_df(
     ]
 
     # add subplant_ids
+    logger.info("Adding subplant_id to gen_cap_under_construction")
     gen_cap_under_construction = add_subplant_ids_to_df(
         gen_cap_under_construction,
         year,
@@ -678,6 +683,7 @@ def add_recently_retired_generator_ids_to_df(
     ]
 
     # add subplant_ids
+    logger.info("Adding subplant_id to gen_cap_recently_retired")
     gen_cap_recently_retired = add_subplant_ids_to_df(
         gen_cap_recently_retired,
         year,
@@ -928,6 +934,7 @@ def clean_cems(year: int, small: bool, primary_fuel_table, subplant_emission_fac
     # See: https://github.com/singularity-energy/open-grid-emissions/issues/50
 
     # add subplant id
+    logger.info("Adding subplant_id to cems")
     cems = add_subplant_ids_to_df(
         cems,
         year,
@@ -1177,6 +1184,7 @@ def assign_fuel_type_to_cems(cems, year, primary_fuel_table):
             year,
             columns=["plant_id_eia", "generator_id", "energy_source_code_1"],
         ).drop_duplicates()
+        logger.info("Adding subplant_id to gen_fuel for cems fuel assignment")
         gen_fuel = add_subplant_ids_to_df(
             gen_fuel, year, "generator_id", how_merge="inner", validate_merge="1:1"
         )

--- a/src/oge/data_pipeline.py
+++ b/src/oge/data_pipeline.py
@@ -168,7 +168,7 @@ def main(args):
         "subplant_crosswalk",
         path_prefix,
         year,
-        args.skip_outputs,
+        skip_outputs=False,  # always output the crosswalk because it is loaded later
     )
 
     # 3. Clean EIA-923 Generation and Fuel Data at the Monthly Level
@@ -185,7 +185,7 @@ def main(args):
         "primary_fuel_table",
         path_prefix,
         year,
-        args.skip_outputs,
+        skip_outputs=False,
     )
     # Add primary fuel data to each generator
     eia923_allocated = eia923_allocated.merge(

--- a/src/oge/data_pipeline.py
+++ b/src/oge/data_pipeline.py
@@ -426,7 +426,7 @@ def main(args):
     logger.info("12. Exporting monthly and annual fleet-level results")
     # output monthly/annual power sector results
     fleet_data = data_cleaning.aggregate_subplant_data_to_fleet(
-        monthly_subplant_data, plant_attributes, primary_fuel_table
+        monthly_subplant_data, plant_attributes, primary_fuel_table, year
     )
     output_data.write_power_sector_results(
         fleet_data, year, path_prefix, args.skip_outputs, include_hourly=False
@@ -545,7 +545,7 @@ def main(args):
         logger.info("16. Assigning hourly profiles to monthly EIA-923 data")
         # Aggregate EIA data to BA/fuel/month, then assign hourly profile per BA/fuel
         monthly_eia_fleet_data = impute_hourly_profiles.aggregate_eia_data_to_fleet(
-            monthly_eia_data_to_shape, plant_attributes, primary_fuel_table
+            monthly_eia_data_to_shape, plant_attributes, primary_fuel_table, year
         )
         shaped_eia_fleet_data = impute_hourly_profiles.shape_monthly_eia_data_as_hourly(
             monthly_eia_fleet_data,
@@ -653,7 +653,7 @@ def main(args):
         )
         # aggregate CEMS data to the fleet level
         cems_fleet_data = data_cleaning.aggregate_subplant_data_to_fleet(
-            combined_cems_subplant_data, plant_attributes, primary_fuel_table
+            combined_cems_subplant_data, plant_attributes, primary_fuel_table, year
         )
         del combined_cems_subplant_data
 

--- a/src/oge/gross_to_net_generation.py
+++ b/src/oge/gross_to_net_generation.py
@@ -513,6 +513,7 @@ def calculate_subplant_nameplate_capacity(year):
     )
 
     # add subplant ids to the generator data
+    logger.info("Adding subplant_id to gen_capacity")
     gen_capacity = add_subplant_ids_to_df(
         gen_capacity,
         year,

--- a/src/oge/helpers.py
+++ b/src/oge/helpers.py
@@ -342,10 +342,10 @@ def assign_fleet_to_subplant_data(
             validate="m:1",
             suffixes=(None, "_fill"),
         )
-        subplant_data[primary_fuel_col] = subplant_data[primary_fuel_col].fillna(
-            subplant_data[f"{primary_fuel_col}_fill"]
+        subplant_data[fuel_category_col] = subplant_data[fuel_category_col].fillna(
+            subplant_data[f"{fuel_category_col}_fill"]
         )
-        subplant_data = subplant_data.drop(columns=[f"{primary_fuel_col}_fill"])
+        subplant_data = subplant_data.drop(columns=[f"{fuel_category_col}_fill"])
 
     # check that there is no missing ba or fuel codes for subplants with nonzero gen
     # for CEMS data, check only units that report positive gross generaiton
@@ -377,7 +377,7 @@ def assign_fleet_to_subplant_data(
             )
         ]
     if len(missing_fleet_keys) > 0:
-        logger.warning(
+        logger.error(
             missing_fleet_keys.groupby(
                 [
                     "plant_id_eia",
@@ -390,9 +390,12 @@ def assign_fleet_to_subplant_data(
             .sum()
             .to_string()
         )
-        raise UserWarning(
+        logger.error(
             "The plant attributes table is missing ba_code or fuel_category data for some plants. This will result in incomplete power sector results."
         )
+        """raise UserWarning(
+            "The plant attributes table is missing ba_code or fuel_category data for some plants. This will result in incomplete power sector results."
+        )"""
 
     return subplant_data
 

--- a/src/oge/helpers.py
+++ b/src/oge/helpers.py
@@ -310,18 +310,28 @@ def assign_fleet_to_subplant_data(
     if "gross_generation_mwh" in subplant_data.columns:
         missing_fleet_keys = subplant_data[
             (
-                (subplant_data["ba_code"].isna())
-                | (subplant_data[fuel_category_col].isna())
-                & (subplant_data["gross_generation_mwh"] > 0)
+                (
+                    (subplant_data["ba_code"].isna())
+                    | (subplant_data[fuel_category_col].isna())
+                )
+                & (
+                    (subplant_data["gross_generation_mwh"] > 0)
+                    | (subplant_data["fuel_consumed_for_electricity_mmbtu"] > 0)
+                )
             )
         ]
     # otherwise, check units that report non-zero net generation
     else:
         missing_fleet_keys = subplant_data[
             (
-                (subplant_data["ba_code"].isna())
-                | (subplant_data[fuel_category_col].isna())
-                & (subplant_data["net_generation_mwh"] != 0)
+                (
+                    (subplant_data["ba_code"].isna())
+                    | (subplant_data[fuel_category_col].isna())
+                )
+                & (
+                    (subplant_data["net_generation_mwh"] != 0)
+                    | (subplant_data["fuel_consumed_for_electricity_mmbtu"] != 0)
+                )
             )
         ]
     if len(missing_fleet_keys) > 0:
@@ -334,11 +344,7 @@ def assign_fleet_to_subplant_data(
                     fuel_category_col,
                 ],
                 dropna=False,
-            )[
-                [
-                    "net_generation_mwh",
-                ]
-            ]
+            )[["net_generation_mwh", "fuel_consumed_for_electricity_mmbtu"]]
             .sum()
             .to_string()
         )

--- a/src/oge/impute_hourly_profiles.py
+++ b/src/oge/impute_hourly_profiles.py
@@ -757,6 +757,7 @@ def identify_missing_profiles(
         residual_profiles (pd.DataFrame): used to determine which profiles are available
         plant_attributes (pd.DataFrame): used to identify fleet keys
         primary_fuel_table (pd.DataFrame): used to identify fleet keys
+        year (int): the data year
 
     Returns:
         pd.DataFrame: table with three columns (ba_code, fuel_category, report_date)
@@ -1273,6 +1274,7 @@ def aggregate_eia_data_to_fleet(
             shaped
         plant_attributes (pd.DataFrame): for assigning fleet keys
         primary_fuel_table (pd.DataFrame): for assigning fleet keys
+        year (int): the data year
 
     Returns:
         pd.DataFrame: returns eia_agg, which is aggregated to the fleet-month level

--- a/src/oge/impute_hourly_profiles.py
+++ b/src/oge/impute_hourly_profiles.py
@@ -93,7 +93,7 @@ def calculate_hourly_profiles(
         year,
     )
     hourly_profiles = add_cems_backstop_profile(
-        hourly_profiles, cems, plant_attributes, primary_fuel_table
+        hourly_profiles, cems, plant_attributes, primary_fuel_table, year
     )
 
     # if there are any months that have incomplete cems data, replace the cems profile with na
@@ -323,6 +323,7 @@ def aggregate_cems_to_fleet_for_residual_calc(
         subplant_data=cems_agg,
         plant_attributes_table=plant_attributes,
         primary_fuel_table=primary_fuel_table,
+        year=year,
         ba_col=ba_column_name,
         primary_fuel_col="subplant_primary_fuel_from_capacity_mw",
         fuel_category_col="fuel_category_eia930",
@@ -658,6 +659,7 @@ def impute_missing_hourly_profiles(
         residual_profiles,
         plant_attributes,
         primary_fuel_table,
+        year,
     )
 
     # load information about directly interconnected balancing authorities (DIBAs)
@@ -745,6 +747,7 @@ def identify_missing_profiles(
     residual_profiles: pd.DataFrame,
     plant_attributes: pd.DataFrame,
     primary_fuel_table: pd.DataFrame,
+    year,
 ) -> pd.DataFrame:
     """Identifies the fleet-months for which there is no profile data in residual_profiles
 
@@ -774,6 +777,7 @@ def identify_missing_profiles(
         monthly_eia_data_to_shape,
         plant_attributes,
         primary_fuel_table,
+        year,
         ba_col="ba_code",
         primary_fuel_col="subplant_primary_fuel_from_capacity_mw",
         fuel_category_col="fuel_category",
@@ -871,6 +875,7 @@ def add_cems_backstop_profile(
     cems: pd.DataFrame,
     plant_attributes: pd.DataFrame,
     primary_fuel_table: pd.DataFrame,
+    year,
 ) -> pd.DataFrame:
     """Adds a "cems_profile" column to hourly_profiles to use as a backstop where
     residuals are not available.
@@ -896,6 +901,7 @@ def add_cems_backstop_profile(
         cems,
         plant_attributes,
         primary_fuel_table,
+        year,
         ba_col="ba_code",
         primary_fuel_col="subplant_primary_fuel_from_capacity_mw",
         fuel_category_col="fuel_category",
@@ -1099,6 +1105,7 @@ def combine_and_export_hourly_plant_data(
         monthly_eia_data_to_shape,
         plant_attributes,
         primary_fuel_table,
+        year,
         ba_col="ba_code",
         primary_fuel_col="subplant_primary_fuel_from_capacity_mw",
         fuel_category_col="fuel_category",
@@ -1250,6 +1257,7 @@ def aggregate_eia_data_to_fleet(
     monthly_eia_data_to_shape: pd.DataFrame,
     plant_attributes: pd.DataFrame,
     primary_fuel_table: pd.DataFrame,
+    year: int,
 ) -> pd.DataFrame:
     """Aggregates monthly EIA-923 data to the fleet level prior to assigning an hourly
     profile
@@ -1277,6 +1285,7 @@ def aggregate_eia_data_to_fleet(
         monthly_eia_data_to_shape,
         plant_attributes,
         primary_fuel_table,
+        year,
         ba_col="ba_code",
         primary_fuel_col="subplant_primary_fuel_from_capacity_mw",
         fuel_category_col="fuel_category",
@@ -1288,6 +1297,7 @@ def aggregate_eia_data_to_fleet(
         eia_agg,
         plant_attributes,
         primary_fuel_table,
+        year,
         ba_col="ba_code",
         primary_fuel_col="subplant_primary_fuel",
         fuel_category_col="fuel_category",

--- a/src/oge/load_data.py
+++ b/src/oge/load_data.py
@@ -701,6 +701,7 @@ def load_epa_eia_crosswalk_from_raw(year: int) -> pd.DataFrame:
             "EIA_BOILER_ID",
             "EIA_FUEL_TYPE",
             "CAMD_FUEL_TYPE",
+            "MATCH_TYPE_GEN",
         ],
     )
 
@@ -725,6 +726,7 @@ def load_epa_eia_crosswalk_from_raw(year: int) -> pd.DataFrame:
             "EIA_BOILER_ID": "boiler_id",
             "EIA_FUEL_TYPE": "energy_source_code_eia",
             "CAMD_FUEL_TYPE": "energy_source_code_epa",
+            "MATCH_TYPE_GEN": "epa_match_type",
         }
     )
 

--- a/src/oge/load_data.py
+++ b/src/oge/load_data.py
@@ -681,6 +681,8 @@ def load_epa_eia_crosswalk_from_raw(year: int) -> pd.DataFrame:
 
     This is only used data_cleaning.assign_fuel_type_to_cems() to access the
     CAMD_FUEL_TYPE column, which is dropped from the PUDL version of the table.
+    This is also used in data_cleaning.remove_non_grid_connected_plants() to identify
+    the units that CAMD identified as NGC.
 
     Args:
         year (int): a four-digit year.
@@ -797,6 +799,8 @@ def load_epa_eia_crosswalk_from_raw(year: int) -> pd.DataFrame:
 
 def load_epa_eia_crosswalk(year: int) -> pd.DataFrame:
     """Read in the manual EPA-EIA Crosswalk table.
+
+    This is currently only used for subplant identification
 
     Args:
         year (int): a four-digit year.

--- a/src/oge/load_data.py
+++ b/src/oge/load_data.py
@@ -487,10 +487,8 @@ def update_epa_to_eia_map(cems_df: pd.DataFrame, year: int) -> pd.DataFrame:
         & (year <= manual_plant_map["end_year"])
     ].drop(columns=["start_year", "end_year"])
 
-    # only keep rows where the epa and eia plant ids don't match
-    manual_plant_map = manual_plant_map.loc[
-        manual_plant_map["plant_id_epa"] != manual_plant_map["plant_id_eia"],
-        ["plant_id_epa", "emissions_unit_id_epa", "plant_id_eia"],
+    manual_plant_map = manual_plant_map[
+        ["plant_id_epa", "emissions_unit_id_epa", "plant_id_eia"]
     ].drop_duplicates()
 
     # merge into the cems data

--- a/src/oge/reference_tables/epa_eia_crosswalk_manual.csv
+++ b/src/oge/reference_tables/epa_eia_crosswalk_manual.csv
@@ -191,3 +191,31 @@ plant_id_epa,emissions_unit_id_epa,plant_id_eia,generator_id,start_year,end_year
 65373,CT-4,65373,CTG-4,,,Matched based on generator ID
 65373,CT-5,65373,CTG-5,,,Matched based on generator ID
 65373,CT-6,65373,CTG-6,,,Matched based on generator ID
+52089,BLR007,52089,GEN1,,,Matched based on boiler_id and EIA-860 BGA table
+52089,BLR008,52089,GEN1,,,Matched based on boiler_id and EIA-860 BGA table
+52089,BLR010,52089,GEN1,,,Matched based on boiler_id and EIA-860 BGA table
+52089,BLR011,52089,GEN1,,,Matched based on boiler_id and EIA-860 BGA table
+52089,BLR012,52089,GEN1,,,Matched based on boiler_id and EIA-860 BGA table
+52089,BLR013,52089,GEN1,,,Matched based on boiler_id and EIA-860 BGA table
+52089,BLR014,52089,GEN1,,,Matched based on boiler_id and EIA-860 BGA table
+52089,BLR007,52089,GEN2,,,Matched based on boiler_id and EIA-860 BGA table
+52089,BLR008,52089,GEN2,,,Matched based on boiler_id and EIA-860 BGA table
+52089,BLR010,52089,GEN2,,,Matched based on boiler_id and EIA-860 BGA table
+52089,BLR011,52089,GEN2,,,Matched based on boiler_id and EIA-860 BGA table
+52089,BLR012,52089,GEN2,,,Matched based on boiler_id and EIA-860 BGA table
+52089,BLR013,52089,GEN2,,,Matched based on boiler_id and EIA-860 BGA table
+52089,BLR014,52089,GEN2,,,Matched based on boiler_id and EIA-860 BGA table
+52089,BLR007,52089,GEN3,,,Matched based on boiler_id and EIA-860 BGA table
+52089,BLR008,52089,GEN3,,,Matched based on boiler_id and EIA-860 BGA table
+52089,BLR010,52089,GEN3,,,Matched based on boiler_id and EIA-860 BGA table
+52089,BLR011,52089,GEN3,,,Matched based on boiler_id and EIA-860 BGA table
+52089,BLR012,52089,GEN3,,,Matched based on boiler_id and EIA-860 BGA table
+52089,BLR013,52089,GEN3,,,Matched based on boiler_id and EIA-860 BGA table
+52089,BLR014,52089,GEN3,,,Matched based on boiler_id and EIA-860 BGA table
+52089,BLR007,52089,GEN4,,,Matched based on boiler_id and EIA-860 BGA table
+52089,BLR008,52089,GEN4,,,Matched based on boiler_id and EIA-860 BGA table
+52089,BLR010,52089,GEN4,,,Matched based on boiler_id and EIA-860 BGA table
+52089,BLR011,52089,GEN4,,,Matched based on boiler_id and EIA-860 BGA table
+52089,BLR012,52089,GEN4,,,Matched based on boiler_id and EIA-860 BGA table
+52089,BLR013,52089,GEN4,,,Matched based on boiler_id and EIA-860 BGA table
+52089,BLR014,52089,GEN4,,,Matched based on boiler_id and EIA-860 BGA table

--- a/src/oge/reference_tables/epa_eia_crosswalk_manual.csv
+++ b/src/oge/reference_tables/epa_eia_crosswalk_manual.csv
@@ -300,10 +300,10 @@ plant_id_epa,emissions_unit_id_epa,plant_id_eia,generator_id,start_year,end_year
 548,10,548,10,,,EPA crosswalk generator matches generator_id
 603,15,603,15,,,EPA crosswalk generator matches generator_id
 603,16,603,16,,,EPA crosswalk generator matches generator_id
-981,3,,3,,,CAMPD generator mapping matches generator name and nameplate cap
-981,3,,3A,,,CAMPD generator mapping matches generator name and nameplate cap
-981,4,,4,,,CAMPD generator mapping matches generator name and nameplate cap
-981,4,,4A,,,CAMPD generator mapping matches generator name and nameplate cap
+981,3,981,3,,,CAMPD generator mapping matches generator name and nameplate cap
+981,3,981,3A,,,CAMPD generator mapping matches generator name and nameplate cap
+981,4,981,4,,,CAMPD generator mapping matches generator name and nameplate cap
+981,4,981,4A,,,CAMPD generator mapping matches generator name and nameplate cap
 1822,5,1822,5,,,EPA crosswalk generator matches generator_id
 1822,6,1822,6,,,EPA crosswalk generator matches generator_id
 1822,7,1822,7,,,EPA crosswalk generator matches generator_id

--- a/src/oge/reference_tables/epa_eia_crosswalk_manual.csv
+++ b/src/oge/reference_tables/epa_eia_crosswalk_manual.csv
@@ -85,8 +85,8 @@ plant_id_epa,emissions_unit_id_epa,plant_id_eia,generator_id,start_year,end_year
 61241,CT2,61241,VC-2,,,Manual fuzzy match of generator ID
 61242,CT1,61242,VP-1,,,Manual fuzzy match of generator ID
 61242,CT2,61242,VP-2,,,Manual fuzzy match of generator ID
-55641,CT-03,64020,CTG3,,,Proposed plant number changed when generator became operational
-55641,CT-04,64020,CTG4,,,Proposed plant number changed when generator became operational
+55641,CT-03,64020,CTG3,2020,,Proposed plant number changed when generator became operational
+55641,CT-04,64020,CTG4,2020,,Proposed plant number changed when generator became operational
 568,BHB5,568,501,,,Matched based on total net generation
 568,BHB5,568,502,,,Matched based on total net generation
 60925,CT1,60925,1A,,,Matched based on generator ID and prime mover code
@@ -105,10 +105,14 @@ plant_id_epa,emissions_unit_id_epa,plant_id_eia,generator_id,start_year,end_year
 335,CT1,62116,1S,,,"Matched based on plant name, prime mover, and generation. Plant 335 is ""Huntington Beach"" while plant 62115 is ""AES Huntington Beach Energy Project"""
 335,CT2,62116,1B,,,"Matched based on plant name, prime mover, and generation. Plant 335 is ""Huntington Beach"" while plant 62115 is ""AES Huntington Beach Energy Project"""
 335,CT2,62116,1S,,,"Matched based on plant name, prime mover, and generation. Plant 335 is ""Huntington Beach"" while plant 62115 is ""AES Huntington Beach Energy Project"""
-613,PFL7A,65978,7GT1,,,"Matched based on plant address, generator id, and generation"
-613,PFL7A,65978,ST7,,,"Matched based on plant address, generator id, and generation"
-613,PFL7B,65978,7GT2,,,"Matched based on plant address, generator id, and generation"
-613,PFL7B,65978,ST7,,,"Matched based on plant address, generator id, and generation"
+613,PFL7A,613,7GT1,,2021,"Matched based on plant address, generator id, and generation"
+613,PFL7A,613,ST7,,2021,"Matched based on plant address, generator id, and generation"
+613,PFL7B,613,7GT2,,2021,"Matched based on plant address, generator id, and generation"
+613,PFL7B,613,ST7,,2021,"Matched based on plant address, generator id, and generation"
+613,PFL7A,65978,7GT1,2022,,"Matched based on plant address, generator id, and generation"
+613,PFL7A,65978,ST7,2022,,"Matched based on plant address, generator id, and generation"
+613,PFL7B,65978,7GT2,2022,,"Matched based on plant address, generator id, and generation"
+613,PFL7B,65978,ST7,2022,,"Matched based on plant address, generator id, and generation"
 6061,3,6061,MOR1,,,"Matched based on operational date, and fuel emission factor. New unit at repowered plant"
 6061,3,6061,MOR2,,,"Matched based on operational date, and fuel emission factor. New unit at repowered plant"
 10350,CTGA,10350,CTGA,,,Matched based on generator ID
@@ -219,3 +223,75 @@ plant_id_epa,emissions_unit_id_epa,plant_id_eia,generator_id,start_year,end_year
 52089,BLR012,52089,GEN4,,,Matched based on boiler_id and EIA-860 BGA table
 52089,BLR013,52089,GEN4,,,Matched based on boiler_id and EIA-860 BGA table
 52089,BLR014,52089,GEN4,,,Matched based on boiler_id and EIA-860 BGA table
+2953,5A-1,2953,5A,,2018,5A and 5B change from Mustang to Tinker plant
+2953,5A-2,2953,5A,,2018,5A and 5B change from Mustang to Tinker plant
+2953,5B-1,2953,5B,,2018,5A and 5B change from Mustang to Tinker plant
+2953,5B-2,2953,5B,,2018,5A and 5B change from Mustang to Tinker plant
+2953,5A-1,63628,5A,2019,2020,5A and 5B change from Mustang to Tinker plant
+2953,5A-2,63628,5A,2019,2020,5A and 5B change from Mustang to Tinker plant
+2953,5B-1,63628,5B,2019,2020,5A and 5B change from Mustang to Tinker plant
+2953,5B-2,63628,5B,2019,2020,5A and 5B change from Mustang to Tinker plant
+63628,5A-1,63628,5A,2021,,5A and 5B change from Mustang to Tinker plant
+63628,5A-2,63628,5A,2021,,5A and 5B change from Mustang to Tinker plant
+63628,5B-1,63628,5B,2021,,5A and 5B change from Mustang to Tinker plant
+63628,5B-2,63628,5B,2021,,5A and 5B change from Mustang to Tinker plant
+693,**5,693,2,,,EPA crosswalk generator matches generator_id
+693,**5,693,5,,,EPA crosswalk generator matches generator_id
+693,3,693,3,,,EPA crosswalk generator matches generator_id
+693,4,693,4,,,EPA crosswalk generator matches generator_id
+1010,1,1010,1,,,"unit_id matches generator_id pattern, and part of CC"
+1010,1,1010,1A,,,"unit_id matches generator_id pattern, and part of CC"
+1619,1,1619,1,,,EPA crosswalk generator matches generator_id
+1619,2,1619,2,,,EPA crosswalk generator matches generator_id
+1619,3,1619,3,,,EPA crosswalk generator matches generator_id
+1619,4,1619,4,,,EPA crosswalk generator matches generator_id
+3470,CTSC,58378,GT2,,,CAMPD generator mapping matches plant of same name and nameplate cap
+4146,B1,4146,1,,,CAMPD generator mapping matches generator name and nameplate cap
+4146,B1,4146,2,,,CAMPD generator mapping matches generator name and nameplate cap
+4146,B2,4146,1,,,CAMPD generator mapping matches generator name and nameplate cap
+4146,B2,4146,2,,,CAMPD generator mapping matches generator name and nameplate cap
+10741,G102,10741,G102,,,CAMPD generator mapping matches generator name and nameplate cap
+10741,G103,10741,G103,,,CAMPD generator mapping matches generator name and nameplate cap
+10741,G104,10741,G104,,,CAMPD generator mapping matches generator name and nameplate cap
+10741,G102,10741,S101,,,CAMPD generator mapping matches generator name and nameplate cap
+10741,G103,10741,S101,,,CAMPD generator mapping matches generator name and nameplate cap
+10741,G104,10741,S101,,,CAMPD generator mapping matches generator name and nameplate cap
+10741,G102,10741,S102,,,CAMPD generator mapping matches generator name and nameplate cap
+10741,G103,10741,S102,,,CAMPD generator mapping matches generator name and nameplate cap
+10741,G104,10741,S102,,,CAMPD generator mapping matches generator name and nameplate cap
+55248,CT4,55248,GT4,,2018,These units change plant ID in 2019
+55248,CT5,55248,GT5,,2018,These units change plant ID in 2019
+55248,CT6,55248,GT6,,2018,These units change plant ID in 2019
+55248,CT7,55248,GT7,,2018,These units change plant ID in 2019
+55248,CT4,2847,GT4,2019,,These units change plant ID in 2019
+55248,CT5,2847,GT5,2019,,These units change plant ID in 2019
+55248,CT6,2847,GT6,2019,,These units change plant ID in 2019
+55248,CT7,2847,GT7,2019,,These units change plant ID in 2019
+55306,1CTGA,55306,CTG1,,2012,These units change plant ID in 2013
+55306,1CTGA,55306,ST9,,2012,These units change plant ID in 2013
+55306,1CTGB,55306,CTG2,,2012,These units change plant ID in 2013
+55306,1CTGB,55306,ST9,,2012,These units change plant ID in 2013
+55306,1CTGA,59338,CTG1,2013,,These units change plant ID in 2013
+55306,1CTGA,59338,ST9,2013,,These units change plant ID in 2013
+55306,1CTGB,59338,CTG2,2013,,These units change plant ID in 2013
+55306,1CTGB,59338,ST9,2013,,These units change plant ID in 2013
+55306,2CTGA,55306,CTG3,,2012,"This changes to power block 2 in 2013, and changes ownership and plant number again in 2016"
+55306,2CTGA,55306,ST10,,2012,"This changes to power block 2 in 2013, and changes ownership and plant number again in 2016"
+55306,2CTGB,55306,CTG4,,2012,"This changes to power block 2 in 2013, and changes ownership and plant number again in 2016"
+55306,2CTGB,55306,ST10,,2012,"This changes to power block 2 in 2013, and changes ownership and plant number again in 2016"
+55306,2CTGA,59338,CTG3,2013,2015,"This changes to power block 2 in 2013, and changes ownership and plant number again in 2016"
+55306,2CTGA,59338,ST10,2013,2015,"This changes to power block 2 in 2013, and changes ownership and plant number again in 2016"
+55306,2CTGB,59338,CTG4,2013,2015,"This changes to power block 2 in 2013, and changes ownership and plant number again in 2016"
+55306,2CTGB,59338,ST10,2013,2015,"This changes to power block 2 in 2013, and changes ownership and plant number again in 2016"
+55306,2CTGA,60768,CTG3,2016,,"This changes to power block 2 in 2013, and changes ownership and plant number again in 2016"
+55306,2CTGA,60768,ST10,2016,,"This changes to power block 2 in 2013, and changes ownership and plant number again in 2016"
+55306,2CTGB,60768,CTG4,2016,,"This changes to power block 2 in 2013, and changes ownership and plant number again in 2016"
+55306,2CTGB,60768,ST10,2016,,"This changes to power block 2 in 2013, and changes ownership and plant number again in 2016"
+55306,3CTGA,55306,CTG5,,2013,This changes plants to power block 3 in 2014
+55306,3CTGA,55306,ST11,,2013,This changes plants to power block 3 in 2014
+55306,3CTGB,55306,CTG6,,2013,This changes plants to power block 3 in 2014
+55306,3CTGB,55306,ST11,,2013,This changes plants to power block 3 in 2014
+55306,3CTGA,59784,CTG5,2014,,This changes plants to power block 3 in 2014
+55306,3CTGA,59784,ST11,2014,,This changes plants to power block 3 in 2014
+55306,3CTGB,59784,CTG6,2014,,This changes plants to power block 3 in 2014
+55306,3CTGB,59784,ST11,2014,,This changes plants to power block 3 in 2014

--- a/src/oge/reference_tables/epa_eia_crosswalk_manual.csv
+++ b/src/oge/reference_tables/epa_eia_crosswalk_manual.csv
@@ -295,3 +295,38 @@ plant_id_epa,emissions_unit_id_epa,plant_id_eia,generator_id,start_year,end_year
 55306,3CTGA,59784,ST11,2014,,This changes plants to power block 3 in 2014
 55306,3CTGB,59784,CTG6,2014,,This changes plants to power block 3 in 2014
 55306,3CTGB,59784,ST11,2014,,This changes plants to power block 3 in 2014
+548,1,548,1,,,EPA crosswalk generator matches generator_id
+548,2,548,2,,,EPA crosswalk generator matches generator_id
+548,10,548,10,,,EPA crosswalk generator matches generator_id
+603,15,603,15,,,EPA crosswalk generator matches generator_id
+603,16,603,16,,,EPA crosswalk generator matches generator_id
+981,3,,3,,,CAMPD generator mapping matches generator name and nameplate cap
+981,3,,3A,,,CAMPD generator mapping matches generator name and nameplate cap
+981,4,,4,,,CAMPD generator mapping matches generator name and nameplate cap
+981,4,,4A,,,CAMPD generator mapping matches generator name and nameplate cap
+1822,5,1822,5,,,EPA crosswalk generator matches generator_id
+1822,6,1822,6,,,EPA crosswalk generator matches generator_id
+1822,7,1822,7,,,EPA crosswalk generator matches generator_id
+1822,GT-1,1822,GT1,,,EPA crosswalk generator matches generator_id
+1961,NEPP,1961,1,,,CAMPD generator mapping matches generator name and nameplate cap
+2169,2,2169,2,,,EPA crosswalk generator matches generator_id
+3788,1,3788,1,,,EPA crosswalk generator matches generator_id
+3788,2,3788,2,,,EPA crosswalk generator matches generator_id
+3788,3,3788,3,,,EPA crosswalk generator matches generator_id
+3788,4,3788,4,,,EPA crosswalk generator matches generator_id
+3788,5,3788,5,,,EPA crosswalk generator matches generator_id
+10670,1001,10670,GEN1,,,EPA crosswalk generator matches generator_id
+10802,1,10802,GEN1,,,CAMPD generator mapping matches generator name and nameplate cap
+10802,1,10802,GEN2,,,CAMPD generator mapping matches generator name and nameplate cap
+50245,GTX017,50245,ABB,,,EPA crosswalk generator matches generator_id
+50245,GTX017,50245,GE,,,EPA crosswalk generator matches generator_id
+50245,GTX017,50245,GT,,,EPA crosswalk generator matches generator_id
+50245,PBX007,50245,ABB,,,EPA crosswalk generator matches generator_id
+50245,PBX007,50245,GE,,,EPA crosswalk generator matches generator_id
+54144,31,54144,GEN1,,,EPA crosswalk generator matches generator_id
+54423,EU003,54423,GT1,,,EPA crosswalk generator matches generator_id
+54423,EU003,54423,ST1,,,EPA crosswalk generator matches generator_id
+54423,EU004,54423,GT2,,,EPA crosswalk generator matches generator_id
+54423,EU004,54423,ST1,,,EPA crosswalk generator matches generator_id
+54658,1,54658,CT,,,EPA crosswalk generator matches generator_id
+54658,1,54658,ST,,,EPA crosswalk generator matches generator_id

--- a/src/oge/reference_tables/epa_eia_crosswalk_manual.csv
+++ b/src/oge/reference_tables/epa_eia_crosswalk_manual.csv
@@ -394,7 +394,7 @@ plant_id_epa,emissions_unit_id_epa,plant_id_eia,generator_id,start_year,end_year
 2840,2,2840,2,,,CAMPD Facility database mapping
 3148,1,3148,1,,,CAMPD Facility database mapping
 3148,2,3148,2,,,CAMPD Facility database mapping
-3176,4,23279,4,,,Matches CAMPD mapping of generator at plant of same name
+3176,4,56397,4,,,Matches CAMPD mapping of generator at plant of same name
 3264,4C,3264,4,,,CAMPD Facility database mapping
 3264,5C,3264,5,,,CAMPD Facility database mapping
 3264,6C,3264,6,,,CAMPD Facility database mapping

--- a/src/oge/reference_tables/epa_eia_crosswalk_manual.csv
+++ b/src/oge/reference_tables/epa_eia_crosswalk_manual.csv
@@ -330,3 +330,143 @@ plant_id_epa,emissions_unit_id_epa,plant_id_eia,generator_id,start_year,end_year
 54423,EU004,54423,ST1,,,EPA crosswalk generator matches generator_id
 54658,1,54658,CT,,,EPA crosswalk generator matches generator_id
 54658,1,54658,ST,,,EPA crosswalk generator matches generator_id
+247,7,247,4,,,CAMPD Facility database mapping
+310,3,310,3,,,CAMPD Facility database mapping
+310,4,310,4,,,CAMPD Facility database mapping
+634,1,634,ST1,,,CAMPD Facility database mapping
+634,2,634,ST2,,,CAMPD Facility database mapping
+634,3,634,ST3,,,CAMPD Facility database mapping
+641,2,641,2,,,CAMPD Facility database mapping
+641,3,641,3,,,CAMPD Facility database mapping
+658,7,658,7,,,CAMPD Facility database mapping
+658,8,658,8,,,CAMPD Facility database mapping
+688,2,688,2,,,CAMPD Facility database mapping
+863,5,863,3,,,CAMPD Facility database mapping
+863,6,863,4,,,CAMPD Facility database mapping
+864,5,864,3,,,CAMPD Facility database mapping
+864,6,864,4,,,CAMPD Facility database mapping
+883,17,883,6,,,CAMPD Facility database mapping
+964,7,964,6,,,CAMPD Facility database mapping
+964,8,964,7,,,CAMPD Facility database mapping
+1012,1,1012,1,,,CAMPD Facility database mapping
+1305,1,1305,1,,,CAMPD Facility database mapping
+1372,6,1372,6,,,CAMPD Facility database mapping
+1392,10,1392,10,,,Matches generator name and CAMPD database capacity
+1392,11,1392,11,,,Matches generator name and CAMPD database capacity
+1392,12,1392,12,,,Matches generator name and CAMPD database capacity
+1458,2,1458,2,,,CAMPD Facility database mapping
+1458,3,1458,3,,,CAMPD Facility database mapping
+1589,1,1589,1,,,CAMPD Facility database mapping
+1589,2,1589,2,,,CAMPD Facility database mapping
+1613,11,1613,JET2,,,CAMPD Facility database mapping
+1613,8,1613,6,,,CAMPD Facility database mapping
+1769,1,1769,1,,,CAMPD Facility database mapping
+1769,2,1769,2,,,CAMPD Facility database mapping
+1769,3,1769,3,,,CAMPD Facility database mapping
+1769,4,1769,4,,,CAMPD Facility database mapping
+1912,3,1912,3,,,CAMPD Facility database mapping
+1912,4,1912,4,,,CAMPD Facility database mapping
+1912,5,1912,5,,,CAMPD Facility database mapping
+1912,6,1912,6,,,CAMPD Facility database mapping
+1927,6,1927,7,,,CAMPD Facility database mapping
+1927,7,1927,7,,,CAMPD Facility database mapping
+1927,7,1927,ST7,,,CAMPD Facility database mapping
+1927,8,1927,8,,,CAMPD Facility database mapping
+2322,1,2322,1,,,CAMPD Facility database mapping
+2322,2,2322,2,,,CAMPD Facility database mapping
+2322,3,2322,3,,,CAMPD Facility database mapping
+2397,A01001,2397,1,,,CAMPD Facility database mapping
+2397,A02001,2397,2,,,CAMPD Facility database mapping
+2539,1,2539,1,,,CAMPD Facility database mapping
+2539,2,2539,2,,,CAMPD Facility database mapping
+2539,3,2539,3,,,CAMPD Facility database mapping
+2539,4,2539,4,,,CAMPD Facility database mapping
+2629,3,2629,3,,,CAMPD Facility database mapping
+2629,4,2629,4,,,CAMPD Facility database mapping
+2629,5,2629,5,,,CAMPD Facility database mapping
+2642,1,2642,1,,,CAMPD Facility database mapping
+2642,2,2642,2,,,CAMPD Facility database mapping
+2642,3,2642,3,,,CAMPD Facility database mapping
+2642,4,2642,4,,,CAMPD Facility database mapping
+2832,5-1,2832,5,,,CAMPD Facility database mapping
+2832,5-2,2832,5,,,CAMPD Facility database mapping
+2840,1,2840,1,,,CAMPD Facility database mapping
+2840,2,2840,2,,,CAMPD Facility database mapping
+3148,1,3148,1,,,CAMPD Facility database mapping
+3148,2,3148,2,,,CAMPD Facility database mapping
+3176,4,23279,4,,,Matches CAMPD mapping of generator at plant of same name
+3264,4C,3264,4,,,CAMPD Facility database mapping
+3264,5C,3264,5,,,CAMPD Facility database mapping
+3264,6C,3264,6,,,CAMPD Facility database mapping
+3438,1,3438,1,,,CAMPD Facility database mapping
+3438,2,3438,2,,,CAMPD Facility database mapping
+3439,1,3439,1,,,CAMPD Facility database mapping
+3439,2,3439,2,,,CAMPD Facility database mapping
+3439,3,3439,3,,,CAMPD Facility database mapping
+3442,7,3442,6,,,CAMPD Facility database mapping
+3453,2,3453,2,,,CAMPD Facility database mapping
+3453,3A,3453,3,,,CAMPD Facility database mapping
+3453,3B,3453,3,,,CAMPD Facility database mapping
+3506,1,3506,1,,,CAMPD Facility database mapping
+3506,2,3506,2,,,CAMPD Facility database mapping
+3508,1,3508,1,,,CAMPD Facility database mapping
+3508,2,3508,2,,,CAMPD Facility database mapping
+3508,3,3508,3,,,CAMPD Facility database mapping
+3549,3,3549,3,,,CAMPD Facility database mapping
+3549,4,3549,4,,,CAMPD Facility database mapping
+3992,11,3992,3,,,CAMPD Facility database mapping
+4072,3,4072,3,,,CAMPD Facility database mapping
+4072,4,4072,4,,,CAMPD Facility database mapping
+4939,2,4939,2,,,CAMPD Facility database mapping
+6052,6A,55965,ST6,,2011,"CAMPD Facility database mapping, changes plant ID in 2012"
+6052,6A,55965,CT6A,,2011,"CAMPD Facility database mapping, changes plant ID in 2013"
+6052,6B,55965,ST6,,2011,"CAMPD Facility database mapping, changes plant ID in 2014"
+6052,6B,55965,CT6B,,2011,"CAMPD Facility database mapping, changes plant ID in 2015"
+6052,7A,55965,ST7,,2011,"CAMPD Facility database mapping, changes plant ID in 2016"
+6052,7A,55965,CT7A,,2011,"CAMPD Facility database mapping, changes plant ID in 2017"
+6052,7B,55965,ST7,,2011,"CAMPD Facility database mapping, changes plant ID in 2018"
+6052,7B,55965,CT7B,,2011,"CAMPD Facility database mapping, changes plant ID in 2019"
+55965,6A,55965,ST6,2012,,"CAMPD Facility database mapping, changes plant ID in 2012"
+55965,6A,55965,CT6A,2012,,"CAMPD Facility database mapping, changes plant ID in 2013"
+55965,6B,55965,ST6,2012,,"CAMPD Facility database mapping, changes plant ID in 2014"
+55965,6B,55965,CT6B,2012,,"CAMPD Facility database mapping, changes plant ID in 2015"
+55965,7A,55965,ST7,2012,,"CAMPD Facility database mapping, changes plant ID in 2016"
+55965,7A,55965,CT7A,2012,,"CAMPD Facility database mapping, changes plant ID in 2017"
+55965,7B,55965,ST7,2012,,"CAMPD Facility database mapping, changes plant ID in 2018"
+55965,7B,55965,CT7B,2012,,"CAMPD Facility database mapping, changes plant ID in 2019"
+7945,1,7945,1,,,CAMPD Facility database mapping
+8906,30,8906,3,,,CAMPD Facility database mapping
+8906,40,8906,4,,,CAMPD Facility database mapping
+8906,50,8906,ST5,,,CAMPD Facility database mapping
+10618,1,10618,GEN1,,,CAMPD Facility database mapping
+10618,1,10618,GEN2,,,CAMPD Facility database mapping
+50012,BLR4,50012,GEN3,,,CAMPD Facility database mapping
+50459,1,50459,GT,,,CAMPD Facility database mapping
+50459,1,50459,ST,,,CAMPD Facility database mapping
+50797,1001,50797,GEN1,,,CAMPD Facility database mapping
+50797,1001,50797,GEN2,,,CAMPD Facility database mapping
+50855,1,50855,GEN1,,,CAMPD Facility database mapping
+50855,1,50855,GEN2,,,CAMPD Facility database mapping
+50855,2,50855,GEN2,,,CAMPD Facility database mapping
+50855,2,50855,GEN3,,,CAMPD Facility database mapping
+54138,01GTDB,54138,GTG,,,CAMPD Facility database mapping
+54425,1,54425,GT1,,,CAMPD Facility database mapping
+54425,2,54425,GT2,,,CAMPD Facility database mapping
+54658,6,55833,CTP,,2008,"Matches CAMPD mapping of generator at plant of same name, changes plant ID in 2009"
+55833,6,55833,CTP,2009,,"Matches CAMPD mapping of generator at plant of same name, changes plant ID in 2009"
+55082,AA-001,55082,1,,,CAMPD Facility database mapping
+55082,AA-002,55082,2,,,CAMPD Facility database mapping
+55082,AA-003,55082,3,,,CAMPD Facility database mapping
+55082,AA-004,55082,4,,,CAMPD Facility database mapping
+55082,AA-005,55082,5,,,CAMPD Facility database mapping
+55082,AA-006,55082,6,,,CAMPD Facility database mapping
+55303,AA-001,55303,A001,,,CAMPD Facility database mapping
+55303,AA-002,55303,A002,,,CAMPD Facility database mapping
+55303,AA-003,55303,A003,,,CAMPD Facility database mapping
+55303,AA-004,55303,A004,,,CAMPD Facility database mapping
+55494,CT1,55494,CT3,,,CAMPD Facility database mapping
+55494,CT2,55494,CT4,,,CAMPD Facility database mapping
+55494,CT3,55494,CT1,,,CAMPD Facility database mapping
+55494,CT4,55494,CT2,,,CAMPD Facility database mapping
+55494,CT5,55494,CT5,,,CAMPD Facility database mapping
+55494,CT6,55494,CT6,,,CAMPD Facility database mapping

--- a/src/oge/validation.py
+++ b/src/oge/validation.py
@@ -133,8 +133,8 @@ def check_allocated_gf_matches_input_gf(year, gen_fuel_allocated):
     ) / plant_total_gf.fillna(0).replace(0, 0.00001).dropna(how="all", axis=0)
     # Flag rows where the absolute percentage difference is greater than our threshold
     mismatched_allocation = plant_total_diff[
-        (~np.isclose(plant_total_diff["fuel_consumed_mmbtu"], 0))
-        | (~np.isclose(plant_total_diff["net_generation_mwh"], 0))
+        (~np.isclose(plant_total_diff["fuel_consumed_mmbtu"], 0, atol=0.0001))
+        | (~np.isclose(plant_total_diff["net_generation_mwh"], 0, atol=0.0001))
     ]
 
     if len(mismatched_allocation) > 0:

--- a/src/oge/validation.py
+++ b/src/oge/validation.py
@@ -437,8 +437,19 @@ def test_chp_allocation(df):
     return chp_allocation_test
 
 
-def test_for_missing_energy_source_code(df: pd.DataFrame, drop_missing: bool = False):
-    """Checks that there are no missing energy source codes"""
+def test_for_missing_energy_source_code(
+    df: pd.DataFrame, drop_missing: bool = False
+) -> pd.DataFrame:
+    """Checks that there are no missing energy source codes
+
+    Args:
+        df (pd.DataFrame): the data to check, containing an energy_source_code column
+        drop_missing (bool, optional): Whether to drop data that has a missing energy
+            source code. Defaults to False.
+
+    Returns:
+        pd.DataFrame: Only returned if drop_missing is True
+    """
     logger.info("Checking that there are no missing energy source codes...  ")
     missing_esc_test = df[(df["energy_source_code"].isna())]
     if not missing_esc_test.empty:

--- a/src/oge/validation.py
+++ b/src/oge/validation.py
@@ -437,22 +437,24 @@ def test_chp_allocation(df):
     return chp_allocation_test
 
 
-def test_for_missing_energy_source_code(df):
-    """Checks that there are no missing energy source codes associated with non-zero fuel consumption."""
-    logger.info(
-        "Checking that there are no missing energy source codes associated with non-zero fuel consumption...  "
-    )
-    missing_esc_test = df[
-        (df["energy_source_code"].isna()) & (df["fuel_consumed_mmbtu"] > 0)
-    ]
+def test_for_missing_energy_source_code(df: pd.DataFrame, drop_missing: bool = False):
+    """Checks that there are no missing energy source codes"""
+    logger.info("Checking that there are no missing energy source codes...  ")
+    missing_esc_test = df[(df["energy_source_code"].isna())]
     if not missing_esc_test.empty:
         logger.warning(
-            f"There are {len(missing_esc_test)} records where there is a missing energy source code associated with non-zero fuel consumption. Check `missing_esc_test` for complete list"
+            f"There are {len(missing_esc_test)} records where there is a missing energy source code associated with non-zero fuel consumption."
         )
+        logger.warning(limit_error_output_df(missing_esc_test).to_string())
+        if drop_missing:
+            logger.warning("These entries will be removed from the dataframe")
+            df = df[~(df["energy_source_code"].isna())]
     else:
         logger.info("OK")
 
-    return missing_esc_test
+    # if missing are being dropped, return the df with the dropped entries
+    if drop_missing:
+        return df
 
 
 def check_non_missing_cems_co2_values_unchanged(cems_original, cems):
@@ -1414,21 +1416,23 @@ def identify_percent_of_data_by_input_source(
 
     # add ba codes and plant primary fuel to all of the data
     eia_only_data = assign_fleet_to_subplant_data(
-        eia_only_data, plant_attributes, primary_fuel_table
+        eia_only_data, plant_attributes, primary_fuel_table, year
     )
     cems = assign_fleet_to_subplant_data(
-        cems, plant_attributes, primary_fuel_table, drop_primary_fuel_col=False
+        cems, plant_attributes, primary_fuel_table, year, drop_primary_fuel_col=False
     )
     partial_cems_subplant = assign_fleet_to_subplant_data(
         partial_cems_subplant,
         plant_attributes,
         primary_fuel_table,
+        year,
         drop_primary_fuel_col=False,
     )
     partial_cems_plant = assign_fleet_to_subplant_data(
         partial_cems_plant,
         plant_attributes,
         primary_fuel_table,
+        year,
         drop_primary_fuel_col=False,
     )
 

--- a/src/oge/validation.py
+++ b/src/oge/validation.py
@@ -520,6 +520,17 @@ def test_for_missing_subplant_id(df, plant_part):
             + limit_error_output_df(
                 missing_subplant_test[
                     ["plant_id_eia", plant_part, "subplant_id"]
+                    + [
+                        col
+                        for col in missing_subplant_test.columns
+                        if col
+                        in [
+                            "net_generation_mwh",
+                            "gross_generation_mwh",
+                            "fuel_consumed_mmbtu",
+                            "capacity_mw",
+                        ]
+                    ]
                 ].drop_duplicates()
             ).to_string()
         )


### PR DESCRIPTION
### Purpose
This PR addresses several warnings that were being raised in the 2023 data pipeline:
- When flagging differences between the inputs and outputs of the EIA-923 allocation process, update threshold to only warn if differences are greater than 0.01% to avoid warnings for rounding errors.
- Add a multi-year backstop for sulfur content so that we have complete sulfur content data for JF fuels
- Drop bad generators from the EIA-923 pipeline that were introduced by https://github.com/catalyst-cooperative/pudl/issues/3987
- Fix issue with missing fuel data for a plant that had recently retired, so wasn't appearing in the primary fuel table even though it was still reporting CEMS data
- Flag and drop CEMS units that report steam-only output and are not mapped to an EIA ID. These are likely for district steam systems and not power generation.
- Add the units flagged as "Manual CAMD Excluded" in the PSDC to the list of non-grid-connected units to remove.

I pulled in the manual mappings from the other PR that were not related to steam-only units without a clear mapping. 

Advances CAR-4691

### Testing
Running pipeline for 2023
Will run for other years as well


### Usage Example/Visuals
Example of warning about CEMS units missing EIA generator mappings (these are actually handled by our manual fuel category reference table since they do not report to EIA):
<img width="614" alt="image" src="https://github.com/user-attachments/assets/90fefada-e1ae-4d65-b7d5-ea5fe2432531">


Example of steam units being removed:
<img width="614" alt="image" src="https://github.com/user-attachments/assets/5d04a45b-ce43-4ff4-a4ce-728771d5918c">


### Review estimate
20 minutes

### Future work
We are still missing some records in the plant attribute table:
<img width="395" alt="image" src="https://github.com/user-attachments/assets/899b67a7-bd1a-4a5e-90f2-032eb407adeb">


There are still some mis-allocations happening. Something that probably needs to be investigated in PUDL sometime in the future:
<img width="719" alt="image" src="https://github.com/user-attachments/assets/52bb6f7e-e447-4d90-a761-ec549399c575">


### Checklist
- [ ] Update the documentation to reflect changes made in this PR
- [x] Format all updated python files using `black`
- [x] Clear outputs from all notebooks modified
- [x] Add docstrings and type hints to any new functions created
