### PR TITLE
Refactor function writing power sector data

### DIFF
--- a/src/oge/consumed.py
+++ b/src/oge/consumed.py
@@ -31,7 +31,7 @@ BA_930_INCONSISTENCY = {
     2020: ["CPLW", "EEI"],
     2021: ["CPLW", "GCPD"],
     2022: ["CPLW", "GCPD", "HST"],
-    2023: [],  # TODO: update when final 2023 data published
+    2023: ["CPLW"],
 }
 
 # Defined in output_data, written to each BA file

--- a/src/oge/data_pipeline.py
+++ b/src/oge/data_pipeline.py
@@ -429,7 +429,13 @@ def main(args):
         monthly_subplant_data, plant_attributes, primary_fuel_table, year
     )
     output_data.write_power_sector_results(
-        fleet_data, year, path_prefix, args.skip_outputs, include_hourly=False
+        fleet_data,
+        year,
+        path_prefix,
+        args.skip_outputs,
+        include_hourly=False,
+        include_monthly=True,
+        include_annual=True,
     )
     # free up memory
     del monthly_subplant_data
@@ -678,6 +684,8 @@ def main(args):
             path_prefix,
             args.skip_outputs,
             include_hourly=True,
+            include_monthly=False,
+            include_annual=False,
         )
         # Write US-average fleet data
         output_data.write_national_fleet_averages(

--- a/src/oge/output_data.py
+++ b/src/oge/output_data.py
@@ -679,21 +679,23 @@ def write_power_sector_results(
                 if include_annual:
                     agg["annual"] = ["fuel_category"]
 
-                for k, v in agg.items():
+                for agg_level, groupby_cols in agg.items():
                     # aggregate data
                     ba_table = (
-                        ba_table.groupby(v, dropna=False)
+                        ba_table.groupby(groupby_cols, dropna=False)
                         .sum(numeric_only=True)
                         .reset_index()
                     )
                     ba_table = add_generated_emission_rate_columns(ba_table)
                     # re-order columns
-                    ba_table = ba_table[v + DATA_COLUMNS + GENERATED_EMISSION_RATE_COLS]
+                    ba_table = ba_table[
+                        groupby_cols + DATA_COLUMNS + GENERATED_EMISSION_RATE_COLS
+                    ]
                     output_to_results(
                         ba_table,
                         year,
                         ba,
-                        f"power_sector_data/{k}/",
+                        f"power_sector_data/{agg_level}/",
                         path_prefix,
                         skip_outputs,
                     )


### PR DESCRIPTION
### Purpose
Monthly and annual power sector data were written twice. Once in Step 12 and one in step 18. This is because the monthly and annual data are always written when the `write_power_sector_results`, hourly data are written or not depending on the setting of a boolean parameter named `include_hourly`. We use the same behavior for monthly and annual.

Also, add CPLW to `BA_930_INCONSISTENCY` dictionary.

Advances CAR-4691

### What the code is doing
Add the `include_monthly` and `include_annual` parameters to the `write_power_sector_results` function and use `if`/`else` logic to write or not data.

### Testing
Ran the pipeline for 2023

### Where to look
* the `write_power_sector_results` function in the `oge.output_data` module and the pipeline where this function is called
* the updated `BA_930_INCONSISTENCY` dictionary where CPLW has been added for 2023

### Usage Example/Visuals
N/A

### Review estimate
5 min

### Future work
Locate subplant/plant(s) in PJM introducing missing fuel category for power sector data

### Checklist
- [x] Update the documentation to reflect changes made in this PR
- [x] Format all updated python files using `black`
- [x] Clear outputs from all notebooks modified
- [x] Add docstrings and type hints to any new functions created
