### PR TITLE
Update to 0.8.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,6 +22,6 @@ authors:
 identifiers:
   - type: doi
     value: 'https://zenodo.org/doi/10.5281/zenodo.7062459'
-version: 0.7.1
+version: 0.8.0
 license: MIT
-date-released: '2026-01-23'
+date-released: '2026-08-12'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "oge"
-version = "0.7.1"
+version = "0.8.0"
 requires-python = ">=3.11,<3.12"
 readme = "README.md"
 authors = [

--- a/src/oge/data_cleaning.py
+++ b/src/oge/data_cleaning.py
@@ -1885,6 +1885,12 @@ def complete_hourly_timeseries(
         pd.DataFrame: dataframe with complete timeseries
     """
 
+    # if the dataframe is empty, return the dataframe
+    # this is necessary in case a small generation-only BA has no active generation
+    # in a year
+    if df.empty:
+        return df
+
     # get all unique groups for which to create complete timeseries
     complete_timeseries = df[group_cols].drop_duplicates()
 

--- a/src/oge/data_cleaning.py
+++ b/src/oge/data_cleaning.py
@@ -1993,8 +1993,32 @@ def filter_to_ba_local_year(df: pd.DataFrame, year: int) -> pd.DataFrame:
     Returns:
         pd.DataFrame: `df` filtered to only the rows within each ba's own local year.
     """
+    # check that there are no missing ba_codes in df, since this would drop data at the
+    # end of this function
+    if len(df[df["ba_code"].isna()]) > 0:
+        raise ValueError(
+            "The df passed into filter_to_ba_local_year() has missing ba_codes."
+        )
+
     ba_reference = load_data.load_ba_reference()[["ba_code", "timezone_local"]]
 
+    # only keep BAs that appear in df
+    ba_codes_in_df = list(df["ba_code"].dropna().unique())
+    # raise an error if any BAs in df are not in ba_reference
+    missing_ba_codes = set(ba_codes_in_df) - set(ba_reference["ba_code"])
+    if missing_ba_codes:
+        raise ValueError(
+            f"The following BAs are missing from ba_reference: {missing_ba_codes}"
+        )
+    ba_reference = ba_reference[ba_reference["ba_code"].isin(ba_codes_in_df)]
+    # raise an error if any BAs are missing timezone_local
+    if len(ba_reference[ba_reference["timezone_local"].isna()]) > 0:
+        raise ValueError(
+            f"The following BAs are missing timezone_local: {ba_reference[ba_reference['timezone_local'].isna()]['ba_code'].unique()}"
+        )
+
+    # create a dataframe that has the complete hourly timeseries for each timezone in
+    # the ba_reference.
     timeseries_for_timezones = []
     for timezone in ba_reference["timezone_local"].unique():
         timezone_df = create_local_year_timestamps(year, timezone)[["datetime_utc"]]
@@ -2002,8 +2026,9 @@ def filter_to_ba_local_year(df: pd.DataFrame, year: int) -> pd.DataFrame:
         timeseries_for_timezones.append(timezone_df)
     timeseries_for_timezones = pd.concat(timeseries_for_timezones, ignore_index=True)
 
+    # this produces a dataframe with complete datetime_utc timestamps for each BA's local year
     ba_local_year_hours = ba_reference.merge(
-        timeseries_for_timezones, on="timezone_local", how="left", validate="1:m"
+        timeseries_for_timezones, on="timezone_local", how="left", validate="m:m"
     )[["ba_code", "datetime_utc"]]
 
     return df.merge(

--- a/uv.lock
+++ b/uv.lock
@@ -3004,7 +3004,7 @@ wheels = [
 
 [[package]]
 name = "oge"
-version = "0.7.1"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "catalystcoop-pudl" },


### PR DESCRIPTION
### Purpose
Prepare for the v0.8.0 release by updating the version number. Advances DAT-542
Also addresses a bug discovered when running the pipeline for 2024, introduced in https://github.com/singularity-energy/open-grid-emissions/pull/440. 

### What the code is doing
Updated the version number of OGE from 0.7.1 to 0.8.0.
Bug was that we were introducing missing timezones into `filter_to_ba_local_year`. This adds some additional filters and validation checks to make sure this doesn't happen.

### Testing
Currently running pipeline for 2025 (early release year) and all previous years

### Where to look
* It's helpful to clarify where your new code lives if you moved files around or there could be confusion/
* What files are most important?

### LLM use description
Claude was used to help diagnose the bug, but the fix was human written.

### Review estimate
< 5 min

### Future work
After this, we will begin working toward the full 2025 releae

### Checklist
- [x] Update the documentation (in `docs/docs/`) to reflect changes made in this PR
- [x] Format all updated python files using `ruff`
- [x] Clear outputs from all notebooks modified
- [x] Add docstrings and type hints to any new functions created
