### PR TITLE
Add plant attributes to the plant_data file

### DIFF
--- a/src/oge/output_data.py
+++ b/src/oge/output_data.py
@@ -323,6 +323,27 @@ def write_plant_data_to_results(
             .reset_index()
         )
 
+        # add some basic plant data to the annual plant output table
+        if resolution == "annual" and plant_part == "plant":
+            df = df.merge(
+                plant_attributes[
+                    [
+                        "plant_id_eia",
+                        "plant_name_eia",
+                        "ba_code",
+                        "fuel_category",
+                        "capacity_mw",
+                        "ba_code",
+                        "city",
+                        "county",
+                        "state",
+                    ]
+                ],
+                how="left",
+                on="plant_id_eia",
+                validate="m:1",
+            )
+
         # calculate emission rates
         df = add_generated_emission_rate_columns(df)
 


### PR DESCRIPTION
### Purpose
This PR addresses https://github.com/singularity-energy/open-grid-emissions/issues/309 by adding some of the data from the plant attributes table to the annual plant data table to make it easier to filter and explore in spreadsheet form without having to use code to merge in the plant attributes table. 

Advances CAR-4691

### What the code is doing
See above

### Testing
Running pipeline


### Review estimate
5 minutes

### Future work
What issues were identified that are not being addressed in this PR but should be addressed in future work?

### Checklist
- [x] Update the documentation to reflect changes made in this PR
- [x] Format all updated python files using `black`
- [x] Clear outputs from all notebooks modified
- [x] Add docstrings and type hints to any new functions created
